### PR TITLE
Update toolchain to v4.23.0

### DIFF
--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -5,7 +5,7 @@
    "type": "git",
    "subDir": null,
    "scope": "leanprover-community",
-   "rev": "e9c65db4823976353cd0bb03199a172719efbeb7",
+   "rev": "57286efe32042270335d2235798f85deab54d22d",
    "name": "Qq",
    "manifestFile": "lake-manifest.json",
    "inputRev": "stable",

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.21.0
+leanprover/lean4:v4.23.0

--- a/src/Iris/ProofMode/Tactics/Assumption.lean
+++ b/src/Iris/ProofMode/Tactics/Assumption.lean
@@ -53,7 +53,7 @@ def assumptionFast {e} (hyps : Hyps bi e) : MetaM Q($e ⊢ $Q) := do
     hyps.removeG true fun _ _ b ty => try? do
       synthInstance q(FromAssumption $b $ty $Q)
     | failure
-  let (_ : Q(FromAssumption $b $ty $Q)) := inst
+  let _ : Q(FromAssumption $b $ty $Q) := inst
   have : $out =Q iprop(□?$b $ty) := ⟨⟩
   match fastPath with
   | .absorbing _ => return q(assumption (Q := $Q) $pf)

--- a/src/Iris/Std/DelabRule.lean
+++ b/src/Iris/Std/DelabRule.lean
@@ -22,8 +22,7 @@ macro_rules
       | [(name, [])] => pure name
       | _           => throwUnsupported
 
-    let (p : TSyntaxArray `term) := p
-    if p.any (· matches `(`($$_))) then
+    if p.any fun t : TSyntax _ ↦ t matches `(`($$_)) then
       `(@[app_unexpander $(mkIdent f)]
         def unexpand : Lean.PrettyPrinter.Unexpander
           $[| $p => $s]*)

--- a/src/Iris/Tests/Notation.lean
+++ b/src/Iris/Tests/Notation.lean
@@ -18,10 +18,10 @@ variable [BIBase PROP] (P Q R : PROP) (Ψ : Nat → PROP) (Φ : Nat → Nat → 
 /-- info: P ⊢ Q : Prop -/
 #guard_msgs in #check P ⊢ Q
 
-/-- info: iprop(emp) : ?m.103 -/
+/-- info: iprop(emp) : ?m.2 -/
 #guard_msgs in #check iprop(emp)
 
-/-- info: iprop(⌜φ⌝) : ?m.144 -/
+/-- info: iprop(⌜φ⌝) : ?m.2 -/
 #guard_msgs in #check iprop(⌜φ⌝)
 
 /-- info: iprop(P ∧ Q) : PROP -/
@@ -86,9 +86,9 @@ variable [BIBase PROP] (P Q R : PROP) (Ψ : Nat → PROP) (Φ : Nat → Nat → 
 /-- info: iprop(P ∗ <pers> Q) : PROP -/
 #guard_msgs in #check iprop(P ∗ (<pers> Q))
 
-/-- info: iprop(True) : ?m.1425 -/
+/-- info: iprop(True) : ?m.2 -/
 #guard_msgs in #check iprop(True)
-/-- info: iprop(False) : ?m.1466 -/
+/-- info: iprop(False) : ?m.2 -/
 #guard_msgs in #check iprop(False)
 
 /-- info: iprop(¬P) : PROP -/


### PR DESCRIPTION
This updates the toolchain to v4.23.0, fixing https://github.com/leanprover-community/iris-lean/issues/77.

Some unused simp arguments are now being flagged (due to the toolchain update), which I left untouched for now.