### PR TITLE
feat: add linter 

### DIFF
--- a/AI_GUIDELINES.md
+++ b/AI_GUIDELINES.md
@@ -1,0 +1,13 @@
+# Generative AI Guidelines
+AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
+Please carefully review your code to ensure it meets the following standards.
+
+- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
+- `have` statements that do not aid readability or code reuse should be inlined. 
+- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
+- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.
+
+In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
+We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
+
+

--- a/Iris/lakefile.toml
+++ b/Iris/lakefile.toml
@@ -1,5 +1,6 @@
 name = "iris"
 defaultTargets = ["Iris", "IrisTest"]
+lintDriver = "batteries/runLinter"
 
 [[require]]
 name = "Qq"
@@ -13,7 +14,6 @@ rev = "v4.30.0"
 
 [[lean_lib]]
 name = "Iris"
-lintDriver := "batteries/runLinter"
 
 [[lean_lib]]
 name = "IrisTest"

--- a/Iris/lakefile.toml
+++ b/Iris/lakefile.toml
@@ -13,6 +13,7 @@ rev = "v4.30.0"
 
 [[lean_lib]]
 name = "Iris"
+lintDriver := "batteries/runLinter"
 
 [[lean_lib]]
 name = "IrisTest"

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -6,15 +6,5 @@ Fixes # (issue number)
 ## Checklist
 * [ ] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
 * [ ] I have added my name to the `authors` section of any appropriate files
-
-## Generative AI Guidelines
-AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
-Please carefully review your code to ensure it meets the following standards.
-
-- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
-- `have` statements that do not aid readability or code reuse should be inlined. 
-- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
-- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.
-
-In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
-We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
+* [ ] My code passes the linter (`lake lint`)
+* [ ] I have followed the Iris-Lean generative AI guidelines, as outlined in [AI_GUIDELINES.md](https://github.com/leanprover-community/iris-lean/blob/master/AI_GUIDELINES.md)


### PR DESCRIPTION
## Description
Adds the batteries linter to the project. This should not be merged until the linter is fully configured and the code passes lint. 

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
