### PR TITLE
feat: UPred Soundness 

### DIFF
--- a/src/Iris/Instances/UPred/Instance.lean
+++ b/src/Iris/Instances/UPred/Instance.lean
@@ -326,4 +326,12 @@ theorem ownM_op (m1 m2 : M) : ownM (m1 • m2) ⊣⊢ ownM m1 ∗ ownM m2 := by
 theorem ownM_always_invalid_elim (m : M) (H : ∀ n, ¬✓{n} m) : cmraValid m ⊢ False :=
   fun n _ _ => H n
 
+theorem pure_soundness : iprop(True ⊢ (⌜P⌝ : UPred M)) → P :=
+  (· 0 _ CMRA.unit_validN ⟨⟩)
+
+theorem later_soundness : iprop(True ⊢ ▷ P) → iprop((True : UPred M) ⊢ P) := by
+  intro HP n x _ H
+  refine UPred.mono _ ?_ CMRA.incN_unit (Nat.le_refl _)
+  exact HP n.succ _ CMRA.unit_validN H
+
 end UPred


### PR DESCRIPTION
Basic UPred soundness lemmas, plus some nearby one-liners that were easy to port. 

The other UPred soundness lemmas (w/ the various kinds of updates, internal eq, etc) reduce to these cases here, so this should be merged before those can be finished. 