### PR TITLE
Heaps

### DIFF
--- a/src/Iris/Algebra.lean
+++ b/src/Iris/Algebra.lean
@@ -2,3 +2,4 @@ import Iris.Algebra.Agree
 import Iris.Algebra.CMRA
 import Iris.Algebra.COFESolver
 import Iris.Algebra.OFE
+import Iris.Algebra.Frac

--- a/src/Iris/Algebra.lean
+++ b/src/Iris/Algebra.lean
@@ -4,3 +4,4 @@ import Iris.Algebra.COFESolver
 import Iris.Algebra.OFE
 import Iris.Algebra.Frac
 import Iris.Algebra.View
+import Iris.Algebra.Heap

--- a/src/Iris/Algebra.lean
+++ b/src/Iris/Algebra.lean
@@ -3,3 +3,4 @@ import Iris.Algebra.CMRA
 import Iris.Algebra.COFESolver
 import Iris.Algebra.OFE
 import Iris.Algebra.Frac
+import Iris.Algebra.View

--- a/src/Iris/Algebra/Agree.lean
+++ b/src/Iris/Algebra/Agree.lean
@@ -184,6 +184,18 @@ theorem Agree.includedN {x y : Agree α} : x ≼{n} y ↔ y ≡{n}≡ y • x :=
 theorem Agree.included {x y : Agree α} : x ≼ y ↔ y ≡ y • x :=
   ⟨fun ⟨z, h⟩ n => includedN.mp ⟨z, h n⟩, fun h => ⟨y, h.trans op_comm⟩⟩
 
+theorem Agree.toAgree.is_discrete {a : α} (Ha : OFE.DiscreteE a) : OFE.DiscreteE (toAgree a) := by
+  simp [toAgree]
+  intro y Ha _
+  cases y
+  rcases Ha with ⟨Hal, Har⟩
+  constructor <;> simp_all
+  · rcases Hal with ⟨b, Hb1, Hb2⟩
+    refine ⟨b, ⟨Hb1, ?_⟩⟩
+    exact OFE.Equiv.dist (Ha (Har b Hb1))
+  · intro H Hb
+    exact OFE.Equiv.dist (Ha (Har H Hb))
+
 open OFE OFE.Discrete in
 instance [OFE α] [OFE.Discrete α] : OFE.Discrete (Agree α) where
   discrete_0 {x y} H := by

--- a/src/Iris/Algebra/Agree.lean
+++ b/src/Iris/Algebra/Agree.lean
@@ -197,3 +197,19 @@ instance [OFE α] [OFE.Discrete α] : OFE.Discrete (Agree α) where
       rcases H.2 b Hb with ⟨c, Hc⟩
       refine ⟨c, ⟨Hc.1, ?_⟩⟩
       apply equiv_dist.mp <| discrete_0 (Dist.le Hc.2 <| Nat.zero_le 0)
+
+instance toAgree.ne [OFE α] : OFE.NonExpansive (toAgree : α → Agree α) where
+  ne n x y H := by
+    simp [toAgree]
+    constructor
+    · intro a Ha; exists y
+      simp only [List.mem_cons, List.not_mem_nil, or_false] at Ha
+      simp only [List.mem_cons, List.not_mem_nil, or_false, true_and]
+      exact Ha ▸ H
+    · intro b Hb; exists x
+      simp only [List.mem_cons, List.not_mem_nil, or_false] at Hb
+      simp only [List.mem_cons, List.not_mem_nil, or_false, true_and]
+      exact Hb ▸ H
+
+theorem toAgree.inj {a1 a2 : α} {n} (H : toAgree a1 ≡{n}≡ toAgree a2) : a1 ≡{n}≡ a2 := by
+  rcases H.1 a1 (by simp [toAgree]) with ⟨_, ⟨_, _⟩⟩; simp_all [toAgree]

--- a/src/Iris/Algebra/Agree.lean
+++ b/src/Iris/Algebra/Agree.lean
@@ -183,3 +183,17 @@ theorem Agree.includedN {x y : Agree α} : x ≼{n} y ↔ y ≡{n}≡ y • x :=
 
 theorem Agree.included {x y : Agree α} : x ≼ y ↔ y ≡ y • x :=
   ⟨fun ⟨z, h⟩ n => includedN.mp ⟨z, h n⟩, fun h => ⟨y, h.trans op_comm⟩⟩
+
+open OFE OFE.Discrete in
+instance [OFE α] [OFE.Discrete α] : OFE.Discrete (Agree α) where
+  discrete_0 {x y} H := by
+    intro n
+    constructor
+    · intro a Ha
+      rcases H.1 a Ha with ⟨c, Hc⟩
+      refine ⟨c, ⟨Hc.1, ?_⟩⟩
+      apply equiv_dist.mp <| discrete_0 (Dist.le Hc.2 <| Nat.zero_le 0)
+    · intro b Hb
+      rcases H.2 b Hb with ⟨c, Hc⟩
+      refine ⟨c, ⟨Hc.1, ?_⟩⟩
+      apply equiv_dist.mp <| discrete_0 (Dist.le Hc.2 <| Nat.zero_le 0)

--- a/src/Iris/Algebra/Agree.lean
+++ b/src/Iris/Algebra/Agree.lean
@@ -138,7 +138,7 @@ theorem Agree.op_invN {x y : Agree α} : (x.op y).validN n → x ≡{n}≡ y := 
     obtain ⟨b, hb⟩ := mem_of_agree x
     exists b; simp_all
 
-instance : CMRA (Agree α) where
+instance Agree_CMRA : CMRA (Agree α) where
   pcore := some
   op := Agree.op
   ValidN := Agree.validN

--- a/src/Iris/Algebra/CMRA.lean
+++ b/src/Iris/Algebra/CMRA.lean
@@ -169,8 +169,19 @@ theorem _root_.Iris.OFE.Equiv.opM {x₁ x₂ : α} {y₁ y₂ : Option α}
     (H1 : x₁ ≡ x₂) (H2 : y₁ ≡ y₂) : x₁ •? y₁ ≡ x₂ •? y₂ :=
   equiv_dist.2 fun _ => H1.dist.opM H2.dist
 
+theorem opM_left_eqv {x y : α} (z : Option α) (e : x ≡ y) : x •? z ≡ y •? z := e.opM Equiv.rfl
+theorem opM_right_eqv (x : α) {y z : Option α} (e : y ≡ z) : x •? y ≡ x •? z := Equiv.rfl.opM e
+
+theorem opM_left_dist {n} {x y : α} (z : Option α) (e : x ≡{n}≡ y) : x •? z ≡{n}≡ y •? z :=
+  e.opM Dist.rfl
+theorem opM_right_dist {n} (x : α) {y z : Option α} (e : y ≡{n}≡ z) : x •? y ≡{n}≡ x •? z :=
+  Dist.rfl.opM e
+
 theorem op_opM_assoc (x y : α) (mz : Option α) : (x • y) •? mz ≡ x • (y •? mz) := by
   unfold op?; cases mz <;> simp [assoc, Equiv.symm]
+
+theorem op_opM_assoc_dist (x y : α) (mz : Option α) : (x • y) •? mz ≡{n}≡ x • (y •? mz) := by
+  unfold op?; cases mz <;> simp [assoc.dist, Dist.symm]
 
 /-! ## Validity -/
 
@@ -194,6 +205,8 @@ theorem _root_.Iris.OFE.Equiv.valid : (x : α) ≡ y → (✓ x ↔ ✓ y) := va
 theorem validN_of_le {n n'} {x : α} : n' ≤ n → ✓{n} x → ✓{n'} x :=
   fun le => le.recOn id fun  _ ih vs => ih (validN_succ vs)
 
+theorem valid0_of_validN {n} {x : α} : ✓{n} x → ✓{0} x := validN_of_le (Nat.zero_le n)
+
 theorem validN_op_right {n} {x y : α} : ✓{n} (x • y) → ✓{n} y :=
   fun v => validN_op_left (validN_of_eqv comm v)
 
@@ -202,6 +215,14 @@ theorem valid_op_right (x y : α) : ✓ (x • y) → ✓ y :=
 
 theorem valid_op_left {x y : α} : ✓ (x • y) → ✓ x :=
   fun v => valid_op_right y x (valid_of_eqv comm v)
+
+theorem validN_opM {x: α}{my: Option α}: ✓{n} (x •? my) → ✓{n} x :=
+  match my with
+  | none => id  | some _ => validN_op_left
+
+theorem valid_opM {x: α}{my: Option α}: ✓ (x •? my) → ✓ x :=
+  match my with
+  | none => id  | some _ => valid_op_left
 
 /-! ## Core -/
 
@@ -377,6 +398,7 @@ theorem Included.validN {n} {x y : α} : x ≼ y → ✓{n} y → ✓{n} x := va
 
 theorem incN_of_incN_le {n n'} {x y : α} (l1 : n' ≤ n) : x ≼{n} y → x ≼{n'} y
   | ⟨z, hz⟩ => ⟨z, Dist.le hz l1⟩
+theorem inc0_of_incN {n} {x y : α} : x ≼{n} y → x ≼{0} y := incN_of_incN_le (Nat.zero_le n)
 theorem IncludedN.le {n n'} {x y : α} : n' ≤ n → x ≼{n} y → x ≼{n'} y := incN_of_incN_le
 
 theorem incN_of_incN_succ {n} {x y : α} : x ≼{n.succ} y → x ≼{n} y :=
@@ -469,6 +491,9 @@ theorem pcore_eq_core (x : α) : pcore x = some (core x) := by
 
 theorem op_core (x : α) : x • core x ≡ x := pcore_op_right (pcore_eq_core x)
 theorem core_op (x : α) : core x • x ≡ x := comm.trans (op_core x)
+
+theorem op_core_dist {n}(x: α) : x • core x ≡{n}≡ x := (op_core x).dist
+theorem core_op_dist {n}(x: α) : core x • x ≡{n}≡ x := (core_op x).dist
 
 theorem core_op_core {x : α} : core x • core x ≡ core x :=
   pcore_op_self (pcore_eq_core x)
@@ -591,6 +616,12 @@ theorem cancelable_iff {x₁ x₂ : α} (e : x₁ ≡ x₂) : Cancelable x₁ �
 theorem _root_.Iris.OFE.Equiv.cancelable {x₁ x₂ : α} : x₁ ≡ x₂ → (Cancelable x₁ ↔ Cancelable x₂) :=
   cancelable_iff
 
+theorem op_opM_cancel_dist {x y z: α} [Cancelable x]
+    (vxy: ✓{n} x • y) (h: x • y ≡{n}≡ (x • z) •? mw): y ≡{n}≡ z •? mw :=
+  match mw with
+  | none => cancelableN vxy h
+  | some _ => cancelableN vxy (h.trans (op_assocN.symm))
+
 end cancelableElements
 
 section idFreeElements
@@ -664,7 +695,11 @@ theorem incN_unit {n} {x : α} : unit ≼{n} x := ⟨x, unit_left_id.symm.dist�
 
 theorem inc_unit {x : α} : unit ≼ x := ⟨x, unit_left_id.symm⟩
 
+theorem unit_left_id_dist {n} (x : α) : unit • x ≡{n}≡ x := unit_left_id.dist
+
 theorem unit_right_id {x : α} : x • unit ≡ x := comm.trans unit_left_id
+
+theorem unit_right_id_dist (x : α) : x • unit ≡{n}≡ x := comm.dist.trans (unit_left_id_dist x)
 
 instance unit_CoreId : CoreId (unit : α) where
   core_id := pcore_unit
@@ -958,25 +993,25 @@ end DiscreteFunURF
 
 section option
 
-variable [CMRA A]
+variable [CMRA α]
 
-def optionCore (x : Option A) : Option A := x.bind CMRA.pcore
+def optionCore (x : Option α) : Option α := x.bind CMRA.pcore
 
-def optionOp (x y : Option A) : Option A :=
+def optionOp (x y : Option α) : Option α :=
   match x, y with
   | some x', some y' => some (CMRA.op x' y')
   | none, _ => y
   | _, none => x
 
-def optionValidN (n : Nat) : Option A → Prop
+def optionValidN (n : Nat) : Option α → Prop
   | some x => ✓{n} x
   | none => True
 
-def optionValid : Option A → Prop
+def optionValid : Option α → Prop
   | some x => ✓ x
   | none => True
 
-instance cmraOption : CMRA (Option A) where
+instance cmraOption : CMRA (Option α) where
   pcore x := some (optionCore x)
   op := optionOp
   ValidN := optionValidN
@@ -1037,13 +1072,151 @@ instance cmraOption : CMRA (Option A) where
     · rcases CMRA.extend Hx Hx' with ⟨mc1, mc2, _, _, _⟩
       exists some mc1, some mc2
 
-instance ucmraOption : UCMRA (Option A) where
+instance ucmraOption : UCMRA (Option α) where
   unit := none
   unit_valid := by simp [CMRA.Valid, optionValid]
   unit_left_id := by rintro ⟨⟩ <;> rfl
   pcore_unit := by rfl
 
+theorem CMRA.equiv_of_some_equiv_some {x y : α} (h: some x ≡ some y): x ≡ y := h
+theorem CMRA.dist_of_some_dist_some {n} {x y : α} (h: some x ≡{n}≡ some y): x ≡{n}≡ y := h
+
+theorem CMRA.op_some_opM_assoc (x y : α) (mz : Option α) : (x • y) •? mz ≡ x •? (some y • mz) :=
+  match mz with
+  | none   => Equiv.rfl
+  | some _ => Equiv.symm assoc
+
+theorem CMRA.op_some_opM_assoc_dist (x y : α) (mz : Option α) : (x • y) •? mz ≡{n}≡ x •? (some y • mz) :=
+  match mz with
+  | none   => Dist.rfl
+  | some _ => Dist.symm assoc.dist
+
+theorem CMRA.some_inc_some_of_dist_opM {x y : α} {mz : Option α} (h: x ≡{n}≡ y •? mz)
+    : some y ≼{n} some x :=
+  match mz with
+  | none   => ⟨none, h⟩
+  | some z => ⟨some z, h⟩
+
+theorem CMRA.inc_of_some_inc_some [CMRA.IsTotal α] {x y : α} (h: some y ≼ some x): y ≼ x :=
+  let ⟨mz, hmz⟩ := h
+  match mz with
+  | none => ⟨core y, (CMRA.equiv_of_some_equiv_some hmz).trans (op_core y).symm⟩
+  | some z => ⟨z, hmz⟩
+
+theorem CMRA.incN_of_some_incN_some [CMRA.IsTotal α] {x y : α} (h: some y ≼{n} some x): y ≼{n} x :=
+  let ⟨mz, hmz⟩ := h
+  match mz with
+  | none => ⟨core y, (CMRA.dist_of_some_dist_some hmz).trans (op_core_dist y).symm⟩
+  | some z => ⟨z, hmz⟩
+
+theorem CMRA.exists_op_some_eqv_some (x : Option α) (y : α): ∃z, x • some y ≡ some z :=
+  match x with
+  | .none => ⟨y, Equiv.rfl⟩
+  | .some w => ⟨w • y, Equiv.rfl⟩
+
+theorem CMRA.exists_op_some_dist_some {n} (x : Option α) (y : α): ∃z, x • some y ≡{n}≡ some z :=
+  (CMRA.exists_op_some_eqv_some x y).elim fun z h => ⟨z, h.dist⟩
+
+theorem not_valid_some_exclN_op_left {n} {x : α} [CMRA.Exclusive x] {y: α}
+    : ¬✓{n} (some x • some y) :=
+  fun h =>
+    have : ✓{n} x • y := h
+    absurd this (by exact CMRA.not_valid_exclN_op_left)
+
+theorem validN_op_unit {n} {x : Option α} (vx: ✓{n} x): ✓{n} x • CMRA.unit :=
+  match x with
+  | .none => vx
+  | .some _ => vx
+
 end option
+
+section unit
+
+instance cmraUnit : CMRA Unit where
+  pcore _ := some ()
+  op _ _ := ()
+  ValidN _ _ := True
+  Valid _ := True
+  op_ne.ne _ _ _ H := H
+  pcore_ne {_} _ _ z _ _ := match z with | .unit => ⟨(), rfl, OFE.Dist.rfl⟩
+  validN_ne {_} _ _ _ := id
+  valid_iff_validN := ⟨fun _ _ => .intro, fun _ => .intro⟩
+  validN_succ := id
+  validN_op_left := id
+  assoc := OFE.Equiv.rfl
+  comm := OFE.Equiv.rfl
+  pcore_op_left {x _} _ := match x with | .unit => OFE.Equiv.rfl
+  pcore_idem {_ cx} _ := match cx with | .unit => OFE.Equiv.rfl
+  pcore_op_mono _ _ := ⟨.unit, OFE.Equiv.rfl⟩
+  extend {_} x y z _ _ :=
+    match x, y, z with
+    | .unit, .unit, .unit => ⟨(), (), OFE.Equiv.rfl, OFE.Dist.rfl, OFE.Dist.rfl⟩
+
+end unit
+
+section prod
+
+variable [CMRA α] [CMRA β]
+
+instance cmraProd : CMRA (α × β) where
+  pcore x := do
+    let a <- CMRA.pcore x.fst
+    let b <- CMRA.pcore x.snd
+    return (a,b)
+  op x y := (x.fst • y.fst, x.snd • y.snd)
+  ValidN n x := ✓{n} x.fst ∧ ✓{n} x.snd
+  Valid x := ✓ x.fst ∧ ✓ x.snd
+  op_ne {x} :=
+    {ne n y z h := dist_prod_ext (Dist.op_r $ dist_fst h) (Dist.op_r $ dist_snd h)}
+  pcore_ne {n x y cx} h ph :=
+    have ⟨cx₁, hcx₁, this⟩ := Option.bind_eq_some.mp ph
+    have ⟨cx₂, hcx₂, hcx⟩ := Option.bind_eq_some.mp this
+    have ⟨cy₁, hcy₁, hxy₁⟩ := CMRA.pcore_ne (dist_fst h) hcx₁
+    have ⟨cy₂, hcy₂, hxy₂⟩ := CMRA.pcore_ne (dist_snd h) hcx₂
+    suffices g: cx ≡{n}≡ (cy₁, cy₂) by simp [hcy₁, hcy₂, g]
+    calc
+      cx ≡{n}≡ (cx₁, cx₂) := Dist.of_eq (Option.some.inj hcx).symm
+      _  ≡{n}≡ (cy₁, cy₂) := dist_prod_ext hxy₁ hxy₂
+  validN_ne {n} x y H := fun ⟨vx1, vx2⟩ =>
+    ⟨ (Dist.validN $ dist_fst H).mp vx1, (Dist.validN $ dist_snd H).mp vx2 ⟩
+  valid_iff_validN {x} :=
+    ⟨ fun ⟨va, vb⟩ n => ⟨CMRA.Valid.validN va, CMRA.Valid.validN vb⟩,
+      fun h =>
+        ⟨ CMRA.valid_iff_validN.mpr fun n => (h n).left,
+          CMRA.valid_iff_validN.mpr fun n => (h n).right ⟩ ⟩
+  validN_succ {x n} := fun ⟨va, vb⟩ => ⟨CMRA.validN_succ va, CMRA.validN_succ vb⟩
+  validN_op_left {n x y} := fun ⟨va, vb⟩ => ⟨CMRA.validN_op_left va, CMRA.validN_op_left vb⟩
+  assoc {x y z} := ⟨CMRA.assoc, CMRA.assoc⟩
+  comm {x y} := ⟨CMRA.comm, CMRA.comm⟩
+  pcore_op_left {x cx} h :=
+    let ⟨a, ha, ho⟩ := Option.bind_eq_some.mp h
+    let ⟨b, hb, hh⟩ := Option.bind_eq_some.mp ho
+    (Option.some.inj hh) ▸ OFE.equiv_prod_ext (CMRA.pcore_op_left ha) (CMRA.pcore_op_left hb)
+  pcore_idem {x cx} h :=
+    have ⟨cx₁, hcx₁, this⟩ := Option.bind_eq_some.mp h
+    have ⟨cx₂, hcx₂, hcx⟩ := Option.bind_eq_some.mp this
+    have ⟨a, ha, ea⟩ := equiv_some (CMRA.pcore_idem hcx₁)
+    have ⟨b, hb, eb⟩ := equiv_some (CMRA.pcore_idem hcx₂)
+    suffices g: (a, b) ≡ (cx₁, cx₂) by
+      rw [Option.some.inj hcx.symm]
+      simp [ha, hb, g]
+    equiv_prod_ext ea eb
+  pcore_op_mono {x cx} h y := by
+    have ⟨cx₁, hcx₁, this⟩ := Option.bind_eq_some.mp h
+    have ⟨cx₂, hcx₂, hcx⟩ := Option.bind_eq_some.mp this
+    have ⟨cy₁, hcy₁⟩ := CMRA.pcore_op_mono hcx₁ y.fst
+    have ⟨cy₂, hcy₂⟩ := CMRA.pcore_op_mono hcx₂ y.snd
+    have ⟨a, ha, ea⟩ := equiv_some hcy₁
+    have ⟨b, hb, eb⟩ := equiv_some hcy₂
+    rw [Option.some.inj hcx.symm, ha, hb]
+    exists (cy₁, cy₂)
+  extend {n x y₁ y₂} := fun ⟨vx₁, vx₂⟩ e =>
+    let ⟨z₁, w₁, hx₁, hz₁, hw₁⟩ := CMRA.extend vx₁ (OFE.dist_fst e)
+    let ⟨z₂, w₂, hx₂, hz₂, hw₂⟩ := CMRA.extend vx₂ (OFE.dist_snd e)
+    ⟨ (z₁, z₂), (w₁, w₂), OFE.equiv_prod_ext hx₁ hx₂,
+      OFE.dist_prod_ext hz₁ hz₂, OFE.dist_prod_ext hw₁ hw₂ ⟩
+
+end prod
 
 section optionOF
 

--- a/src/Iris/Algebra/CMRA.lean
+++ b/src/Iris/Algebra/CMRA.lean
@@ -1128,6 +1128,8 @@ theorem validN_op_unit {n} {x : Option α} (vx: ✓{n} x): ✓{n} x • CMRA.uni
   | .none => vx
   | .some _ => vx
 
+instance Some_ne : NonExpansive (some : α → Option α) := ⟨fun _ _ _ => id⟩
+
 end option
 
 section unit

--- a/src/Iris/Algebra/DFrac.lean
+++ b/src/Iris/Algebra/DFrac.lean
@@ -1,0 +1,161 @@
+/-
+Copyright (c) 2025 Markus de Medeiros. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Markus de Medeiros
+-/
+
+import Iris.Algebra.CMRA
+import Iris.Algebra.OFE
+import Iris.Algebra.Frac
+
+open Iris
+
+inductive DFracK (F : Type _) where
+| Own : F → DFracK F
+| Discard : DFracK F
+| OwnDiscard : F → DFracK F
+
+abbrev DFrac F := LeibnizO (DFracK F)
+
+-- TODO: Delete this class. I have it now because the Fractional class is being
+-- changed concurrently. Also I'm certain that some of these fields will be derivable.
+class DFractional (F : Type _) extends Fractional F where
+  one_strict_max {y : F} : ¬(One.one + y ≤ One.one)
+  lt_irrefl : ¬(One.one < (One.one : F))
+  strict_pos {x y : F} : ¬(x + y = x)
+  lt_op_mono {x y z : F} : x + y ≤ z → y < z -- OK because positive
+
+section dfrac
+
+open DFracK
+
+variable {F : Type _} [DFractional F]
+
+instance : Inhabited (DFrac F) := ⟨⟨Discard⟩⟩
+
+abbrev valid : DFrac F → Prop
+| ⟨Own f⟩        => f ≤ One.one
+| ⟨Discard⟩      => True
+| ⟨OwnDiscard f⟩ => f < One.one
+
+abbrev pcore : DFrac F → Option (DFrac F)
+| ⟨Own _⟩        => none
+| ⟨Discard⟩      => some ⟨Discard⟩
+| ⟨OwnDiscard _⟩ => some ⟨Discard⟩
+
+abbrev op : DFrac F → DFrac F → DFrac F
+| ⟨Own f⟩, ⟨Own f'⟩               => ⟨Own (f + f')⟩
+| ⟨Own f⟩, ⟨Discard⟩              => ⟨OwnDiscard f⟩
+| ⟨Own f⟩, ⟨OwnDiscard f'⟩        => ⟨OwnDiscard (f + f')⟩
+| ⟨Discard⟩, ⟨Own f'⟩             => ⟨OwnDiscard f'⟩
+| ⟨Discard⟩, ⟨Discard⟩            => ⟨Discard⟩
+| ⟨Discard⟩, ⟨OwnDiscard f'⟩      => ⟨OwnDiscard f'⟩
+| ⟨OwnDiscard f⟩, ⟨Own f'⟩        => ⟨OwnDiscard (f + f')⟩
+| ⟨OwnDiscard f⟩, ⟨Discard⟩       => ⟨OwnDiscard f⟩
+| ⟨OwnDiscard f⟩, ⟨OwnDiscard f'⟩ => ⟨OwnDiscard (f + f')⟩
+
+instance DFrac_CMRA : CMRA (DFrac F) where
+  pcore := pcore
+  op := op
+  Valid := valid
+  ValidN _ := valid
+  op_ne {x} := ⟨by intro _ f1 f2 H; cases x <;> cases f1 <;> cases f2; exact congrArg (op _) H⟩
+  pcore_ne {n x y z} := by
+    rcases x with ⟨x|_|x⟩ <;>
+    rcases y with ⟨y|_|y⟩ <;>
+    rcases z with ⟨z|_|z⟩ <;>
+    simp
+    all_goals intro H; have H' := LeibnizO.dist_inj H; simp at H'
+  validN_ne {_ x y} H := by cases x <;> cases y; exact (H ▸ id)
+  valid_iff_validN := ⟨fun x _ => x, fun x => x 0⟩
+  validN_succ := id
+  validN_op_left {_ x y} := by
+    have Lleft {a' a : F} (H : a' + a < one) : a' < one := by
+      rcases Fractional.lt_sum.mp H with ⟨r, Hr⟩
+      exact (Fractional.lt_sum.mpr ⟨a + r, Hr.symm ▸ Fractional.assoc.symm⟩)
+    rcases x with ⟨x|_|x⟩ <;> rcases y with ⟨y|_|y⟩ <;> simp
+    · exact Fractional.add_le_mono
+    · exact Fractional.lt_le
+    · exact (Fractional.add_le_mono <| Fractional.lt_le ·)
+    · exact Lleft
+    · exact Lleft
+  assoc {x y z} := by
+    rcases x with ⟨x|_|x⟩ <;>
+    rcases y with ⟨y|_|y⟩ <;>
+    rcases z with ⟨z|_|z⟩ <;>
+    simp [op, Fractional.assoc]
+  comm {x y} := by rcases x with ⟨x|_|x⟩ <;> rcases y with ⟨y|_|y⟩ <;> simp [op, Fractional.comm]
+  pcore_op_left {x y} := by rcases x with ⟨x|_|x⟩ <;> rcases y with ⟨y|_|y⟩ <;> simp
+  pcore_idem {x y} := by rcases x with ⟨x|_|x⟩ <;> rcases y with ⟨y|_|y⟩ <;> simp
+  pcore_op_mono {x y} := by
+    rcases x with ⟨x|_|x⟩ <;>
+    rcases y with ⟨y|_|y⟩ <;>
+    simp <;>
+    intro z <;>
+    exists ⟨Discard⟩ <;>
+    rcases z with ⟨z|_|z⟩ <;>
+    simp [op]
+  extend {_ x y z} Hx Hxyz := by
+    rcases x with ⟨x|_|x⟩
+    · rcases y with ⟨y|_|y⟩ <;> rcases z with ⟨z|_|z⟩ <;> simp [op] at Hxyz
+      all_goals have Hxyz' := LeibnizO.dist_inj Hxyz <;> simp at Hxyz'
+      exists ⟨Own y⟩
+      exists ⟨Own z⟩
+    · rcases y with ⟨y|_|y⟩ <;> rcases z with ⟨z|_|z⟩ <;> simp [op] at Hxyz
+      all_goals (try have Hxyz' := LeibnizO.dist_inj Hxyz <;> simp at Hxyz')
+      exists ⟨Discard⟩
+      exists ⟨Discard⟩
+    · rcases y with ⟨y|_|y⟩ <;> rcases z with ⟨z|_|z⟩ <;> simp [op] at Hxyz
+      all_goals (try have Hxyz' := LeibnizO.dist_inj Hxyz <;> simp at Hxyz')
+      all_goals subst Hxyz'
+      · exists ⟨Own x⟩; exists ⟨Discard⟩
+      · exists ⟨Own y⟩; exists ⟨OwnDiscard z⟩
+      · exists ⟨Discard⟩; exists ⟨Own x⟩
+      · exists ⟨Discard⟩; exists ⟨OwnDiscard x⟩
+      · exists ⟨OwnDiscard y⟩; exists ⟨Own z⟩
+      · exists ⟨OwnDiscard x⟩; exists ⟨Discard⟩
+      · exists ⟨OwnDiscard y⟩; exists ⟨OwnDiscard z⟩
+
+instance : CMRA.Exclusive (α := DFrac F) ⟨Own One.one⟩ where
+  exclusive0_l y := by
+    rcases y with ⟨y|_|y⟩ <;>
+    simp only [CMRA.ValidN, valid]
+    · exact DFractional.one_strict_max
+    · exact DFractional.lt_irrefl
+    · exact DFractional.one_strict_max ∘ Fractional.lt_le
+
+instance {f : F} : CMRA.Cancelable (α := DFrac F) ⟨Own f⟩ where
+  cancelableN {_ x y} := by
+    rcases x with ⟨x|_|x⟩ <;>
+    rcases y with ⟨y|_|y⟩ <;>
+    simp [CMRA.ValidN, CMRA.op, op]
+    all_goals intro H Hxyz
+    all_goals (try have Hxyz' := LeibnizO.dist_inj Hxyz <;> simp at Hxyz')
+    · exact congrArg (LeibnizO.mk ∘ Own) (Fractional.cancel Hxyz')
+    · exact (DFractional.strict_pos (F := F) Hxyz'.symm).elim
+    · exact (DFractional.strict_pos (F := F) Hxyz').elim
+    · exact congrArg (LeibnizO.mk ∘ OwnDiscard) (Fractional.cancel Hxyz')
+
+instance {f : F} : CMRA.IdFree (α := DFrac F) ⟨Own f⟩ where
+  id_free0_r y := by
+    rcases y with ⟨y|_|y⟩ <;> simp [CMRA.ValidN, CMRA.op, op] <;> intro H Hxyz
+    all_goals (try have Hxyz' := LeibnizO.dist_inj Hxyz <;> simp at Hxyz')
+    exact (DFractional.strict_pos (F := F) Hxyz').elim
+
+theorem valid_own_iff {f : F} : ✓ (LeibnizO.mk (Own f)) ↔ f ≤ One.one := by simp [CMRA.Valid]
+theorem valid_own_one : ✓ (LeibnizO.mk (Own (One.one : F))) := valid_own_iff.mpr Fractional.le_refl
+
+theorem valid_op_own_r {dq : DFrac F} {q : F} : ✓ (dq • ⟨Own q⟩) → (q < One.one) := by
+  rcases dq with ⟨y|_|y⟩ <;> simp [CMRA.ValidN, CMRA.op, op, CMRA.Valid]
+  · exact DFractional.lt_op_mono
+  · exact DFractional.lt_op_mono ∘ Fractional.lt_le
+
+theorem valid_op_own_l {dq : DFrac F} {q : F} : ✓ (⟨Own q⟩ • dq) → (q < One.one) :=
+  valid_op_own_r ∘ CMRA.valid_of_eqv (CMRA.comm (y := dq))
+
+theorem valid_discarded : ✓ (LeibnizO.mk Discard : DFrac F) := by simp [CMRA.Valid, valid]
+
+theorem valid_own_op_discarded {q : F} : ✓ (⟨Own q⟩ • ⟨Discard⟩ : DFrac F) ↔ q < One.one := by
+  simp [CMRA.op, op, CMRA.Valid, valid]
+
+end dfrac

--- a/src/Iris/Algebra/DFrac.lean
+++ b/src/Iris/Algebra/DFrac.lean
@@ -158,4 +158,7 @@ theorem valid_discarded : ✓ (LeibnizO.mk Discard : DFrac F) := by simp [CMRA.V
 theorem valid_own_op_discarded {q : F} : ✓ (⟨Own q⟩ • ⟨Discard⟩ : DFrac F) ↔ q < One.one := by
   simp [CMRA.op, op, CMRA.Valid, valid]
 
+instance : CMRA.Discrete (DFrac F) where
+  discrete_valid {x} := by simp [CMRA.Valid, CMRA.ValidN]
+
 end dfrac

--- a/src/Iris/Algebra/DFrac.lean
+++ b/src/Iris/Algebra/DFrac.lean
@@ -161,4 +161,6 @@ theorem valid_own_op_discarded {q : F} : ✓ (⟨Own q⟩ • ⟨Discard⟩ : DF
 instance : CMRA.Discrete (DFrac F) where
   discrete_valid {x} := by simp [CMRA.Valid, CMRA.ValidN]
 
+theorem dfrac.is_discrete {q : DFrac F} : OFE.DiscreteE q := congrArg id
+
 end dfrac

--- a/src/Iris/Algebra/Frac.lean
+++ b/src/Iris/Algebra/Frac.lean
@@ -1,0 +1,120 @@
+/-
+Copyright (c) 2025 Markus de Medeiros. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Markus de Medeiros
+-/
+
+import Iris.Algebra.CMRA
+import Iris.Algebra.OFE
+
+-- TODO: The typeclasses generalize the fractional construction by paramaterizing by the operations we need,
+-- but this could probably be simpified, and use an actual arithmetic type if we have access to it.
+-- I want this to be generalized so I can use posreal from mathlib.
+
+class One (T : Type _) where one : T
+export One(one)
+
+/-- A type which can be used as a a fraction. -/
+class Fractional (T : Type _) extends One T, Add T, LE T, LT T where
+  add_le_mono {x y z : T} : x + y ≤ z → x ≤ z
+  assoc {a b c : T} : (a + b) + c = a + (b + c)
+  comm {a b : T} : a + b = b + a
+  lt_sum {a b : T} : a < b ↔ ∃ r, a + r = b
+  lt_le {a b : T} : a < b → a ≤ b
+  positive {a : T} : ¬∃ (b : T), a + b ≤ a
+  cancel {a b c : T} : c + a = c + b → a = b
+  le_refl {a : T} : a ≤ a
+
+namespace Iris
+
+def Frac (T : Type _) [Fractional T] := LeibnizO T
+
+-- TODO: How do I get rid of these instances?
+-- I definitely do not want to use an abbrev for Frac (there are many different OFE's for numerical types)
+-- so do we need to keep around all of these coercions?
+instance [Fractional T] : Coe (Frac T) T := ⟨(·.1)⟩
+instance [Fractional T] : Coe T (Frac T) := ⟨(⟨·⟩)⟩
+@[simp] instance [Fractional T] : COFE (Frac T) := by unfold Frac; infer_instance
+@[simp] instance [Fractional T] : One (Frac T) := ⟨⟨One.one⟩⟩
+@[simp] instance [Fractional T] : LE (Frac T) := ⟨fun x y => x.1 ≤ y.1⟩
+@[simp] instance [Fractional T] : LT (Frac T) := ⟨fun x y => x.1 < y.1⟩
+@[simp] instance [Fractional T] : Add (Frac T) := ⟨fun x y => x.1 + y.1⟩
+
+namespace Frac
+
+variable [Fractional α]
+
+instance Frac_CMRA : CMRA (Frac α) where
+  pcore _ := none
+  op := Add.add
+  ValidN _ x := x ≤ one
+  Valid x := x ≤ one
+  op_ne {x} := ⟨fun _ _ _ => congrArg (Add.add x)⟩
+  pcore_ne := fun _ => (exists_eq_right'.mpr ·)
+  validN_ne := (le_of_eq_of_le ∘ OFE.Dist.symm <| ·)
+  valid_iff_validN := Iff.symm (forall_const Nat)
+  validN_succ := (·)
+  validN_op_left := Fractional.add_le_mono
+  assoc := by simp [← Fractional.assoc]
+  comm := by simp [← Fractional.comm]
+  pcore_op_left := by simp
+  pcore_idem := by simp
+  pcore_op_mono := by simp
+  extend {_ _ y1 y2} _ _ := by exists y1; exists y2
+
+-- TODO: Simplify
+theorem frac_included {p q : Frac α} : p ≼ q ↔ p < q :=
+  ⟨ by
+      rintro ⟨r, Hr⟩
+      apply Fractional.lt_sum.mpr
+      exists r
+      rw [Hr]
+      rfl,
+    by
+      intro H
+      rcases Fractional.lt_sum.mp H with ⟨r, Hr⟩
+      exists r
+      simp [Iris.Frac.Frac_CMRA]
+      rw [Hr]
+      rfl⟩
+
+theorem frac_included_weak {p q : Frac α} (H : p ≼ q) : p ≤ q :=
+  Fractional.lt_le (frac_included.mp H)
+
+instance : CMRA.Discrete (Frac α) where
+  discrete_0 := id
+  discrete_valid := id
+
+instance : CMRA.Exclusive (one : Frac α) where
+  exclusive0_l _ H := Fractional.positive ⟨_, H⟩
+
+-- TODO: Simplify
+instance {q : Frac α} : CMRA.Cancelable q where
+  cancelableN {n x y} := by
+    simp [CMRA.ValidN]
+    intro _
+    suffices q + x = q + y → x = y by apply this
+    intro H
+    have H' := @Fractional.cancel α _ x.car y.car q.car
+    rcases x with ⟨x⟩
+    rcases y with ⟨y⟩
+    rcases q with ⟨q⟩
+    simp_all [Add.add]
+    rw [H']
+    simp [HAdd.hAdd] at H
+    have H'' : ({ car := Add.add q x } : Frac α).car = ({ car := Add.add q y } : Frac α).car := by
+      rw [H]
+    exact H''
+
+-- TODO: Simplify
+instance {q : Frac α} : CMRA.IdFree q where
+  id_free0_r y := by
+    intro H H'
+    apply @Fractional.positive (T := α) (a := q)
+    exists y
+    conv=>
+      rhs
+      rw [← H']
+    apply Fractional.le_refl
+
+end Frac

--- a/src/Iris/Algebra/Heap.lean
+++ b/src/Iris/Algebra/Heap.lean
@@ -1,0 +1,27 @@
+/-
+Copyright (c) 2025 Markus de Medeiros. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Markus de Medeiros
+-/
+
+import Iris.Algebra.CMRA
+import Iris.Algebra.OFE
+
+/- # Datatype and CMRA for a generic heap-like structure -/
+
+open Classical in
+noncomputable def fset {K V : Type _} (f : K → V) (k : K) (v : V) : K → V :=
+  fun k' => if (k = k') then v else f k'
+
+/-- `T` can store and retrieve keys and values. -/
+class StoreLike (T K V : Type _) where
+  get : T → K → V
+  set : T → K → V → T
+export StoreLike (get set)
+
+/-- `T`'s store and retrieve operations behave like a classical store. -/
+class Store (T K V : Type _) extends StoreLike T K V where
+  get_set {t k v} : get (set t k v) = fset (get t : K → V) k v
+
+/-- A type is HeapLike when it behaves like store for Optional values -/
+class abbrev HeapLike (T K V : Type _) := StoreLike T K (Option V)

--- a/src/Iris/Algebra/Heap.lean
+++ b/src/Iris/Algebra/Heap.lean
@@ -9,11 +9,10 @@ import Iris.Algebra.OFE
 
 open Iris
 
-/- # Datatype and CMRA for a generic heap-like structure.
-
-Like FunLike in Mathlib, but not exactly the same, since the type must also be able to be updated. -/
+/- # Datatype and CMRA for a generic heap-like structure. -/
 
 open Classical in
+/-- Update a (classical) function at a point. Used to specify the correctness of stores. -/
 noncomputable def fset {K V : Type _} (f : K → V) (k : K) (v : V) : K → V :=
   fun k' => if (k = k') then v else f k'
 
@@ -30,12 +29,27 @@ class Store (T : Type _) (K V : outParam (Type _)) extends StoreLike T K V where
   /-- One-sided inverse between get and of_fun. The other direction does not need to hold. -/
   of_fun_get {f} : get (of_fun f) = f
 
+class StoreIso (T : Type _) (K V : outParam (Type _)) extends Store T K V where
+  get_of_fun t : of_fun (get t) = t
+
+def StoreLike.map [StoreLike T1 K V1] [StoreLike T2 K V2] (t : T1) (f : V1 → V2) : T2 :=
+  StoreLike.of_fun <| f ∘ StoreLike.get t
+
+def StoreLike.merge [StoreLike T K V] (op : V → V → V) (t1 t2 : T) : T :=
+  StoreLike.of_fun <| (fun k => op (StoreLike.get t1 k) (StoreLike.get t2 k))
+
 class Alloc (T : Type _) (K : outParam (Type _)) where
   fresh : T → K
 
+class HeapLike (T : Type _) (K V : outParam (Type _)) extends StoreLike T K (Option V)
+
 /-- A type is HeapLike when it behaves like store for Optional values -/
-class Heap (T : Type _) (K V : outParam (Type _)) extends StoreLike T K (Option V), Alloc T K where
+class Heap (T : Type _) (K V : outParam (Type _)) extends HeapLike T K V, Alloc T K where
   fresh_get {t} : get t (fresh t) = none
+
+abbrev delete [HeapLike T K V] (t : T) (k : K) : T := StoreLike.set t k .none
+abbrev empty [HeapLike T K V] : T := StoreLike.of_fun (fun _ => .none)
+abbrev dom [HeapLike T K V] : T → K → Prop := fun t k => (StoreLike.get t k).isSome
 
 
 namespace Store
@@ -47,36 +61,99 @@ theorem get_set_ne {m : T} (H : k ≠ k') : get (set m k v) k' = get m k' := by
 theorem get_set_eq {m : T} (H : k = k') : get (set m k v) k' = v := by
   rw [get_set]; unfold fset; rw [if_pos H]
 
+theorem get_merge {op : V → V → V} (t1 t2 : T) (k : K) :
+    StoreLike.get (StoreLike.merge op t1 t2) k = op (StoreLike.get t1 k) (StoreLike.get t2 k) := by
+  unfold StoreLike.merge; rw [Store.of_fun_get]
+
 end Store
 
+theorem Store.get_map [StoreLike T1 K V1] [Store T2 K V2] {t : T1} {f : V1 → V2} {k : K} :
+    StoreLike.get (StoreLike.map t f : T2) k = f (StoreLike.get t k) := by
+  unfold StoreLike.map; rw [Store.of_fun_get]; rfl
 
 /-- Wrapper type for functions with the Store OFE -/
-structure StoreO (T : Type _) where car : T
+@[ext] structure StoreO (T : Type _) where car : T
 
-section algebra
+section ofe
 
-open OFE
+open OFE 
 
-/-- The OFE on StoreO is the discrete function OFE on it's .get function. -/
-instance StoreO_OFE {T K V : Type _} [StoreLike T K V] [OFE V] : OFE (StoreO T) where
+/-- The OFE on StoreO is the discrete function OFE on its .get function. -/
+instance StoreO_OFE [StoreLike T K V] [OFE V] : OFE (StoreO T) where
   Equiv s0 s1  := StoreLike.get s0.1 ≡ StoreLike.get s1.1
   Dist n s0 s1 := StoreLike.get s0.1 ≡{n}≡ StoreLike.get s1.1
   dist_eqv     := ⟨fun _ => .of_eq rfl, (·.symm), (·.trans ·)⟩
   equiv_dist   := equiv_dist
   dist_lt      := dist_lt
 
-def StoreO.toMap {T K V : Type _} [StoreLike T K V] [OFE V] : (StoreO T) -n> (K → V) where
+@[simp] def StoreO.toMap [StoreLike T K V] [OFE V] : (StoreO T) -n> (K → V) where
   f x := StoreLike.get <| StoreO.car x
   ne.1 {_ _ _} H k := H k
 
-def StoreO.ofMap {T K V : Type _} [Store T K V] [OFE V] : (K → V) -n> (StoreO T) where
+@[simp] def StoreO.ofMap [Store T K V] [OFE V] : (K → V) -n> (StoreO T) where
   f x := StoreO.mk <| StoreLike.of_fun x
   ne.1 {_ _ _} H k := by rw [Store.of_fun_get, Store.of_fun_get]; exact H k
 
-instance StoreO_COFE {T K V : Type _} [Store T K V] [COFE V] : COFE (StoreO T) where
+@[simp] def StoreO.get [StoreLike T K V] (k : K) : StoreO T → V :=
+  fun s => StoreLike.get s.1 k
+
+-- TODO: A `Proper` class could avoid the variable reordering.
+instance [StoreLike T K V] [OFE V] (k : K) : NonExpansive (StoreO.get k : StoreO T → V) where
+  ne {_ _ _} Ht := Ht k
+
+@[simp] def StoreO.set [StoreLike T K V] [OFE V] (k : K) : V → StoreO T → StoreO T :=
+  fun v s => StoreO.mk (StoreLike.set s.1 k v)
+
+-- TODO: A `Proper` class could avoid the variable reordering.
+instance [Store T K V] [OFE V] (k : K) : NonExpansive₂ (StoreO.set k : V → StoreO T → StoreO T) where
+  ne {n v1 v2} Hv {t1 t2} Ht k' := by
+    simp only [StoreO.set, Store.get_set, fset]
+    split
+    · exact Hv
+    · exact Ht k'
+
+@[simp] def StoreO.merge [StoreLike T K V] (op : V → V → V) (s1 s2 : StoreO T) : StoreO T :=
+  .mk (StoreLike.merge op s1.1 s2.1)
+
+instance [Store T K V] [OFE V] (op : V → V → V) [NonExpansive₂ op] :
+    NonExpansive₂ (StoreO.merge (T := T) op) where
+  ne n {_ _} Ht {_ _} Hs k := by
+    simp only [StoreO.merge, Store.get_merge]
+    exact NonExpansive₂.ne (Ht k) (Hs k)
+
+instance StoreO_COFE [Store T K V] [COFE V] : COFE (StoreO T) where
   compl c := ⟨StoreLike.of_fun <| COFE.compl <| c.map StoreO.toMap⟩
   conv_compl {n c} k := by
     rw [Store.of_fun_get]
     exact COFE.conv_compl (c := Chain.map StoreO.toMap c) k
 
-end algebra
+instance [Store T K V] [COFE V] [Discrete V] : Discrete (StoreO T) where
+  discrete_0 H k := discrete_0 <| H k
+
+/-- We can lift a Leibniz OFE on V to a Leibniz OFE on (StoreO T) as long as
+stores uniquely represent functions. -/
+instance [StoreIso T K V] [COFE V] [Leibniz V] : Leibniz (StoreO T) where
+  eq_of_eqv {x y} H := by
+    apply StoreO.ext
+    rewrite [← StoreIso.get_of_fun x.car, ← StoreIso.get_of_fun y.car]
+    congr 1
+    apply funext
+    intro k
+    apply eq_of_eqv (H k)
+
+end ofe
+
+
+section cmra
+
+/- ## A CMRA on Heaps
+TODO: I think there may be a generic way to put a CMRA on Stores, but I'm not sure of it. -/
+
+
+
+
+open CMRA
+
+
+
+end cmra

--- a/src/Iris/Algebra/Heap.lean
+++ b/src/Iris/Algebra/Heap.lean
@@ -7,21 +7,76 @@ Authors: Markus de Medeiros
 import Iris.Algebra.CMRA
 import Iris.Algebra.OFE
 
-/- # Datatype and CMRA for a generic heap-like structure -/
+open Iris
+
+/- # Datatype and CMRA for a generic heap-like structure.
+
+Like FunLike in Mathlib, but not exactly the same, since the type must also be able to be updated. -/
 
 open Classical in
 noncomputable def fset {K V : Type _} (f : K → V) (k : K) (v : V) : K → V :=
   fun k' => if (k = k') then v else f k'
 
 /-- `T` can store and retrieve keys and values. -/
-class StoreLike (T K V : Type _) where
+class StoreLike (T : Type _) (K V : outParam (Type _)) where
   get : T → K → V
   set : T → K → V → T
+  of_fun : (K → V) → T
 export StoreLike (get set)
 
 /-- `T`'s store and retrieve operations behave like a classical store. -/
-class Store (T K V : Type _) extends StoreLike T K V where
+class Store (T : Type _) (K V : outParam (Type _)) extends StoreLike T K V where
   get_set {t k v} : get (set t k v) = fset (get t : K → V) k v
+  /-- One-sided inverse between get and of_fun. The other direction does not need to hold. -/
+  of_fun_get {f} : get (of_fun f) = f
+
+class Alloc (T : Type _) (K : outParam (Type _)) where
+  fresh : T → K
 
 /-- A type is HeapLike when it behaves like store for Optional values -/
-class abbrev HeapLike (T K V : Type _) := StoreLike T K (Option V)
+class Heap (T : Type _) (K V : outParam (Type _)) extends StoreLike T K (Option V), Alloc T K where
+  fresh_get {t} : get t (fresh t) = none
+
+
+namespace Store
+variable {T K V : Type _} [Store T K V]
+
+theorem get_set_ne {m : T} (H : k ≠ k') : get (set m k v) k' = get m k' := by
+  rw [get_set]; unfold fset; rw [if_neg H]
+
+theorem get_set_eq {m : T} (H : k = k') : get (set m k v) k' = v := by
+  rw [get_set]; unfold fset; rw [if_pos H]
+
+end Store
+
+
+/-- Wrapper type for functions with the Store OFE -/
+structure StoreO (T : Type _) where car : T
+
+section algebra
+
+open OFE
+
+/-- The OFE on StoreO is the discrete function OFE on it's .get function. -/
+instance StoreO_OFE {T K V : Type _} [StoreLike T K V] [OFE V] : OFE (StoreO T) where
+  Equiv s0 s1  := StoreLike.get s0.1 ≡ StoreLike.get s1.1
+  Dist n s0 s1 := StoreLike.get s0.1 ≡{n}≡ StoreLike.get s1.1
+  dist_eqv     := ⟨fun _ => .of_eq rfl, (·.symm), (·.trans ·)⟩
+  equiv_dist   := equiv_dist
+  dist_lt      := dist_lt
+
+def StoreO.toMap {T K V : Type _} [StoreLike T K V] [OFE V] : (StoreO T) -n> (K → V) where
+  f x := StoreLike.get <| StoreO.car x
+  ne.1 {_ _ _} H k := H k
+
+def StoreO.ofMap {T K V : Type _} [Store T K V] [OFE V] : (K → V) -n> (StoreO T) where
+  f x := StoreO.mk <| StoreLike.of_fun x
+  ne.1 {_ _ _} H k := by rw [Store.of_fun_get, Store.of_fun_get]; exact H k
+
+instance StoreO_COFE {T K V : Type _} [Store T K V] [COFE V] : COFE (StoreO T) where
+  compl c := ⟨StoreLike.of_fun <| COFE.compl <| c.map StoreO.toMap⟩
+  conv_compl {n c} k := by
+    rw [Store.of_fun_get]
+    exact COFE.conv_compl (c := Chain.map StoreO.toMap c) k
+
+end algebra

--- a/src/Iris/Algebra/LocalUpdates.lean
+++ b/src/Iris/Algebra/LocalUpdates.lean
@@ -1,0 +1,289 @@
+import Iris.Algebra.CMRA
+
+namespace Iris
+
+def LocalUpdate {α: Type}[CMRA α] (x y: α × α) :=
+  ∀n mz, ✓{n} x.1 → x.1 ≡{n}≡ x.2 •? mz → ✓{n} y.1 ∧ y.1 ≡{n}≡ y.2 •? mz
+
+infixr:50 " ~l~> " => LocalUpdate
+
+namespace LocalUpdate
+
+section CMRA
+  variable [cmr: CMRA α]
+
+  -- Global Instance local_update_proper :
+  -- Proper ((≡) ==> (≡) ==> iff) (@local_update SI A).
+  -- Proof. unfold local_update. by repeat intro; setoid_subst. Qed.
+
+  theorem local_update_id (x: α × α): x ~l~> x := fun _ _ vx e => ⟨vx, e⟩
+
+  theorem local_update_left_eqv {x y: α × α} (z: α × α) (h: x ≡ y) : x ~l~> z → y ~l~> z :=
+    fun u => fun n mw v e =>
+      have e1: x.fst ≡{n}≡ y.fst := (OFE.equiv_fst h).dist
+      have := calc
+        x.fst       ≡{n}≡ y.fst       := e1
+        y.fst       ≡{n}≡ y.snd •? mw := e
+        y.snd •? mw ≡{n}≡ x.snd •? mw := CMRA.opM_left_dist mw (OFE.equiv_snd h).dist.symm
+      u n mw ((OFE.Dist.validN e1.symm).mp v) this
+
+  theorem local_update_right_eqv (x: α × α) {y z: α × α} (h: y ≡ z): x ~l~> y → x ~l~> z :=
+    fun u => fun n mw v e =>
+      let ⟨vy, e⟩ := u n mw v e
+      have e1: y.fst ≡{n}≡ z.fst := OFE.dist_fst (OFE.Equiv.dist h)
+      have := calc
+        z.fst ≡{n}≡ y.fst := e1.symm
+        _ ≡{n}≡ y.snd •? mw := e
+        _ ≡{n}≡ z.snd •? mw := CMRA.opM_left_dist mw $ OFE.dist_snd (OFE.Equiv.dist h)
+      ⟨(OFE.Dist.validN e1).mp vy, this⟩
+
+  -- Global Instance local_update_preorder : PreOrder (@local_update SI A).
+  -- Proof. split; unfold local_update; red; naive_solver. Qed.
+
+  theorem exclusive_local_update {y: α}[CMRA.Exclusive y](x x': α)(vx': ✓ x'): (x,y) ~l~> (x', x') :=
+    fun n mz vx e =>
+      have : mz = none         := CMRA.none_of_excl_valid_op ((OFE.Dist.validN e).mp vx)
+      have : x' ≡{n}≡ x' •? mz := calc
+        x' ≡{n}≡ x'   := OFE.Dist.of_eq rfl
+        _  = x' •? mz := by rw[this]; rfl
+      ⟨vx'.validN, this⟩
+
+  theorem op_local_update (x y z : α) (h : ∀ n, ✓{n} x → ✓{n} (z • x)) : (x, y) ~l~> (z • x, z • y) :=
+    fun n mz vx (e : x ≡{n}≡ y •? mz) =>
+      have g1 : ✓{n} (z • x) := h n vx
+      have g2 := calc
+        (z • x) ≡{n}≡ z • (y •? mz) := CMRA.op_right_dist z e
+        _       ≡{n}≡ (z • y) •? mz := OFE.Dist.symm (CMRA.op_opM_assoc_dist z y mz)
+      ⟨g1, g2⟩
+
+  theorem op_local_update_discrete [CMRA.Discrete α] (x y z : α)
+      (h : ✓ x → ✓ (z • x)) : (x, y) ~l~> (z • x, z • y) :=
+    fun n mz vx e =>
+      have this n (vx: ✓{n} x): ✓{n} (z • x) :=
+        CMRA.Valid.validN (h ((CMRA.valid_iff_validN' n).mpr vx))
+      op_local_update x y z this n mz vx e
+
+  theorem op_local_update_frame (x y x' y' yf : α)
+      (h : (x, y) ~l~> (x', y')) : (x, y • yf) ~l~> (x', y' • yf) :=
+    fun n mz vx e =>
+      have := h n (some yf • mz) vx
+      have := calc
+        x ≡{n}≡ (y • yf) •? mz := e
+        _ ≡{n}≡ y •? (some yf • mz) := CMRA.op_some_opM_assoc_dist y yf mz
+      have u := h n (some yf • mz) vx this
+      have := calc
+        x' ≡{n}≡ y' •? (some yf • mz) := u.2
+        _  ≡{n}≡ (y' • yf) •? mz      := (CMRA.op_some_opM_assoc_dist y' yf mz).symm
+      ⟨u.1, this⟩
+
+  theorem cancel_local_update (x y z : α) [CMRA.Cancelable x] : (x • y, x • z) ~l~> (y, z) :=
+    fun _ _ vx e => ⟨CMRA.validN_op_right vx, CMRA.op_opM_cancel_dist vx e⟩
+
+  theorem replace_local_update (x y : α) [CMRA.IdFree x] (h : ✓ y) : (x, x) ~l~> (y, y) :=
+    fun _ mz vx e =>
+      match mz with
+      | none   => ⟨CMRA.Valid.validN h, OFE.Dist.symm (OFE.Dist.of_eq rfl)⟩
+      | some _ => absurd e.symm (CMRA.id_freeN_r vx)
+
+  theorem core_id_local_update (x y z : α) [CMRA.CoreId y] (inc : y ≼ x) : (x, z) ~l~> (x, z • y) :=
+    fun n mz vx e =>
+      have g: x ≡{n}≡ (z • y) •? mz :=
+        suffices h: y • x ≡{n}≡ (z • y) •? mz
+          from (CMRA.op_core_right_of_inc inc).symm.dist.trans h
+        match mz with
+        | none =>
+          calc
+            y • x ≡{n}≡ y • z := CMRA.op_right_dist y e
+            _ ≡{n}≡ z • y := CMRA.op_commN
+        | some w =>
+          calc
+            y • x ≡{n}≡ y • (z • w) := CMRA.op_right_dist y e
+            _ ≡{n}≡ (y • z) • w := CMRA.op_assocN
+            _ ≡{n}≡ (z • y) • w := CMRA.op_left_dist w (CMRA.op_commN)
+      ⟨vx, g⟩
+
+  theorem local_update_discrete [CMRA.Discrete α] (x y x' y' : α) :
+      (x, y) ~l~> (x', y') ↔ ∀ mz, ✓ x → x ≡ y •? mz → (✓ x' ∧ x' ≡ y' •? mz) :=
+    Iff.intro
+      (fun h mz vx e =>
+        have ⟨vx', e⟩ := h 0 mz vx.validN e.dist
+        ⟨CMRA.Discrete.discrete_valid vx', OFE.discrete_0 e⟩)
+      (fun h n mz vx e =>
+        have ⟨vx', e'⟩ := h mz ((CMRA.valid_iff_validN' n).mpr vx) (OFE.discrete_n e)
+        ⟨CMRA.Valid.validN vx', e'.dist⟩)
+
+  theorem local_update_valid0 (x y x' y' : α)
+      (h: ✓{0} x → ✓{0} y → some y ≼{0} some x → (x, y) ~l~> (x', y')) :
+      (x, y) ~l~> (x', y') :=
+    fun n mz vx e =>
+      have v0y: ✓{0} y := CMRA.valid0_of_validN $ CMRA.validN_opM ((OFE.Dist.validN e).mp vx)
+      have: some y ≼{0} some x := CMRA.inc0_of_incN (CMRA.some_inc_some_of_dist_opM e)
+      have: (x, y) ~l~> (x', y') := h (CMRA.valid0_of_validN vx) v0y this
+      this n mz vx e
+
+  theorem local_update_valid [CMRA.Discrete α] (x y x' y' : α)
+      (h: ✓ x → ✓ y → some y ≼ some x → (x, y) ~l~> (x', y')) : (x, y) ~l~> (x', y') :=
+    have h0 vx0 vy0 mz: (x, y) ~l~> (x', y') :=
+      h (CMRA.discrete_valid vx0) (CMRA.discrete_valid vy0) ((CMRA.inc_iff_incN 0).mpr mz)
+    local_update_valid0 x y x' y' h0
+
+  theorem local_update_total_valid0 [CMRA.IsTotal α] (x y x' y' : α)
+      (h: ✓{0} x → ✓{0} y → y ≼{0} x → (x, y) ~l~> (x', y')) : (x, y) ~l~> (x', y') :=
+    have h0 (vx0: ✓{0} x) (vy0: ✓{0} y) (mz : some y ≼{0} some x) : (x, y) ~l~> (x', y') :=
+      h vx0 vy0 (CMRA.incN_of_some_incN_some mz)
+    local_update_valid0 x y x' y' h0
+
+  theorem local_update_total_valid [CMRA.IsTotal α] [CMRA.Discrete α] (x y x' y' : α)
+      (h: ✓ x → ✓ y → y ≼ x → (x, y) ~l~> (x', y')) : (x, y) ~l~> (x', y') :=
+    have hs vx vy inc : (x, y) ~l~> (x', y') := h vx vy (CMRA.inc_of_some_inc_some inc)
+    local_update_valid x y x' y' hs
+end CMRA
+
+section updates_unital
+  variable [UCMRA α]
+
+  theorem local_update_unital (x y x' y' : α) :
+      (x, y) ~l~> (x', y') ↔ ∀ n z, ✓{n} x → x ≡{n}≡ y • z → (✓{n} x' ∧ x' ≡{n}≡ y' • z) where
+    mp  h n z       := h n (some z)
+    mpr h n mz vx e :=
+      match mz with
+      | none =>
+        have := h n UCMRA.unit vx (e.trans (CMRA.unit_right_id_dist y).symm)
+        ⟨this.left, this.right.trans (CMRA.unit_right_id_dist y')⟩
+      | some z => h n z vx e
+
+  theorem local_update_unital_discrete [CMRA.Discrete α] (x y x' y' : α) :
+      (x, y) ~l~> (x', y') ↔ ∀ z, ✓ x → x ≡ y • z → (✓ x' ∧ x' ≡ y' • z) where
+    mp  h z vx e :=
+      have ⟨vx', e'⟩ := h 0 (some z) (CMRA.Valid.validN vx) e.dist
+      ⟨CMRA.discrete_valid vx', OFE.discrete_0 e'⟩
+    mpr h :=
+      have h' n z vnx e : (✓{n} x' ∧ x' ≡{n}≡ y' • z) :=
+        have ⟨vx', e'⟩ := h z ((CMRA.valid_iff_validN' n).mpr vnx) (OFE.discrete_n e)
+        ⟨CMRA.Valid.validN vx', OFE.Equiv.dist e'⟩
+      (local_update_unital x y x' y').mpr h'
+
+  theorem cancel_local_update_unit (x y : α) [CMRA.Cancelable x] :
+      (x • y, x) ~l~> (y, UCMRA.unit) :=
+    have e : (x • y, x • UCMRA.unit) ≡ (x • y, x) :=
+      OFE.equiv_prod_ext OFE.Equiv.rfl (CMRA.unit_right_id)
+    local_update_left_eqv _ e (cancel_local_update x y UCMRA.unit)
+
+end updates_unital
+
+section updates_unit
+
+  theorem unit_local_update (x y x' y' : Unit) : (x, y) ~l~> (x', y') :=
+    match x, y, x', y' with
+    | .unit, .unit, .unit, .unit => local_update_id ((), ())
+
+end updates_unit
+
+section updates_discrete_fun
+
+  theorem discrete_fun_local_update {α : Type} (β : α → Type _) [∀ x, UCMRA (β x)]
+      (f g f' g' : ∀ x, β x) (h : ∀ x : α, (f x, g x) ~l~> (f' x, g' x))
+      : (f, g) ~l~> (f', g') :=
+    fun n mz vx e =>
+      have g₁ : ✓{n} f' := fun x =>
+        match mz with
+        | .none => (h x n .none (vx x) (e x)).left
+        | .some z => (h x n (.some (z x)) (vx x) (e x)).left
+      have g₂ : f' ≡{n}≡ g' •? mz := fun x =>
+        match mz with
+        | .none => (h x n .none (vx x) (e x)).right
+        | .some z => (h x n (.some (z x)) (vx x) (e x)).right
+      ⟨g₁, g₂⟩
+
+end updates_discrete_fun
+
+section updates_product
+  variable [CMRA α] [CMRA β]
+
+  theorem prod_local_update
+      {x y x' y' : α × β} (hl: (x.1, y.1) ~l~> (x'.1, y'.1)) (hr: (x.2, y.2) ~l~> (x'.2, y'.2))
+      : (x, y) ~l~> (x', y') :=
+    fun n mz vx e =>
+      match mz with
+      | .none =>
+        have ⟨v₁, e₁⟩ := hl n .none vx.left e.left
+        have ⟨v₂, e₂⟩ := hr n .none vx.right e.right
+        ⟨⟨v₁, v₂⟩, ⟨e₁, e₂⟩⟩
+      | .some z =>
+        have ⟨v₁, e₁⟩ := hl n (.some z.fst) vx.left e.left
+        have ⟨v₂, e₂⟩ := hr n (.some z.snd) vx.right e.right
+        ⟨⟨v₁, v₂⟩, ⟨e₁, e₂⟩⟩
+
+  theorem prod_local_update'
+      {x1 y1 x1' y1' : α} {x2 y2 x2' y2' : β}
+      (hl: (x1, y1) ~l~> (x1', y1')) (hr: (x2, y2) ~l~> (x2', y2'))
+      : ((x1, x2), (y1, y2)) ~l~> ((x1', x2'), (y1', y2')) :=
+    prod_local_update hl hr
+
+  theorem prod_local_update_1
+      (x1 y1 x1' y1' : α) (x2 y2 : β) (h: (x1, y1) ~l~> (x1', y1'))
+      : ((x1, x2), (y1, y2)) ~l~> ((x1', x2), (y1', y2)) :=
+    prod_local_update' h (local_update_id (x2, y2))
+
+  theorem prod_local_update_2
+      (x1 y1 : α) (x2 y2 x2' y2' : β) (h: (x2, y2) ~l~> (x2', y2'))
+      : ((x1, x2), (y1, y2)) ~l~> ((x1, x2'), (y1, y2')) :=
+    prod_local_update' (local_update_id (x1, y1)) h
+
+end updates_product
+
+section updates_option
+  theorem option_local_update {α : Type} [CMRA α]
+      {x y x' y' : α} (h: (x, y) ~l~> (x', y')) : (some x, some y) ~l~> (some x', some y') :=
+    fun n mz vx e =>
+      match mz with
+      | .none           => h n .none vx e
+      | .some .none     => have ⟨vx, e⟩ := h n .none vx e;  ⟨vx, e⟩
+      | .some (.some z) => have ⟨vx, e⟩ := h n (.some z) vx e;  ⟨vx, e⟩
+
+  theorem option_local_update_none {α : Type} [UCMRA α]
+      {x x' y' : α} (h: (x, UCMRA.unit) ~l~> (x', y')): (some x, none) ~l~> (some x', some y') :=
+    fun n mz vx e =>
+      match mz with
+      | .none           => False.elim e
+      | .some .none     => False.elim e
+      | .some (.some z) =>
+        have e: x ≡{n}≡ z := e
+        have ⟨vx, e⟩ := h n (.some z) vx (e.trans (CMRA.unit_left_id_dist z).symm)
+        ⟨vx, e⟩
+
+  theorem alloc_option_local_update {α : Type} [CMRA α]
+      {x : α} (y : Option α) (vx: ✓ x): (none, y) ~l~> (some x, some x) :=
+    fun n mz _ e =>
+      match mz with
+      | .none           => ⟨CMRA.Valid.validN vx, OFE.Dist.of_eq rfl⟩
+      | .some .none     => ⟨CMRA.Valid.validN vx, OFE.Dist.of_eq rfl⟩
+      | .some (.some z) =>
+        have ⟨_, hw⟩ := CMRA.exists_op_some_dist_some (n := n) y z
+        False.elim (e.trans hw)
+
+  theorem delete_option_local_update {α : Type} [CMRA α]
+      (x : Option α) (y : α) [CMRA.Exclusive y] :
+      (x, some y) ~l~> (none, none) :=
+    fun n mz vx e =>
+      match mz with
+      | .none           => ⟨True.intro, OFE.Dist.of_eq rfl⟩
+      | .some .none     => ⟨True.intro, OFE.Dist.of_eq rfl⟩
+      | .some (.some z) =>
+        have : ✓{n} some y • some z := (OFE.Dist.validN e).mp vx
+        absurd this not_valid_some_exclN_op_left
+
+  theorem delete_option_local_update_cancelable {α : Type} [CMRA α]
+      (mx : Option α) [CMRA.Cancelable mx] : (mx, mx) ~l~> (none, none) :=
+    fun n mz vx e =>
+      match mz with
+      | .none           => ⟨True.intro, OFE.Dist.of_eq rfl⟩
+      | .some .none     => ⟨True.intro, OFE.Dist.of_eq rfl⟩
+      | .some (.some z) =>
+        have : CMRA.unit ≡{n}≡ some z :=
+          CMRA.cancelableN (validN_op_unit vx) ((CMRA.unit_right_id_dist mx).trans e)
+        ⟨True.intro, this⟩
+
+end updates_option
+
+end LocalUpdate

--- a/src/Iris/Algebra/LocalUpdates.lean
+++ b/src/Iris/Algebra/LocalUpdates.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2025 Сухарик. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Сухарик (@suhr)
+-/
 import Iris.Algebra.CMRA
 
 namespace Iris

--- a/src/Iris/Algebra/OFE.lean
+++ b/src/Iris/Algebra/OFE.lean
@@ -274,6 +274,8 @@ instance [OFE α] [Discrete α] : Discrete (Option α) where
     | none, none => H
     | some _, some _ => some_eqv_some.mpr (discrete_0 H)
 
+instance OFE.Option.some.ne [OFE α] : OFE.NonExpansive (some : α → Option α) := ⟨fun _ _ _ => id⟩
+
 abbrev OFEFun {α : Type _} (β : α → Type _) := ∀ a, OFE (β a)
 
 instance [OFEFun (β : α → _)] : OFE ((x : α) → β x) where

--- a/src/Iris/Algebra/OFE.lean
+++ b/src/Iris/Algebra/OFE.lean
@@ -229,6 +229,14 @@ instance [OFE α] : OFE (Option α) where
   equiv_dist {x y} := by cases x <;> cases y <;> simp [Option.Forall₂]; apply equiv_dist
   dist_lt {_ x y _} := by cases x <;> cases y <;> simp [Option.Forall₂]; apply dist_lt
 
+instance [OFE α][OFE.Discrete α]: OFE.Discrete (Option α) where
+  discrete_0 {mx my} e :=
+    match mx, my with
+    | none,   none   => e
+    | none,   some _ => e
+    | some _, none   => e
+    | some x, some y => show x ≡ y from discrete_0 e
+
 @[simp] theorem some_eqv_some [OFE α] {x y : α} : (some x ≡ some y) ↔ x ≡ y := .rfl
 @[simp] theorem not_some_eqv_none [OFE α] {x : α} : ¬some x ≡ none := id
 @[simp] theorem not_none_eqv_some [OFE α] {x : α} : ¬none ≡ some x := id
@@ -303,6 +311,16 @@ instance [OFE α] [OFE β] : OFE (α × β) where
   }
   equiv_dist {_ _} := by simp [equiv_dist, forall_and]
   dist_lt h1 h2 := ⟨dist_lt h1.1 h2, dist_lt h1.2 h2⟩
+
+def equiv_fst [OFE α] [OFE β] {x y: α × β} (h: x ≡ y): x.fst ≡ y.fst := h.left
+def equiv_snd [OFE α] [OFE β] {x y: α × β} (h: x ≡ y): x.snd ≡ y.snd := h.right
+def equiv_prod_ext [OFE α] [OFE β] {x₁ x₂: α} {y₁ y₂: β}
+    (ex: x₁ ≡ x₂) (ey: y₁ ≡ y₂): (x₁, y₁) ≡ (x₂, y₂) := ⟨ex, ey⟩
+
+def dist_fst {n} [OFE α] [OFE β] {x y: α × β} (h: x ≡{n}≡ y): x.fst ≡{n}≡ y.fst := h.left
+def dist_snd {n} [OFE α] [OFE β] {x y: α × β} (h: x ≡{n}≡ y): x.snd ≡{n}≡ y.snd := h.right
+def dist_prod_ext {n} [OFE α] [OFE β] {x₁ x₂: α} {y₁ y₂: β}
+    (ex: x₁ ≡{n}≡ x₂) (ey: y₁ ≡{n}≡ y₂): (x₁, y₁) ≡{n}≡ (x₂, y₂) := ⟨ex, ey⟩
 
 /-- An isomorphism between two OFEs is a pair of morphisms whose composition is equivalent to the identity morphism. -/
 @[ext] structure Iso (α β : Type _) [OFE α] [OFE β] where

--- a/src/Iris/Algebra/OFE.lean
+++ b/src/Iris/Algebra/OFE.lean
@@ -276,6 +276,14 @@ instance [OFE α] [Discrete α] : Discrete (Option α) where
 
 instance OFE.Option.some.ne [OFE α] : OFE.NonExpansive (some : α → Option α) := ⟨fun _ _ _ => id⟩
 
+theorem Option.some_is_discrete [OFE α] {a : α} (Ha : DiscreteE a) : DiscreteE (some a) := by
+  intro y H; cases y
+  · exact H
+  · exact Ha H
+
+theorem Option.none_is_discrete [OFE α] : DiscreteE (none : Option α) := by
+  intro y; cases y <;> simp
+
 abbrev OFEFun {α : Type _} (β : α → Type _) := ∀ a, OFE (β a)
 
 instance [OFEFun (β : α → _)] : OFE ((x : α) → β x) where
@@ -331,9 +339,12 @@ def dist_snd {n} [OFE α] [OFE β] {x y: α × β} (h: x ≡{n}≡ y): x.snd ≡
 def dist_prod_ext {n} [OFE α] [OFE β] {x₁ x₂: α} {y₁ y₂: β}
     (ex: x₁ ≡{n}≡ x₂) (ey: y₁ ≡{n}≡ y₂): (x₁, y₁) ≡{n}≡ (x₂, y₂) := ⟨ex, ey⟩
 
+theorem prod.is_discrete [OFE α] [OFE β] {a : α} {b : β} (Ha : DiscreteE a) (Hb : DiscreteE b) :
+    DiscreteE (a, b) := by
+  intro y H; refine ⟨Ha H.1, Hb H.2⟩
+
 instance [OFE α] [OFE β] [OFE.Discrete α] [OFE.Discrete β] : OFE.Discrete (α × β) where
   discrete_0 H := ⟨discrete_0 H.1, discrete_0 H.2⟩
-
 
 /-- An isomorphism between two OFEs is a pair of morphisms whose composition is equivalent to the identity morphism. -/
 @[ext] structure Iso (α β : Type _) [OFE α] [OFE β] where

--- a/src/Iris/Algebra/OFE.lean
+++ b/src/Iris/Algebra/OFE.lean
@@ -523,6 +523,16 @@ theorem Eq_Equivalence {T : Type _} : Equivalence (@Eq T) :=
 
 instance : COFE (LeibnizO T) := COFE.ofDiscrete _ Eq_Equivalence
 
+instance {T : Type _} : OFE.Discrete (LeibnizO T) := ⟨congrArg id⟩
+instance {T : Type _} : OFE.Leibniz (LeibnizO T) := ⟨congrArg id⟩
+
+theorem LeibnizO.eqv_inj {T : Type _} {x y : T} (H : LeibnizO.mk x ≡ LeibnizO.mk y) : x = y := by
+  suffices (LeibnizO.mk x).car = (LeibnizO.mk y).car by exact this
+  exact H ▸ rfl
+
+theorem LeibnizO.dist_inj {T : Type _} {x y : T} {n} (H : LeibnizO.mk x ≡{n}≡ LeibnizO.mk y) : x = y :=
+  LeibnizO.eqv_inj <| OFE.Discrete.discrete_n H
+
 section DiscreteFunOF
 open COFE
 

--- a/src/Iris/Algebra/OFE.lean
+++ b/src/Iris/Algebra/OFE.lean
@@ -268,6 +268,12 @@ instance [OFE α] [Leibniz α] : Leibniz (Option α) where
     | none, none, _ => rfl
     | some _, some _, h => congrArg some (Leibniz.eq_of_eqv h)
 
+instance [OFE α] [Discrete α] : Discrete (Option α) where
+  discrete_0 {x y} H :=
+    match x, y with
+    | none, none => H
+    | some _, some _ => some_eqv_some.mpr (discrete_0 H)
+
 abbrev OFEFun {α : Type _} (β : α → Type _) := ∀ a, OFE (β a)
 
 instance [OFEFun (β : α → _)] : OFE ((x : α) → β x) where
@@ -312,6 +318,7 @@ instance [OFE α] [OFE β] : OFE (α × β) where
   equiv_dist {_ _} := by simp [equiv_dist, forall_and]
   dist_lt h1 h2 := ⟨dist_lt h1.1 h2, dist_lt h1.2 h2⟩
 
+
 def equiv_fst [OFE α] [OFE β] {x y: α × β} (h: x ≡ y): x.fst ≡ y.fst := h.left
 def equiv_snd [OFE α] [OFE β] {x y: α × β} (h: x ≡ y): x.snd ≡ y.snd := h.right
 def equiv_prod_ext [OFE α] [OFE β] {x₁ x₂: α} {y₁ y₂: β}
@@ -321,6 +328,10 @@ def dist_fst {n} [OFE α] [OFE β] {x y: α × β} (h: x ≡{n}≡ y): x.fst ≡
 def dist_snd {n} [OFE α] [OFE β] {x y: α × β} (h: x ≡{n}≡ y): x.snd ≡{n}≡ y.snd := h.right
 def dist_prod_ext {n} [OFE α] [OFE β] {x₁ x₂: α} {y₁ y₂: β}
     (ex: x₁ ≡{n}≡ x₂) (ey: y₁ ≡{n}≡ y₂): (x₁, y₁) ≡{n}≡ (x₂, y₂) := ⟨ex, ey⟩
+
+instance [OFE α] [OFE β] [OFE.Discrete α] [OFE.Discrete β] : OFE.Discrete (α × β) where
+  discrete_0 H := ⟨discrete_0 H.1, discrete_0 H.2⟩
+
 
 /-- An isomorphism between two OFEs is a pair of morphisms whose composition is equivalent to the identity morphism. -/
 @[ext] structure Iso (α β : Type _) [OFE α] [OFE β] where

--- a/src/Iris/Algebra/View.lean
+++ b/src/Iris/Algebra/View.lean
@@ -115,10 +115,33 @@ abbrev validN (n : Nat) (v : View F R) : Prop :=
   | some (dq, ag) => ✓ dq ∧ (∃ a, ag ≡{n}≡ toAgree a ∧ R n a (π_frag v))
   | none => ∃ a, R n a (π_frag v)
 
--- -- #synth CMRA (DFrac F × Agree A) -- Need Prod CMRA to continue, rebase over local_update PR.
--- abbrev pcore (v : View F R) : Option (View F R) :=
---   some (View.mk (CMRA.core (π_auth v)) sorry)
---   --  Some (View (core (view_auth_proj x)) (core (view_frag_proj x))).
+def pcore (v : View F R) : Option (View F R) :=
+  let ag : Option (DFrac F × Agree A) := CMRA.core v.1
+  let b : B := CMRA.core v.2
+  some <| View.mk ag b
+
+abbrev op (v1 v2 : View F R) : View F R :=
+  View.mk (v1.1 • v2.1) (v1.2 • v2.2)
+
+instance : CMRA (View F R) where
+  pcore := pcore
+  op := op
+  ValidN := validN
+  Valid := valid
+  op_ne := sorry
+  pcore_ne := sorry
+  validN_ne := sorry
+  valid_iff_validN := sorry
+  validN_succ := sorry
+  validN_op_left := sorry
+  assoc := sorry
+  comm := sorry
+  pcore_op_left := sorry
+  pcore_idem := sorry
+  pcore_op_mono := sorry
+  extend := sorry
+
+
 
 
 

--- a/src/Iris/Algebra/View.lean
+++ b/src/Iris/Algebra/View.lean
@@ -196,9 +196,6 @@ instance : CMRA (View F R) where
     · exact H2 ▸ CMRA.core_idem _
   pcore_op_mono := by
     apply pcore_op_mono_of_core_op_mono
-
-    -- A is (Option ((DFrac F) × Agree A) × B)
-    -- B is View F R
     let f : (Option ((DFrac F) × Agree A) × B) → View F R := fun x => ⟨x.1, x.2⟩
     let g : View F R → (Option ((DFrac F) × Agree A) × B) := fun x => (x.1, x.2)
     let opM' (x : View F R) (y : Option (View F R)) : View F R :=
@@ -220,7 +217,6 @@ instance : CMRA (View F R) where
     have g_opM_f {x y} : g (opM' y (f x)) ≡ CMRA.op (g y) x := by
       simp [opM', g, f, CMRA.op, prod.op]
 
-    -- Port: Line 1921 of CMRA
     rintro y1 cy y2 ⟨z, Hy2⟩ Hy1
     let Lcore := (@CMRA.pcore_mono' _ _ (g y1) (g y2) (g cy) ?G1 ?G2)
     case G1 => exists (g z)
@@ -237,7 +233,6 @@ instance : CMRA (View F R) where
     exists (f x)
   extend {n x y1 y2} Hv He := by
     let g : View F R → (Option ((DFrac F) × Agree A) × B) := fun x => (x.1, x.2)
-    -- let g_ne : OFE.NonExpansive g := ⟨fun _ _ _ H => ⟨H.1, H.2⟩⟩
     have H2 := @CMRA.extend _ _ n (g x) (g y1) (g y2) ?G1 He
     case G1 =>
       simp_all [validN, CMRA.ValidN, prod.ValidN, g, optionValidN]
@@ -252,6 +247,43 @@ instance : CMRA (View F R) where
     rcases H2 with ⟨z1, z2, Hze, Hz1, Hz2⟩
     exists ⟨z1.1, z1.2⟩
     exists ⟨z2.1, z2.2⟩
+
+omit [ViewRel R] in
+theorem view_auth_discrete {dq a} (Ha : OFE.DiscreteE a) (He : OFE.DiscreteE (UCMRA.unit : B)) :
+    OFE.DiscreteE (●V{dq} a : View F R) := by
+  refine is_discrete ?_ He
+  apply OFE.Option.some_is_discrete
+  apply OFE.prod.is_discrete dfrac.is_discrete
+  apply Agree.toAgree.is_discrete
+  exact Ha
+
+omit [DFractional F] [ViewRel R] in
+theorem view_frag_discrete {b : B} (Hb : OFE.DiscreteE b) : (OFE.DiscreteE (◯V b : View F R)) :=
+  is_discrete OFE.Option.none_is_discrete Hb
+
+instance [OFE.Discrete A] [CMRA.Discrete B] [ViewRelDiscrete R] : CMRA.Discrete (View F R) where
+  discrete_valid := by
+    simp [CMRA.ValidN, validN, CMRA.Valid, valid]
+    intro x
+    split
+    · rintro ⟨H1, ⟨a, H2, H3⟩⟩
+      refine ⟨H1, fun n => ⟨a, ⟨?_, ?_⟩⟩⟩
+      · exact OFE.equiv_dist.mp (OFE.Discrete.discrete_0 H2) _
+      · exact ViewRelDiscrete.discrete _ _ _ H3
+    · rintro ⟨a, H⟩ _
+      exact ⟨a, ViewRelDiscrete.discrete _ _ _ H⟩
+
+instance : UCMRA (View F R) where
+  unit := ⟨UCMRA.unit, UCMRA.unit⟩
+  unit_valid := by
+    simp [CMRA.Valid, valid]
+    exact ViewRel.rel_unit
+  unit_left_id := by exact ⟨UCMRA.unit_left_id, UCMRA.unit_left_id⟩
+  pcore_unit := by
+    simp [CMRA.pcore, pcore]
+    constructor <;> simp only []
+    · simp [CMRA.core, CMRA.pcore, optionCore, Option.bind, UCMRA.unit]
+    · exact CMRA.core_eqv_self UCMRA.unit
 
 end cmra
 end View

--- a/src/Iris/Algebra/View.lean
+++ b/src/Iris/Algebra/View.lean
@@ -1,0 +1,89 @@
+/-
+Copyright (c) 2025 Markus de Medeiros. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Markus de Medeiros
+-/
+
+import Iris.Algebra.CMRA
+import Iris.Algebra.OFE
+import Iris.Algebra.Frac
+import Iris.Algebra.DFrac
+import Iris.Algebra.Agree
+
+open Iris
+
+abbrev view_rel (A B : Type _) := Nat → A → B → Prop
+
+class ViewRel [OFE A] [UCMRA B] (R : view_rel A B) where
+  mono {n1 n2 : Nat} {a1 a2 : A} {b1 b2 : B} :
+    R n1 a1 b1 → a1 ≡{n2}≡ a2 → b2 ≼{n2} b1 → n2 ≤ n1 → R n2 a2 b2
+  rel_validN n a b : R n a b → ✓{n} b
+  rel_unit n : ∃ a, R n a ε
+
+class ViewRelDiscrete [OFE A] [UCMRA B] (R : view_rel A B) extends ViewRel R where
+  discrete n a b : R 0 a b → R n a b
+
+namespace viewrel
+
+variable [OFE A] [UCMRA B] {R : view_rel A B} [ViewRel R]
+
+theorem ne {a1 a2 : A} {b1 b2 : B} {n : Nat} (Ha : a1 ≡{n}≡ a2) (Hb : b1 ≡{n}≡ b2) : R n a1 b1 ↔ R n a2 b2 :=
+  ⟨(ViewRel.mono · Ha Hb.symm.to_incN n.le_refl), (ViewRel.mono · Ha.symm Hb.to_incN n.le_refl)⟩
+
+theorem eqv_ne {a1 a2 : A} {b1 b2 : B} (Ha : a1 ≡ a2) (Hb : b1 ≡ b2) : R n a1 b1 ↔ R n a2 b2 :=
+  ne Ha.dist Hb.dist
+
+end viewrel
+
+structure View (F : Type _) {A B : Type _} (R : view_rel A B) where
+  π_auth : Option ((DFrac F) × Agree A)
+  π_frag : B
+
+def View.auth [UCMRA B] {R : view_rel A B} (dq : DFrac F) (a : A) : View F R :=
+  ⟨some (dq, toAgree a), UCMRA.unit⟩
+
+def View.frag {R : view_rel A B} (b : B) : View F R := ⟨none, b⟩
+
+notation "●V{" dq "} " a => View.auth dq a
+notation "◯V " b => View.frag b
+
+namespace View
+section ofe
+
+variable [OFE A] [OFE B] {R : view_rel A B}
+
+abbrev equiv (x y : View F R) : Prop := x.π_auth ≡ y.π_auth ∧ x.π_frag ≡ y.π_frag
+abbrev dist (n : Nat) (x y : View F R) : Prop := x.π_auth ≡{n}≡ y.π_auth ∧ x.π_frag ≡{n}≡ y.π_frag
+
+instance : OFE (View F R) where
+  Equiv := equiv
+  Dist := dist
+  dist_eqv := {
+    refl _ := ⟨OFE.Dist.of_eq rfl, OFE.Dist.of_eq rfl⟩
+    symm H := ⟨H.1.symm, H.2.symm⟩
+    trans H1 H2 := ⟨H1.1.trans H2.1, H1.2.trans H2.2⟩
+  }
+  equiv_dist :=
+    ⟨fun H _ => ⟨H.1.dist, H.2.dist⟩,
+     fun H => ⟨OFE.equiv_dist.mpr (H · |>.1), OFE.equiv_dist.mpr (H · |>.2)⟩⟩
+  dist_lt H Hn := ⟨OFE.dist_lt H.1 Hn, OFE.dist_lt H.2 Hn⟩
+
+instance : OFE.NonExpansive₂ (View.mk : _ → _ → View F R) := ⟨fun _ _ _ Ha _ _ Hb => ⟨Ha, Hb⟩⟩
+instance : OFE.NonExpansive (View.π_auth : View F R → _) := ⟨fun _ _ _ H => H.1⟩
+instance : OFE.NonExpansive (View.π_frag : View F R → _) := ⟨fun _ _ _ H => H.2⟩
+
+theorem is_discrete {ag : Option ((DFrac F) × Agree A)} (Ha : OFE.DiscreteE ag) (Hb : OFE.DiscreteE b) :
+  OFE.DiscreteE (α := View F R) (View.mk ag b) := fun H => ⟨Ha H.1, Hb H.2⟩
+
+instance [OFE.Discrete A] [OFE.Discrete B] : OFE.Discrete (View F R) where
+  discrete_0 H := ⟨OFE.Discrete.discrete_0 H.1, OFE.Discrete.discrete_0 H.2⟩
+
+end ofe
+
+section cmra
+
+variable [OFE A] [UCMRA B] {R : view_rel A B} [ViewRel R]
+
+end cmra
+
+end View

--- a/src/Iris/Algebra/View.lean
+++ b/src/Iris/Algebra/View.lean
@@ -45,6 +45,7 @@ def View.auth [UCMRA B] {R : view_rel A B} (dq : DFrac F) (a : A) : View F R :=
 def View.frag {R : view_rel A B} (b : B) : View F R := ⟨none, b⟩
 
 notation "●V{" dq "} " a => View.auth dq a
+notation "●V " a => View.auth (LeibnizO.mk <| DFracK.Own One.one) a
 notation "◯V " b => View.frag b
 
 namespace View
@@ -338,89 +339,131 @@ instance view_both_core_id [CMRA.CoreId b] : CMRA.CoreId ((●V{⟨DFracK.Discar
     trivial
 
 
-
+theorem view_auth_dfrac_op_invN (H :✓{n} ((●V{dq1} a1 : View F R) • ●V{dq2} a2)) : a1 ≡{n}≡ a2 := by
+  sorry
 /-
-  (** Validity *)
-  Lemma view_auth_dfrac_op_invN n dq1 a1 dq2 a2 :
-    ✓{n} (●V{dq1} a1 ⋅ ●V{dq2} a2) → a1 ≡{n}≡ a2.
   Proof.
     rewrite /op /view_op_instance /= left_id -Some_op -pair_op view_validN_eq /=.
     intros (?&?& Eq &?). apply (inj to_agree), agree_op_invN. by rewrite Eq.
   Qed.
-  Lemma view_auth_dfrac_op_inv dq1 a1 dq2 a2 : ✓ (●V{dq1} a1 ⋅ ●V{dq2} a2) → a1 ≡ a2.
+-/
+
+theorem view_auth_dfrac_op_inv : ✓ ((●V{dq1} a1 : View F R) • ●V{dq2} a2) → a1 ≡ a2 := sorry
+/-
   Proof.
     intros ?. apply equiv_dist. intros n.
     by eapply view_auth_dfrac_op_invN, cmra_valid_validN.
   Qed.
-  Lemma view_auth_dfrac_op_inv_L `{!LeibnizEquiv A} dq1 a1 dq2 a2 :
-    ✓ (●V{dq1} a1 ⋅ ●V{dq2} a2) → a1 = a2.
-  Proof. by intros ?%view_auth_dfrac_op_inv%leibniz_equiv. Qed.
+-/
 
-  Lemma view_auth_dfrac_validN n dq a : ✓{n} (●V{dq} a) ↔ ✓{n}dq ∧ rel n a ε.
+theorem view_auth_dfrac_validN : ✓{n} (●V{dq} a : View F R) ↔ ✓{n}dq ∧ R n a UCMRA.unit := sorry
+
+/-
   Proof.
     rewrite view_validN_eq /=. apply and_iff_compat_l. split; [|by eauto].
     by intros [? [->%(inj to_agree) ?]].
   Qed.
-  Lemma view_auth_validN n a : ✓{n} (●V a) ↔ rel n a ε.
-  Proof. rewrite view_auth_dfrac_validN. split; [naive_solver|done]. Qed.
+-/
 
-  Lemma view_auth_dfrac_op_validN n dq1 dq2 a1 a2 :
-    ✓{n} (●V{dq1} a1 ⋅ ●V{dq2} a2) ↔ ✓(dq1 ⋅ dq2) ∧ a1 ≡{n}≡ a2 ∧ rel n a1 ε.
+theorem view_auth_validN n a : ✓{n} (●V a : View F R) ↔ R n a UCMRA.unit := sorry
+/-
+  Lemma
+  Proof. rewrite view_auth_dfrac_validN. split; [naive_solver|done]. Qed.
+-/
+
+theorem view_auth_dfrac_op_validN :
+  ✓{n} ((●V{dq1} a1 : View F R) • ●V{dq2} a2) ↔ ✓(dq1 • dq2) ∧ a1 ≡{n}≡ a2 ∧ R n a1 UCMRA.unit := sorry
+/-
   Proof.
     split.
     - intros Hval. assert (a1 ≡{n}≡ a2) as Ha by eauto using view_auth_dfrac_op_invN.
       revert Hval. rewrite Ha -view_auth_dfrac_op view_auth_dfrac_validN. naive_solver.
     - intros (?&->&?). by rewrite -view_auth_dfrac_op view_auth_dfrac_validN.
   Qed.
-  Lemma view_auth_op_validN n a1 a2 : ✓{n} (●V a1 ⋅ ●V a2) ↔ False.
+-/
+
+theorem view_auth_op_validN :
+  ✓{n} ((●V a1 : View F R) • ●V a2) ↔ False := sorry
+/-
   Proof. rewrite view_auth_dfrac_op_validN. naive_solver. Qed.
+-/
 
-  Lemma view_frag_validN n b : ✓{n} (◯V b) ↔ ∃ a, rel n a b.
+theorem view_frag_validN : ✓{n} (◯V b : View F R) ↔ ∃ a, R n a b := sorry
+/-
   Proof. done. Qed.
+-/
 
-  Lemma view_both_dfrac_validN n dq a b :
-    ✓{n} (●V{dq} a ⋅ ◯V b) ↔ ✓dq ∧ rel n a b.
+theorem view_both_dfrac_validN : ✓{n} ((●V{dq} a : View F R) • ◯V b) ↔ ✓dq ∧ R n a b := sorry
+/-
   Proof.
     rewrite view_validN_eq /=. apply and_iff_compat_l.
     setoid_rewrite (left_id _ _ b). split; [|by eauto].
     by intros [?[->%(inj to_agree)]].
   Qed.
-  Lemma view_both_validN n a b : ✓{n} (●V a ⋅ ◯V b) ↔ rel n a b.
-  Proof. rewrite view_both_dfrac_validN. split; [naive_solver|done]. Qed.
+-/
 
-  Lemma view_auth_dfrac_valid dq a : ✓ (●V{dq} a) ↔ ✓dq ∧ ∀ n, rel n a ε.
+theorem view_both_validN : ✓{n} ((●V a : View F R) • ◯V b) ↔ R n a b := sorry
+/-
+  Proof. rewrite view_both_dfrac_validN. split; [naive_solver|done]. Qed.
+-/
+
+theorem view_auth_dfrac_valid : ✓ (●V{dq} a : View F R) ↔ ✓dq ∧ ∀ n, R n a ε := sorry
+
+/-
   Proof.
     rewrite view_valid_eq /=. apply and_iff_compat_l. split; [|by eauto].
     intros H n. by destruct (H n) as [? [->%(inj to_agree) ?]].
   Qed.
-  Lemma view_auth_valid a : ✓ (●V a) ↔ ∀ n, rel n a ε.
-  Proof. rewrite view_auth_dfrac_valid. split; [naive_solver|done]. Qed.
+-/
 
-  Lemma view_auth_dfrac_op_valid dq1 dq2 a1 a2 :
-    ✓ (●V{dq1} a1 ⋅ ●V{dq2} a2) ↔ ✓(dq1 ⋅ dq2) ∧ a1 ≡ a2 ∧ ∀ n, rel n a1 ε.
+theorem view_auth_valid : ✓ (●V a : View F R) ↔ ∀ n, R n a ε := sorry
+/-
+  Proof. rewrite view_auth_dfrac_valid. split; [naive_solver|done]. Qed.
+-/
+
+
+theorem view_auth_dfrac_op_valid :
+    ✓ ((●V{dq1} a1 : View F R) • ●V{dq2} a2) ↔ ✓(dq1 • dq2) ∧ a1 ≡ a2 ∧ ∀ n, R n a1 ε := sorry
+/-
   Proof.
     rewrite 1!cmra_valid_validN equiv_dist. setoid_rewrite view_auth_dfrac_op_validN.
     split; last naive_solver. intros Hv.
     split; last naive_solver. apply (Hv 0ᵢ).
   Qed.
-  Lemma view_auth_op_valid a1 a2 : ✓ (●V a1 ⋅ ●V a2) ↔ False.
+-/
+
+
+theorem view_auth_op_valid : ✓ ((●V a1 : View F R) • ●V a2) ↔ False := sorry
+
+/-
   Proof. rewrite view_auth_dfrac_op_valid. naive_solver. Qed.
+-/
 
-  Lemma view_frag_valid b : ✓ (◯V b) ↔ ∀ n, ∃ a, rel n a b.
+
+theorem view_frag_valid : ✓ (◯V b : View F R) ↔ ∀ n, ∃ a, R n a b := sorry
+/-
   Proof. done. Qed.
+-/
 
-  Lemma view_both_dfrac_valid dq a b : ✓ (●V{dq} a ⋅ ◯V b) ↔ ✓dq ∧ ∀ n, rel n a b.
+theorem view_both_dfrac_valid : ✓ ((●V{dq} a : View F R) • ◯V b) ↔ ✓dq ∧ ∀ n, R n a b := sorry
+/-
   Proof.
     rewrite view_valid_eq /=. apply and_iff_compat_l.
     setoid_rewrite (left_id _ _ b). split; [|by eauto].
     intros H n. by destruct (H n) as [?[->%(inj to_agree)]].
   Qed.
-  Lemma view_both_valid a b : ✓ (●V a ⋅ ◯V b) ↔ ∀ n, rel n a b.
-  Proof. rewrite view_both_dfrac_valid. split; [naive_solver|done]. Qed.
+-/
 
-  (** Inclusion *)
-  Lemma view_auth_dfrac_includedN n dq1 dq2 a1 a2 b :
-    ●V{dq1} a1 ≼{n} ●V{dq2} a2 ⋅ ◯V b ↔ (dq1 ≼ dq2 ∨ dq1 = dq2) ∧ a1 ≡{n}≡ a2.
+theorem view_both_valid : ✓ ((●V a : View F R) • ◯V b) ↔ ∀ n, R n a b := sorry
+/-
+  Proof. rewrite view_both_dfrac_valid. split; [naive_solver|done]. Qed.
+-/
+
+
+
+theorem view_auth_dfrac_includedN :
+    (●V{dq1} a1 : View F R) ≼{n} ((●V{dq2} a2) • ◯V b) ↔ (dq1 ≼ dq2 ∨ dq1 = dq2) ∧ a1 ≡{n}≡ a2 := sorry
+/-
   Proof.
     split.
     - intros [[[[dqf agf]|] bf]
@@ -431,8 +474,12 @@ instance view_both_core_id [CMRA.CoreId b] : CMRA.CoreId ((●V{⟨DFracK.Discar
       + rewrite view_auth_dfrac_op -assoc. apply cmra_includedN_l.
       + apply cmra_includedN_l.
   Qed.
-  Lemma view_auth_dfrac_included dq1 dq2 a1 a2 b :
-    ●V{dq1} a1 ≼ ●V{dq2} a2 ⋅ ◯V b ↔ (dq1 ≼ dq2 ∨ dq1 = dq2) ∧ a1 ≡ a2.
+-/
+
+
+theorem view_auth_dfrac_included :
+    ((●V{dq1} a1 : View F R) ≼ (●V{dq2} a2 : View F R) • ◯V b) ↔ (dq1 ≼ dq2 ∨ dq1 = dq2) ∧ a1 ≡ a2 := sorry
+/-
   Proof.
     intros. split.
     - split.
@@ -443,35 +490,47 @@ instance view_both_core_id [CMRA.CoreId b] : CMRA.CoreId ((●V{⟨DFracK.Discar
       + by rewrite view_auth_dfrac_op -assoc.
       + done.
   Qed.
-  Lemma view_auth_includedN n a1 a2 b :
-    ●V a1 ≼{n} ●V a2 ⋅ ◯V b ↔ a1 ≡{n}≡ a2.
-  Proof. rewrite view_auth_dfrac_includedN. naive_solver. Qed.
-  Lemma view_auth_included a1 a2 b :
-    ●V a1 ≼ ●V a2 ⋅ ◯V b ↔ a1 ≡ a2.
-  Proof. rewrite view_auth_dfrac_included. naive_solver. Qed.
+-/
 
-  Lemma view_frag_includedN n p a b1 b2 :
-    ◯V b1 ≼{n} ●V{p} a ⋅ ◯V b2 ↔ b1 ≼{n} b2.
+
+theorem view_auth_includedN : (●V a1 : View F R) ≼{n} ((●V a2) • ◯V b) ↔ a1 ≡{n}≡ a2 := sorry
+/-
+  Proof. rewrite view_auth_dfrac_includedN. naive_solver. Qed.
+-/
+
+theorem view_auth_included : (●V a1 : View F R) ≼ ((●V a2) • ◯V b) ↔ a1 ≡ a2 := sorry
+/-
+  Proof. rewrite view_auth_dfrac_included. naive_solver. Qed.
+-/
+
+
+theorem view_frag_includedN : (◯V b1 : View F R) ≼{n} ((●V{p} a) • ◯V b2) ↔ b1 ≼{n} b2 := sorry
+/-
   Proof.
     split.
     - intros [xf [_ Hb]]; simpl in *.
       revert Hb; rewrite left_id. by exists (view_frag_proj xf).
     - intros [bf ->]. rewrite comm view_frag_op -assoc. apply cmra_includedN_l.
   Qed.
-  Lemma view_frag_included p a b1 b2 :
-    ◯V b1 ≼ ●V{p} a ⋅ ◯V b2 ↔ b1 ≼ b2.
+-/
+
+theorem view_frag_included : (◯V b1 : View F R) ≼ ((●V{p} a) • ◯V b2) ↔ b1 ≼ b2 := sorry
+/-
   Proof.
     split.
     - intros [xf [_ Hb]]; simpl in *.
       revert Hb; rewrite left_id. by exists (view_frag_proj xf).
     - intros [bf ->]. by rewrite comm view_frag_op -assoc.
   Qed.
+-/
 
+
+theorem view_both_dfrac_includedN :
+    ((●V{dq1} a1 : View F R) • ◯V b1) ≼{n} ((●V{dq2} a2) • ◯V b2) ↔
+      (dq1 ≼ dq2 ∨ dq1 = dq2) ∧ a1 ≡{n}≡ a2 ∧ b1 ≼{n} b2 := sorry
+/-
   (** The weaker [view_both_included] lemmas below are a consequence of the
   [view_auth_included] and [view_frag_included] lemmas above. *)
-  Lemma view_both_dfrac_includedN n dq1 dq2 a1 a2 b1 b2 :
-    ●V{dq1} a1 ⋅ ◯V b1 ≼{n} ●V{dq2} a2 ⋅ ◯V b2 ↔
-      (dq1 ≼ dq2 ∨ dq1 = dq2) ∧ a1 ≡{n}≡ a2 ∧ b1 ≼{n} b2.
   Proof.
     split.
     - intros. rewrite assoc. split.
@@ -480,9 +539,11 @@ instance view_both_core_id [CMRA.CoreId b] : CMRA.CoreId ((●V{⟨DFracK.Discar
     - intros (?&->&?bf&->). rewrite (comm _ b1) view_frag_op assoc.
       by apply cmra_monoN_r, view_auth_dfrac_includedN.
   Qed.
-  Lemma view_both_dfrac_included dq1 dq2 a1 a2 b1 b2 :
-    ●V{dq1} a1 ⋅ ◯V b1 ≼ ●V{dq2} a2 ⋅ ◯V b2 ↔
-      (dq1 ≼ dq2 ∨ dq1 = dq2) ∧ a1 ≡ a2 ∧ b1 ≼ b2.
+-/
+
+theorem view_both_dfrac_included : ((●V{dq1} a1 : View F R) • ◯V b1) ≼ ((●V{dq2} a2) • ◯V b2) ↔
+      (dq1 ≼ dq2 ∨ dq1 = dq2) ∧ a1 ≡ a2 ∧ b1 ≼ b2 := sorry
+/-
   Proof.
     split.
     - intros. rewrite assoc. split.
@@ -491,13 +552,17 @@ instance view_both_core_id [CMRA.CoreId b] : CMRA.CoreId ((●V{⟨DFracK.Discar
     - intros (?&->&?bf&->). rewrite (comm _ b1) view_frag_op assoc.
       by apply cmra_mono_r, view_auth_dfrac_included.
   Qed.
-  Lemma view_both_includedN n a1 a2 b1 b2 :
-    ●V a1 ⋅ ◯V b1 ≼{n} ●V a2 ⋅ ◯V b2 ↔ a1 ≡{n}≡ a2 ∧ b1 ≼{n} b2.
-  Proof. rewrite view_both_dfrac_includedN. naive_solver. Qed.
-  Lemma view_both_included a1 a2 b1 b2 :
-    ●V a1 ⋅ ◯V b1 ≼ ●V a2 ⋅ ◯V b2 ↔ a1 ≡ a2 ∧ b1 ≼ b2.
-  Proof. rewrite view_both_dfrac_included. naive_solver. Qed.
+-/
 
+theorem view_both_includedN : ((●V a1 : View F R) • ◯V b1) ≼{n} ((●V a2) •  ◯V b2) ↔ a1 ≡{n}≡ a2 ∧ b1 ≼{n} b2 := sorry
+/-
+  Proof. rewrite view_both_dfrac_includedN. naive_solver. Qed.
+-/
+
+
+theorem view_both_included : ((●V a1 : View F R) • ◯V b1) ≼ ((●V a2) • ◯V b2) ↔ a1 ≡ a2 ∧ b1 ≼ b2 := sorry
+/-
+  Proof. rewrite view_both_dfrac_included. naive_solver. Qed.
 -/
 
 end cmra


### PR DESCRIPTION
Depends on #60 (and its transitive dependencies) 

Defines a conservative generalization of `gmap` using a generic notion of a map-like type. This removes the restriction in Rocq Iris that ghost maps need to have a countable domain. 