### PR TITLE
(Do not merge) Shaking imports with lake shake 

### DIFF
--- a/Iris/Iris/Algebra.lean
+++ b/Iris/Iris/Algebra.lean
@@ -1,5 +1,6 @@
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.Agree
 public import Iris.Algebra.Auth
 public import Iris.Algebra.BigOp
@@ -30,4 +31,3 @@ public import Iris.Algebra.StepIndex
 public import Iris.Algebra.UFrac
 public import Iris.Algebra.Updates
 public import Iris.Algebra.UPred
-import Iris.Std.RocqPorting

--- a/Iris/Iris/Algebra.lean
+++ b/Iris/Iris/Algebra.lean
@@ -24,10 +24,10 @@ public import Iris.Algebra.LocalUpdates
 public import Iris.Algebra.MaxPrefixList
 public import Iris.Algebra.Numbers
 public import Iris.Algebra.Mra
-public import Iris.Algebra.IProp
 public import Iris.Algebra.OFE
 public import Iris.Algebra.ReservationMap
 public import Iris.Algebra.StepIndex
 public import Iris.Algebra.UFrac
 public import Iris.Algebra.Updates
 public import Iris.Algebra.UPred
+import Iris.Std.RocqPorting

--- a/Iris/Iris/Algebra/Agree.lean
+++ b/Iris/Iris/Algebra/Agree.lean
@@ -5,9 +5,8 @@ Authors: Leo Stefanesco, Puming Liu, Sergei Stepanenko
 -/
 module
 
-public import Iris.Algebra.CMRA
-public import Iris.Algebra.OFE
 public import Iris.Algebra.IsOp
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/Agree.lean
+++ b/Iris/Iris/Algebra/Agree.lean
@@ -5,8 +5,8 @@ Authors: Leo Stefanesco, Puming Liu, Sergei Stepanenko
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.IsOp
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/Auth.lean
+++ b/Iris/Iris/Algebra/Auth.lean
@@ -5,8 +5,8 @@ Authors: Alexander Bai
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.View
-import Iris.Std.RocqPorting
 
 /-!
 # Authoritative Camera

--- a/Iris/Iris/Algebra/Auth.lean
+++ b/Iris/Iris/Algebra/Auth.lean
@@ -6,7 +6,7 @@ Authors: Alexander Bai
 module
 
 public import Iris.Algebra.View
-public import Iris.Algebra.LocalUpdates
+import Iris.Std.RocqPorting
 
 /-!
 # Authoritative Camera

--- a/Iris/Iris/Algebra/BigOp.lean
+++ b/Iris/Iris/Algebra/BigOp.lean
@@ -5,12 +5,12 @@ Authors: Zongyuan Liu, Markus de Medeiros, Sergei Stepanenko
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.CMRA
 public import Iris.Std.List
 public import Iris.Std.PartialMap
 public import Iris.Std.GenMultiSets
 import Iris.Std.Equivalence
-import Iris.Std.RocqPorting
 
 namespace Iris.Algebra
 

--- a/Iris/Iris/Algebra/BigOp.lean
+++ b/Iris/Iris/Algebra/BigOp.lean
@@ -5,15 +5,12 @@ Authors: Zongyuan Liu, Markus de Medeiros, Sergei Stepanenko
 -/
 module
 
-public import Iris.Algebra.Monoid
 public import Iris.Algebra.CMRA
-import Batteries.Data.List.Perm
 public import Iris.Std.List
 public import Iris.Std.PartialMap
-public import Iris.Std.GenSets
 public import Iris.Std.GenMultiSets
-public import Iris.Std.Positives
-public import Iris.Std.Equivalence
+import Iris.Std.Equivalence
+import Iris.Std.RocqPorting
 
 namespace Iris.Algebra
 

--- a/Iris/Iris/Algebra/CMRA.lean
+++ b/Iris/Iris/Algebra/CMRA.lean
@@ -5,8 +5,9 @@ Authors: Mario Carneiro, Сухарик (@suhr), Markus de Medeiros, Puming Liu
 -/
 module
 
-public import Iris.Algebra.OFE
 public import Iris.Algebra.Monoid
+import Iris.Std.RocqPorting
+import Std.Data.DTreeMap.Internal.Operations
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/CMRA.lean
+++ b/Iris/Iris/Algebra/CMRA.lean
@@ -5,8 +5,8 @@ Authors: Mario Carneiro, Сухарик (@suhr), Markus de Medeiros, Puming Liu
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.Monoid
-import Iris.Std.RocqPorting
 import Std.Data.DTreeMap.Internal.Operations
 
 @[expose] public section

--- a/Iris/Iris/Algebra/COFESolver.lean
+++ b/Iris/Iris/Algebra/COFESolver.lean
@@ -5,8 +5,8 @@ Authors: Mario Carneiro, Sebastian Graf
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.OFE
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/COFESolver.lean
+++ b/Iris/Iris/Algebra/COFESolver.lean
@@ -6,6 +6,7 @@ Authors: Mario Carneiro, Sebastian Graf
 module
 
 public import Iris.Algebra.OFE
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/Chain.lean
+++ b/Iris/Iris/Algebra/Chain.lean
@@ -6,7 +6,7 @@ Authors: Sergei Stepanenko
 module
 
 public import Iris.Algebra.OFE
-meta import Iris.Std.RocqPorting
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/Chain.lean
+++ b/Iris/Iris/Algebra/Chain.lean
@@ -5,8 +5,8 @@ Authors: Sergei Stepanenko
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.OFE
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/Csum.lean
+++ b/Iris/Iris/Algebra/Csum.lean
@@ -5,9 +5,9 @@ Authors: Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.Updates
 public import Iris.Algebra.LocalUpdates
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/Csum.lean
+++ b/Iris/Iris/Algebra/Csum.lean
@@ -5,9 +5,9 @@ Authors: Markus de Medeiros
 -/
 module
 
-public import Iris.Algebra.CMRA
 public import Iris.Algebra.Updates
 public import Iris.Algebra.LocalUpdates
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/DFrac.lean
+++ b/Iris/Iris/Algebra/DFrac.lean
@@ -5,9 +5,9 @@ Authors: Markus de Medeiros, Mario Carneiro
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.Frac
 public import Iris.Algebra.Updates
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/DFrac.lean
+++ b/Iris/Iris/Algebra/DFrac.lean
@@ -5,12 +5,9 @@ Authors: Markus de Medeiros, Mario Carneiro
 -/
 module
 
-public import Iris.Algebra.CMRA
-public import Iris.Algebra.OFE
 public import Iris.Algebra.Frac
 public import Iris.Algebra.Updates
-public import Iris.Algebra.LocalUpdates
-public import Iris.Algebra.IsOp
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/DynReservationMap.lean
+++ b/Iris/Iris/Algebra/DynReservationMap.lean
@@ -5,10 +5,10 @@ Authors: Zongyuan Liu
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.Heap
 public import Iris.Algebra.IsOp
 public import Iris.Algebra.LeibnizSet
-import Iris.Std.RocqPorting
 
 namespace Iris
 

--- a/Iris/Iris/Algebra/DynReservationMap.lean
+++ b/Iris/Iris/Algebra/DynReservationMap.lean
@@ -5,14 +5,10 @@ Authors: Zongyuan Liu
 -/
 module
 
-public import Iris.Std.CoPset
-public import Iris.Std.GenSets
-public import Iris.Std.PartialMap
-public import Iris.Algebra.CMRA
 public import Iris.Algebra.Heap
 public import Iris.Algebra.IsOp
-public import Iris.Algebra.Updates
 public import Iris.Algebra.LeibnizSet
+import Iris.Std.RocqPorting
 
 namespace Iris
 

--- a/Iris/Iris/Algebra/Excl.lean
+++ b/Iris/Iris/Algebra/Excl.lean
@@ -6,6 +6,7 @@ Authors: Oliver Soeser, Mario Carneiro
 module
 
 public import Iris.Algebra.CMRA
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/Excl.lean
+++ b/Iris/Iris/Algebra/Excl.lean
@@ -5,8 +5,8 @@ Authors: Oliver Soeser, Mario Carneiro
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.CMRA
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/Frac.lean
+++ b/Iris/Iris/Algebra/Frac.lean
@@ -5,9 +5,8 @@ Authors: Markus de Medeiros, Shreyas Srinivas, Mario Carneiro
 -/
 module
 
-public import Iris.Algebra.CMRA
-public import Iris.Algebra.OFE
 public import Iris.Algebra.IsOp
+import Iris.Std.RocqPorting
 
 /-!
 # The Frac CMRA

--- a/Iris/Iris/Algebra/Frac.lean
+++ b/Iris/Iris/Algebra/Frac.lean
@@ -5,8 +5,8 @@ Authors: Markus de Medeiros, Shreyas Srinivas, Mario Carneiro
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.IsOp
-import Iris.Std.RocqPorting
 
 /-!
 # The Frac CMRA

--- a/Iris/Iris/Algebra/Functions.lean
+++ b/Iris/Iris/Algebra/Functions.lean
@@ -5,8 +5,8 @@ Authors: Zongyuan Liu
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.Updates
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/Functions.lean
+++ b/Iris/Iris/Algebra/Functions.lean
@@ -6,6 +6,7 @@ Authors: Zongyuan Liu
 module
 
 public import Iris.Algebra.Updates
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/GenMap.lean
+++ b/Iris/Iris/Algebra/GenMap.lean
@@ -5,8 +5,8 @@ Authors: Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.CMRA
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/GenMap.lean
+++ b/Iris/Iris/Algebra/GenMap.lean
@@ -5,9 +5,8 @@ Authors: Markus de Medeiros
 -/
 module
 
-public import Iris.Algebra.OFE
 public import Iris.Algebra.CMRA
-public import Iris.Algebra.Updates
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/Heap.lean
+++ b/Iris/Iris/Algebra/Heap.lean
@@ -5,10 +5,10 @@ Authors: Markus de Medeiros, Puming Liu
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.CMRA
 public import Iris.Std.Set
 public import Iris.Std.PartialMap
-import Iris.Std.RocqPorting
 import Std.Data.DTreeMap.Internal.Operations
 
 @[expose] public section

--- a/Iris/Iris/Algebra/Heap.lean
+++ b/Iris/Iris/Algebra/Heap.lean
@@ -6,9 +6,10 @@ Authors: Markus de Medeiros, Puming Liu
 module
 
 public import Iris.Algebra.CMRA
-public import Iris.Algebra.OFE
 public import Iris.Std.Set
 public import Iris.Std.PartialMap
+import Iris.Std.RocqPorting
+import Std.Data.DTreeMap.Internal.Operations
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/HeapView.lean
+++ b/Iris/Iris/Algebra/HeapView.lean
@@ -5,9 +5,9 @@ Authors: Markus de Medeiros, Puming Liu
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.Heap
 public import Iris.Algebra.View
-import Iris.Std.RocqPorting
 
 /-!
 # Heap Views

--- a/Iris/Iris/Algebra/HeapView.lean
+++ b/Iris/Iris/Algebra/HeapView.lean
@@ -7,9 +7,7 @@ module
 
 public import Iris.Algebra.Heap
 public import Iris.Algebra.View
-public import Iris.Algebra.DFrac
-public import Iris.Algebra.Frac
-public import Iris.Algebra.BigOp
+import Iris.Std.RocqPorting
 
 /-!
 # Heap Views

--- a/Iris/Iris/Algebra/IProp.lean
+++ b/Iris/Iris/Algebra/IProp.lean
@@ -5,12 +5,10 @@ Authors: Markus de Medeiros
 -/
 module
 
-public import Iris.Algebra.CMRA
-public import Iris.Algebra.OFE
 public import Iris.Algebra.UPred
 public import Iris.Algebra.GenMap
 public import Iris.Algebra.COFESolver
-public import Init.Data.Vector
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/IProp.lean
+++ b/Iris/Iris/Algebra/IProp.lean
@@ -5,10 +5,10 @@ Authors: Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.UPred
 public import Iris.Algebra.GenMap
 public import Iris.Algebra.COFESolver
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/IsOp.lean
+++ b/Iris/Iris/Algebra/IsOp.lean
@@ -5,9 +5,9 @@ Authors: Michael Sammler, Alvin Tang
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.CMRA
 public import Iris.ProofMode.SynthInstanceAttr
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/IsOp.lean
+++ b/Iris/Iris/Algebra/IsOp.lean
@@ -7,6 +7,7 @@ module
 
 public import Iris.Algebra.CMRA
 public import Iris.ProofMode.SynthInstanceAttr
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/LeibnizMultiSet.lean
+++ b/Iris/Iris/Algebra/LeibnizMultiSet.lean
@@ -5,10 +5,10 @@ Authors: Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.BigOp
 public import Iris.Algebra.LocalUpdates
 public import Iris.Algebra.Updates
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/LeibnizMultiSet.lean
+++ b/Iris/Iris/Algebra/LeibnizMultiSet.lean
@@ -6,10 +6,9 @@ Authors: Markus de Medeiros
 module
 
 public import Iris.Algebra.BigOp
-public import Iris.Algebra.CMRA
 public import Iris.Algebra.LocalUpdates
 public import Iris.Algebra.Updates
-public import Iris.Std.GenMultiSets
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/LeibnizSet.lean
+++ b/Iris/Iris/Algebra/LeibnizSet.lean
@@ -5,11 +5,11 @@ Authors: Sergei Stepanenko, Zongyuan Liu
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.BigOp
 public import Iris.Algebra.LocalUpdates
 public import Iris.Algebra.Updates
 public import Iris.Std.CoPset
-import Iris.Std.RocqPorting
 import Std.Data.DTreeMap.Internal.Balancing
 
 @[expose] public section

--- a/Iris/Iris/Algebra/LeibnizSet.lean
+++ b/Iris/Iris/Algebra/LeibnizSet.lean
@@ -6,13 +6,11 @@ Authors: Sergei Stepanenko, Zongyuan Liu
 module
 
 public import Iris.Algebra.BigOp
-public import Iris.Algebra.CMRA
-public import Iris.Algebra.OFE
 public import Iris.Algebra.LocalUpdates
 public import Iris.Algebra.Updates
-public import Iris.Std.GenSets
-public import Iris.Std.Infinite
 public import Iris.Std.CoPset
+import Iris.Std.RocqPorting
+import Std.Data.DTreeMap.Internal.Balancing
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/Lib.lean
+++ b/Iris/Iris/Algebra/Lib.lean
@@ -1,5 +1,6 @@
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.Lib.DFracAgree
 public import Iris.Algebra.Lib.ExclAuth
 public import Iris.Algebra.Lib.FracAuth
@@ -7,4 +8,3 @@ public import Iris.Algebra.Lib.MonoList
 public import Iris.Algebra.Lib.MonoNat
 public import Iris.Algebra.Lib.MonoZ
 public import Iris.Algebra.Lib.UFracAuth
-import Iris.Std.RocqPorting

--- a/Iris/Iris/Algebra/Lib.lean
+++ b/Iris/Iris/Algebra/Lib.lean
@@ -7,3 +7,4 @@ public import Iris.Algebra.Lib.MonoList
 public import Iris.Algebra.Lib.MonoNat
 public import Iris.Algebra.Lib.MonoZ
 public import Iris.Algebra.Lib.UFracAuth
+import Iris.Std.RocqPorting

--- a/Iris/Iris/Algebra/Lib/DFracAgree.lean
+++ b/Iris/Iris/Algebra/Lib/DFracAgree.lean
@@ -5,9 +5,9 @@ Authors: Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.DFrac
 public import Iris.Algebra.Agree
-import Iris.Std.RocqPorting
 
 /-!
 # The DFrac Agree Camera

--- a/Iris/Iris/Algebra/Lib/DFracAgree.lean
+++ b/Iris/Iris/Algebra/Lib/DFracAgree.lean
@@ -7,6 +7,7 @@ module
 
 public import Iris.Algebra.DFrac
 public import Iris.Algebra.Agree
+import Iris.Std.RocqPorting
 
 /-!
 # The DFrac Agree Camera

--- a/Iris/Iris/Algebra/Lib/ExclAuth.lean
+++ b/Iris/Iris/Algebra/Lib/ExclAuth.lean
@@ -7,6 +7,7 @@ module
 
 public import Iris.Algebra.Auth
 public import Iris.Algebra.Excl
+import Iris.Std.RocqPorting
 
 public section
 

--- a/Iris/Iris/Algebra/Lib/ExclAuth.lean
+++ b/Iris/Iris/Algebra/Lib/ExclAuth.lean
@@ -5,9 +5,9 @@ Authors: Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.Auth
 public import Iris.Algebra.Excl
-import Iris.Std.RocqPorting
 
 public section
 

--- a/Iris/Iris/Algebra/Lib/FracAuth.lean
+++ b/Iris/Iris/Algebra/Lib/FracAuth.lean
@@ -5,8 +5,8 @@ Authors: Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.Auth
-import Iris.Std.RocqPorting
 
 /-!
 # Fractional Authoritative Camera

--- a/Iris/Iris/Algebra/Lib/FracAuth.lean
+++ b/Iris/Iris/Algebra/Lib/FracAuth.lean
@@ -6,8 +6,7 @@ Authors: Markus de Medeiros
 module
 
 public import Iris.Algebra.Auth
-public import Iris.Algebra.IsOp
-import Iris.Algebra.LocalUpdates
+import Iris.Std.RocqPorting
 
 /-!
 # Fractional Authoritative Camera

--- a/Iris/Iris/Algebra/Lib/MonoList.lean
+++ b/Iris/Iris/Algebra/Lib/MonoList.lean
@@ -5,9 +5,9 @@ Authors: Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.Auth
 public import Iris.Algebra.MaxPrefixList
-import Iris.Std.RocqPorting
 
 /-! # Monotone lists -/
 

--- a/Iris/Iris/Algebra/Lib/MonoList.lean
+++ b/Iris/Iris/Algebra/Lib/MonoList.lean
@@ -6,9 +6,8 @@ Authors: Markus de Medeiros
 module
 
 public import Iris.Algebra.Auth
-public import Iris.Algebra.IsOp
 public import Iris.Algebra.MaxPrefixList
-meta import Iris.Std.RocqPorting
+import Iris.Std.RocqPorting
 
 /-! # Monotone lists -/
 

--- a/Iris/Iris/Algebra/Lib/MonoNat.lean
+++ b/Iris/Iris/Algebra/Lib/MonoNat.lean
@@ -5,8 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Iris.Algebra.Auth
-public import Iris.Algebra.LocalUpdates
 public import Iris.Algebra.Numbers
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/Lib/MonoNat.lean
+++ b/Iris/Iris/Algebra/Lib/MonoNat.lean
@@ -4,9 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.Auth
 public import Iris.Algebra.Numbers
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/Lib/MonoZ.lean
+++ b/Iris/Iris/Algebra/Lib/MonoZ.lean
@@ -5,9 +5,9 @@ Authors: Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.Auth
 public import Iris.Algebra.Numbers
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/Lib/MonoZ.lean
+++ b/Iris/Iris/Algebra/Lib/MonoZ.lean
@@ -6,8 +6,8 @@ Authors: Markus de Medeiros
 module
 
 public import Iris.Algebra.Auth
-public import Iris.Algebra.LocalUpdates
 public import Iris.Algebra.Numbers
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/Lib/UFracAuth.lean
+++ b/Iris/Iris/Algebra/Lib/UFracAuth.lean
@@ -5,9 +5,9 @@ Authors: Zongyuan Liu, Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.Auth
 public import Iris.Algebra.UFrac
-import Iris.Std.RocqPorting
 
 /-!
 # Unbounded Fractional Authoritative Camera

--- a/Iris/Iris/Algebra/Lib/UFracAuth.lean
+++ b/Iris/Iris/Algebra/Lib/UFracAuth.lean
@@ -6,9 +6,8 @@ Authors: Zongyuan Liu, Markus de Medeiros
 module
 
 public import Iris.Algebra.Auth
-public import Iris.Algebra.IsOp
 public import Iris.Algebra.UFrac
-import Iris.Algebra.LocalUpdates
+import Iris.Std.RocqPorting
 
 /-!
 # Unbounded Fractional Authoritative Camera

--- a/Iris/Iris/Algebra/List.lean
+++ b/Iris/Iris/Algebra/List.lean
@@ -5,9 +5,8 @@ Authors: Markus de Medeiros
 -/
 module
 
-public import Iris.Algebra.OFE
 public import Iris.Algebra.BigOp
-public import Iris.Std.List
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/List.lean
+++ b/Iris/Iris/Algebra/List.lean
@@ -5,8 +5,8 @@ Authors: Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.BigOp
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/LocalUpdates.lean
+++ b/Iris/Iris/Algebra/LocalUpdates.lean
@@ -6,6 +6,7 @@ Authors: Сухарик (@suhr), Mario Carneiro
 module
 
 public import Iris.Algebra.CMRA
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/LocalUpdates.lean
+++ b/Iris/Iris/Algebra/LocalUpdates.lean
@@ -5,8 +5,8 @@ Authors: Сухарик (@suhr), Mario Carneiro
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.CMRA
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/MaxPrefixList.lean
+++ b/Iris/Iris/Algebra/MaxPrefixList.lean
@@ -10,7 +10,7 @@ public import Iris.Algebra.Heap
 public import Iris.Algebra.List
 public import Iris.Algebra.LocalUpdates
 public import Iris.Std.HeapInstances
-meta import Iris.Std.RocqPorting
+import Iris.Std.RocqPorting
 
 /-! # Max prefix lists
 

--- a/Iris/Iris/Algebra/MaxPrefixList.lean
+++ b/Iris/Iris/Algebra/MaxPrefixList.lean
@@ -5,12 +5,12 @@ Authors: Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.Agree
 public import Iris.Algebra.Heap
 public import Iris.Algebra.List
 public import Iris.Algebra.LocalUpdates
 public import Iris.Std.HeapInstances
-import Iris.Std.RocqPorting
 
 /-! # Max prefix lists
 

--- a/Iris/Iris/Algebra/Monoid.lean
+++ b/Iris/Iris/Algebra/Monoid.lean
@@ -6,6 +6,7 @@ Authors: Zongyuan Liu
 module
 
 public import Iris.Algebra.OFE
+import Iris.Std.RocqPorting
 
 public section
 

--- a/Iris/Iris/Algebra/Monoid.lean
+++ b/Iris/Iris/Algebra/Monoid.lean
@@ -5,8 +5,8 @@ Authors: Zongyuan Liu
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.OFE
-import Iris.Std.RocqPorting
 
 public section
 

--- a/Iris/Iris/Algebra/Mra.lean
+++ b/Iris/Iris/Algebra/Mra.lean
@@ -7,6 +7,7 @@ module
 
 public import Iris.Algebra.LocalUpdates
 public import Iris.Std.Classes
+import Iris.Std.RocqPorting
 
 /-!
 # Monotone resource algebras

--- a/Iris/Iris/Algebra/Mra.lean
+++ b/Iris/Iris/Algebra/Mra.lean
@@ -5,9 +5,9 @@ Authors: Zongyuan Liu
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.LocalUpdates
 public import Iris.Std.Classes
-import Iris.Std.RocqPorting
 
 /-!
 # Monotone resource algebras

--- a/Iris/Iris/Algebra/Numbers.lean
+++ b/Iris/Iris/Algebra/Numbers.lean
@@ -5,9 +5,9 @@ Authors: Shreyas Srinivas, Markus de Medeiros, Fernando Leal
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.IsOp
 public import Iris.Algebra.LocalUpdates
-import Iris.Std.RocqPorting
 
 /-! ## Numbers CMRAs
 For simple numerical types which form commutative monoids, there are three classes of CMRA:

--- a/Iris/Iris/Algebra/Numbers.lean
+++ b/Iris/Iris/Algebra/Numbers.lean
@@ -5,10 +5,9 @@ Authors: Shreyas Srinivas, Markus de Medeiros, Fernando Leal
 -/
 module
 
-public import Iris.Algebra.CMRA
-public import Iris.Algebra.OFE
 public import Iris.Algebra.IsOp
 public import Iris.Algebra.LocalUpdates
+import Iris.Std.RocqPorting
 
 /-! ## Numbers CMRAs
 For simple numerical types which form commutative monoids, there are three classes of CMRA:

--- a/Iris/Iris/Algebra/OFE.lean
+++ b/Iris/Iris/Algebra/OFE.lean
@@ -6,6 +6,7 @@ Authors: Mario Carneiro, Sebastian Graf, Sergei Stepanenko
 module
 
 public import Iris.Std.Option
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/OFE.lean
+++ b/Iris/Iris/Algebra/OFE.lean
@@ -5,8 +5,8 @@ Authors: Mario Carneiro, Sebastian Graf, Sergei Stepanenko
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Std.Option
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/ReservationMap.lean
+++ b/Iris/Iris/Algebra/ReservationMap.lean
@@ -1,13 +1,9 @@
 module
 
-import Iris.Std.Positives
-public import Iris.Std.CoPset
-public import Iris.Std.PartialMap
-public import Iris.Algebra.CMRA
 public import Iris.Algebra.Heap
 public import Iris.Algebra.IsOp
-public import Iris.Algebra.Updates
 public import Iris.Algebra.LeibnizSet
+import Iris.Std.RocqPorting
 
 namespace Iris
 

--- a/Iris/Iris/Algebra/ReservationMap.lean
+++ b/Iris/Iris/Algebra/ReservationMap.lean
@@ -1,9 +1,9 @@
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.Heap
 public import Iris.Algebra.IsOp
 public import Iris.Algebra.LeibnizSet
-import Iris.Std.RocqPorting
 
 namespace Iris
 

--- a/Iris/Iris/Algebra/StepIndex.lean
+++ b/Iris/Iris/Algebra/StepIndex.lean
@@ -6,6 +6,7 @@ Authors: Michael Sammler, Alvin Tang
 module
 
 public import Iris.Std.Classes
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/StepIndex.lean
+++ b/Iris/Iris/Algebra/StepIndex.lean
@@ -5,8 +5,8 @@ Authors: Michael Sammler, Alvin Tang
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Std.Classes
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/UFrac.lean
+++ b/Iris/Iris/Algebra/UFrac.lean
@@ -5,10 +5,8 @@ Authors: Markus de Medeiros
 -/
 module
 
-public import Iris.Algebra.CMRA
-public import Iris.Algebra.OFE
 public import Iris.Algebra.Frac
-public import Iris.Algebra.IsOp
+import Iris.Std.RocqPorting
 
 /-!
 # The UFrac CMRA

--- a/Iris/Iris/Algebra/UFrac.lean
+++ b/Iris/Iris/Algebra/UFrac.lean
@@ -5,8 +5,8 @@ Authors: Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.Frac
-import Iris.Std.RocqPorting
 
 /-!
 # The UFrac CMRA

--- a/Iris/Iris/Algebra/UPred.lean
+++ b/Iris/Iris/Algebra/UPred.lean
@@ -6,7 +6,7 @@ Authors: Markus de Medeiros
 module
 
 public import Iris.Algebra.CMRA
-public import Iris.Algebra.OFE
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/UPred.lean
+++ b/Iris/Iris/Algebra/UPred.lean
@@ -5,8 +5,8 @@ Authors: Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.CMRA
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/Updates.lean
+++ b/Iris/Iris/Algebra/Updates.lean
@@ -6,6 +6,7 @@ Authors: Сухарик (@suhr)
 module
 
 public import Iris.Algebra.CMRA
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/Updates.lean
+++ b/Iris/Iris/Algebra/Updates.lean
@@ -5,8 +5,8 @@ Authors: Сухарик (@suhr)
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.CMRA
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/View.lean
+++ b/Iris/Iris/Algebra/View.lean
@@ -5,11 +5,11 @@ Authors: Markus de Medeiros, Puming Liu
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.DFrac
 public import Iris.Algebra.Agree
 public import Iris.Algebra.BigOp
 public import Iris.Algebra.LocalUpdates
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Algebra/View.lean
+++ b/Iris/Iris/Algebra/View.lean
@@ -5,14 +5,11 @@ Authors: Markus de Medeiros, Puming Liu
 -/
 module
 
-public import Iris.Algebra.CMRA
-public import Iris.Algebra.OFE
-public import Iris.Algebra.Frac
 public import Iris.Algebra.DFrac
 public import Iris.Algebra.Agree
 public import Iris.Algebra.BigOp
-public import Iris.Algebra.Updates
 public import Iris.Algebra.LocalUpdates
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/BI.lean
+++ b/Iris/Iris/BI.lean
@@ -1,5 +1,6 @@
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI.Algebra
 public import Iris.BI.BI
 public import Iris.BI.BIBase
@@ -19,4 +20,3 @@ public import Iris.BI.Sbi
 public import Iris.BI.SIProp
 public import Iris.BI.Updates
 public import Iris.BI.WeakestPre
-import Iris.Std.RocqPorting

--- a/Iris/Iris/BI.lean
+++ b/Iris/Iris/BI.lean
@@ -19,3 +19,4 @@ public import Iris.BI.Sbi
 public import Iris.BI.SIProp
 public import Iris.BI.Updates
 public import Iris.BI.WeakestPre
+import Iris.Std.RocqPorting

--- a/Iris/Iris/BI/Algebra.lean
+++ b/Iris/Iris/BI/Algebra.lean
@@ -4,9 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Iris.BI.BI
 public import Iris.BI.Cmra
 public import Iris.Algebra.Lib.DFracAgree
+public import Iris.Algebra.Auth
+public import Iris.Algebra.HeapView
+import Iris.BI.DerivedLaws
+import Iris.Std.RocqPorting
+import Std.Tactic.BVDecide.Normalize.Prop
 
 /-! ## Algebra wrappers for BI
 This file provides introduction rules (BI entailments) for (some) CMRA operations and properties.

--- a/Iris/Iris/BI/Algebra.lean
+++ b/Iris/Iris/BI/Algebra.lean
@@ -4,13 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI.Cmra
 public import Iris.Algebra.Lib.DFracAgree
 public import Iris.Algebra.Auth
 public import Iris.Algebra.HeapView
 import Iris.BI.DerivedLaws
-import Iris.Std.RocqPorting
-import Std.Tactic.BVDecide.Normalize.Prop
 
 /-! ## Algebra wrappers for BI
 This file provides introduction rules (BI entailments) for (some) CMRA operations and properties.

--- a/Iris/Iris/BI/BI.lean
+++ b/Iris/Iris/BI/BI.lean
@@ -5,11 +5,9 @@ Authors: Lars König, Mario Carneiro
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.OFE
 public import Iris.BI.BIBase
-import Iris.Std.Rewrite
-import Iris.Std.RocqPorting
-import Std.Tactic.BVDecide.Normalize.Prop
 
 @[expose] public section
 

--- a/Iris/Iris/BI/BI.lean
+++ b/Iris/Iris/BI/BI.lean
@@ -7,6 +7,9 @@ module
 
 public import Iris.Algebra.OFE
 public import Iris.BI.BIBase
+import Iris.Std.Rewrite
+import Iris.Std.RocqPorting
+import Std.Tactic.BVDecide.Normalize.Prop
 
 @[expose] public section
 

--- a/Iris/Iris/BI/BIBase.lean
+++ b/Iris/Iris/BI/BIBase.lean
@@ -6,10 +6,11 @@ Authors: Lars König, Mario Carneiro
 module
 
 public import Iris.BI.Notation
-public import Iris.Std.Classes
-public import Iris.Std.DelabRule
-public import Iris.Std.Rewrite
 public import Iris.Std.BigOp
+public meta import Lean.PrettyPrinter.Delaborator.Builtins
+import Iris.Std.DelabRule
+import Iris.Std.RocqPorting
+import Lean.PrettyPrinter.Delaborator.Basic
 
 @[expose] public section
 

--- a/Iris/Iris/BI/BIBase.lean
+++ b/Iris/Iris/BI/BIBase.lean
@@ -5,12 +5,13 @@ Authors: Lars König, Mario Carneiro
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI.Notation
 public import Iris.Std.BigOp
 public meta import Lean.PrettyPrinter.Delaborator.Builtins
-import Iris.Std.DelabRule
-import Iris.Std.RocqPorting
-import Lean.PrettyPrinter.Delaborator.Basic
+public import Iris.Std.DelabRule -- shake: keep
+public import Iris.Std.Classes -- shake: keep
+public import Iris.Std.Rewrite -- shake: keep
 
 @[expose] public section
 

--- a/Iris/Iris/BI/BigOp.lean
+++ b/Iris/Iris/BI/BigOp.lean
@@ -8,3 +8,4 @@ public import Iris.BI.BigOp.BigSepList
 public import Iris.BI.BigOp.BigSepMap
 public import Iris.BI.BigOp.BigSepMSet
 public import Iris.BI.BigOp.BigSepSet
+import Iris.Std.RocqPorting

--- a/Iris/Iris/BI/BigOp.lean
+++ b/Iris/Iris/BI/BigOp.lean
@@ -1,5 +1,6 @@
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI.BigOp.BigAndList
 public import Iris.BI.BigOp.BigAndMap
 public import Iris.BI.BigOp.BigOp
@@ -8,4 +9,3 @@ public import Iris.BI.BigOp.BigSepList
 public import Iris.BI.BigOp.BigSepMap
 public import Iris.BI.BigOp.BigSepMSet
 public import Iris.BI.BigOp.BigSepSet
-import Iris.Std.RocqPorting

--- a/Iris/Iris/BI/BigOp/BigAndList.lean
+++ b/Iris/Iris/BI/BigOp/BigAndList.lean
@@ -7,6 +7,8 @@ module
 
 public import Iris.BI.BigOp.BigOp
 import Iris.BI.DerivedLawsLater
+import Iris.BI.DerivedLaws
+import Iris.Std.RocqPorting
 
 public section
 

--- a/Iris/Iris/BI/BigOp/BigAndList.lean
+++ b/Iris/Iris/BI/BigOp/BigAndList.lean
@@ -5,10 +5,10 @@ Authors: Zongyuan Liu
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI.BigOp.BigOp
 import Iris.BI.DerivedLawsLater
 import Iris.BI.DerivedLaws
-import Iris.Std.RocqPorting
 
 public section
 

--- a/Iris/Iris/BI/BigOp/BigAndMap.lean
+++ b/Iris/Iris/BI/BigOp/BigAndMap.lean
@@ -7,6 +7,8 @@ module
 
 public import Iris.BI.BigOp.BigOp
 import Iris.BI.DerivedLawsLater
+import Iris.BI.DerivedLaws
+import Iris.Std.RocqPorting
 
 public section
 

--- a/Iris/Iris/BI/BigOp/BigAndMap.lean
+++ b/Iris/Iris/BI/BigOp/BigAndMap.lean
@@ -5,10 +5,10 @@ Authors: Zongyuan Liu
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI.BigOp.BigOp
 import Iris.BI.DerivedLawsLater
 import Iris.BI.DerivedLaws
-import Iris.Std.RocqPorting
 
 public section
 

--- a/Iris/Iris/BI/BigOp/BigOp.lean
+++ b/Iris/Iris/BI/BigOp/BigOp.lean
@@ -5,10 +5,11 @@ Authors: Zongyuan Liu
 -/
 module
 
-public import Iris.Algebra.Monoid
 public import Iris.Algebra.BigOp
-public import Iris.BI.DerivedLaws
-public import Iris.BI.Notation
+public import Iris.BI.Extensions
+import Iris.BI.DerivedLaws
+import Iris.Std.RocqPorting
+import Lean.Expr
 
 namespace Iris.BI
 

--- a/Iris/Iris/BI/BigOp/BigOp.lean
+++ b/Iris/Iris/BI/BigOp/BigOp.lean
@@ -5,11 +5,10 @@ Authors: Zongyuan Liu
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.BigOp
 public import Iris.BI.Extensions
 import Iris.BI.DerivedLaws
-import Iris.Std.RocqPorting
-import Lean.Expr
 
 namespace Iris.BI
 

--- a/Iris/Iris/BI/BigOp/BigOrList.lean
+++ b/Iris/Iris/BI/BigOp/BigOrList.lean
@@ -7,6 +7,8 @@ module
 
 public import Iris.BI.BigOp.BigOp
 import Iris.BI.DerivedLawsLater
+import Iris.BI.DerivedLaws
+import Iris.Std.RocqPorting
 
 public section
 namespace Iris.BI

--- a/Iris/Iris/BI/BigOp/BigOrList.lean
+++ b/Iris/Iris/BI/BigOp/BigOrList.lean
@@ -5,10 +5,10 @@ Authors: Zongyuan Liu
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI.BigOp.BigOp
 import Iris.BI.DerivedLawsLater
 import Iris.BI.DerivedLaws
-import Iris.Std.RocqPorting
 
 public section
 namespace Iris.BI

--- a/Iris/Iris/BI/BigOp/BigSepList.lean
+++ b/Iris/Iris/BI/BigOp/BigSepList.lean
@@ -8,7 +8,10 @@ module
 public import Iris.BI.BigOp.BigOp
 import Iris.BI.DerivedLawsLater
 import Iris.BI.Instances
-import Iris.Std.TC
+public import Iris.Std.TC
+import Iris.BI.DerivedLaws
+import Iris.Std.RocqPorting
+import Std.Tactic.BVDecide.Normalize.Prop
 
 public section
 

--- a/Iris/Iris/BI/BigOp/BigSepList.lean
+++ b/Iris/Iris/BI/BigOp/BigSepList.lean
@@ -5,13 +5,12 @@ Authors: Zongyuan Liu
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI.BigOp.BigOp
 import Iris.BI.DerivedLawsLater
 import Iris.BI.Instances
 public import Iris.Std.TC
 import Iris.BI.DerivedLaws
-import Iris.Std.RocqPorting
-import Std.Tactic.BVDecide.Normalize.Prop
 
 public section
 

--- a/Iris/Iris/BI/BigOp/BigSepMSet.lean
+++ b/Iris/Iris/BI/BigOp/BigSepMSet.lean
@@ -7,11 +7,11 @@ module
 
 public import Iris.BI.BigOp.BigOp
 import Iris.BI.BigOp.BigSepList
-import Iris.BI.BigOp.BigSepMap
 import Iris.BI.BigOp.BigSepSet
 import Iris.BI.DerivedLawsLater
 import Iris.BI.Instances
-import Iris.Std.TC
+import Iris.BI.DerivedLaws
+import Iris.Std.RocqPorting
 
 public section
 

--- a/Iris/Iris/BI/BigOp/BigSepMSet.lean
+++ b/Iris/Iris/BI/BigOp/BigSepMSet.lean
@@ -5,13 +5,13 @@ Authors: Haokun Li
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI.BigOp.BigOp
 import Iris.BI.BigOp.BigSepList
 import Iris.BI.BigOp.BigSepSet
 import Iris.BI.DerivedLawsLater
 import Iris.BI.Instances
 import Iris.BI.DerivedLaws
-import Iris.Std.RocqPorting
 
 public section
 

--- a/Iris/Iris/BI/BigOp/BigSepMap.lean
+++ b/Iris/Iris/BI/BigOp/BigSepMap.lean
@@ -5,13 +5,13 @@ Authors: Zongyuan Liu
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI.BigOp.BigOp
 import Iris.BI.BigOp.BigSepList
 import Iris.BI.DerivedLawsLater
 import Iris.BI.Instances
 public import Iris.Std.TC
 import Iris.BI.DerivedLaws
-import Iris.Std.RocqPorting
 
 public section
 

--- a/Iris/Iris/BI/BigOp/BigSepMap.lean
+++ b/Iris/Iris/BI/BigOp/BigSepMap.lean
@@ -9,9 +9,9 @@ public import Iris.BI.BigOp.BigOp
 import Iris.BI.BigOp.BigSepList
 import Iris.BI.DerivedLawsLater
 import Iris.BI.Instances
-import Iris.BI.BigOp.BigSepSet
-import Iris.Std.TC
-import Batteries.Data.List.Perm
+public import Iris.Std.TC
+import Iris.BI.DerivedLaws
+import Iris.Std.RocqPorting
 
 public section
 

--- a/Iris/Iris/BI/BigOp/BigSepSet.lean
+++ b/Iris/Iris/BI/BigOp/BigSepSet.lean
@@ -5,13 +5,13 @@ Authors: Zongyuan Liu
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI.BigOp.BigOp
 import Iris.BI.BigOp.BigSepList
 import Iris.BI.DerivedLawsLater
 import Iris.BI.Instances
 public import Iris.Std.TC
 import Iris.BI.DerivedLaws
-import Iris.Std.RocqPorting
 
 public section
 

--- a/Iris/Iris/BI/BigOp/BigSepSet.lean
+++ b/Iris/Iris/BI/BigOp/BigSepSet.lean
@@ -9,7 +9,9 @@ public import Iris.BI.BigOp.BigOp
 import Iris.BI.BigOp.BigSepList
 import Iris.BI.DerivedLawsLater
 import Iris.BI.Instances
-import Iris.Std.TC
+public import Iris.Std.TC
+import Iris.BI.DerivedLaws
+import Iris.Std.RocqPorting
 
 public section
 

--- a/Iris/Iris/BI/Classes.lean
+++ b/Iris/Iris/BI/Classes.lean
@@ -5,8 +5,8 @@ Authors: Lars König, Mario Carneiro
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI.BI
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/BI/Classes.lean
+++ b/Iris/Iris/BI/Classes.lean
@@ -6,6 +6,7 @@ Authors: Lars König, Mario Carneiro
 module
 
 public import Iris.BI.BI
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/BI/Cmra.lean
+++ b/Iris/Iris/BI/Cmra.lean
@@ -5,11 +5,10 @@ Authors: Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI.Plainly
 import Iris.BI.DerivedLaws
 import Iris.BI.DerivedLawsLater
-import Iris.Std.DelabRule
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/BI/Cmra.lean
+++ b/Iris/Iris/BI/Cmra.lean
@@ -5,9 +5,11 @@ Authors: Markus de Medeiros
 -/
 module
 
-public import Iris.BI.Sbi
 public import Iris.BI.Plainly
-public import Iris.BI.InternalEq
+import Iris.BI.DerivedLaws
+import Iris.BI.DerivedLawsLater
+import Iris.Std.DelabRule
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/BI/DerivedLaws.lean
+++ b/Iris/Iris/BI/DerivedLaws.lean
@@ -5,11 +5,9 @@ Authors: Lars König, Mario Carneiro, Markus de Medeiros, Michael Sammler, Alvin
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI.Extensions
-public import Iris.Std.Classes
 public import Iris.Std.TC
-import Iris.Std.Rewrite
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/BI/DerivedLaws.lean
+++ b/Iris/Iris/BI/DerivedLaws.lean
@@ -5,13 +5,11 @@ Authors: Lars König, Mario Carneiro, Markus de Medeiros, Michael Sammler, Alvin
 -/
 module
 
-public import Iris.BI.Classes
 public import Iris.BI.Extensions
-public import Iris.BI.BI
-public import Iris.Std.Nat
 public import Iris.Std.Classes
-public import Iris.Std.Rewrite
 public import Iris.Std.TC
+import Iris.Std.Rewrite
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/BI/DerivedLawsLater.lean
+++ b/Iris/Iris/BI/DerivedLawsLater.lean
@@ -5,14 +5,10 @@ Authors: Michael Sammler
 -/
 module
 
-public import Iris.BI.Classes
-public import Iris.BI.Extensions
-public import Iris.BI.BI
-public import Iris.BI.DerivedLaws
 public import Iris.BI.BigOp.BigOp
-public import Iris.Std.Classes
-public import Iris.Std.Rewrite
-public import Iris.Std.TC
+import Iris.BI.DerivedLaws
+import Iris.Std.Rewrite
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/BI/DerivedLawsLater.lean
+++ b/Iris/Iris/BI/DerivedLawsLater.lean
@@ -5,10 +5,9 @@ Authors: Michael Sammler
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI.BigOp.BigOp
 import Iris.BI.DerivedLaws
-import Iris.Std.Rewrite
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/BI/Embedding.lean
+++ b/Iris/Iris/BI/Embedding.lean
@@ -5,19 +5,11 @@ Authors: Haokun Li
 -/
 module
 
-public import Iris.BI.BI
-public import Iris.BI.BIBase
-public import Iris.BI.DerivedLaws
-public import Iris.BI.DerivedLawsLater
-public import Iris.BI.Classes
-public import Iris.BI.Notation
 public import Iris.BI.Updates
-public import Iris.BI.Plainly
-public import Iris.BI.Sbi
-public import Iris.BI.InternalEq
-public import Iris.BI.BigOp
-public import Iris.Algebra.OFE
-public import Iris.Algebra.Monoid
+import Iris.BI.DerivedLaws
+import Iris.BI.DerivedLawsLater
+import Iris.Std.DelabRule
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/BI/Embedding.lean
+++ b/Iris/Iris/BI/Embedding.lean
@@ -5,11 +5,9 @@ Authors: Haokun Li
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI.Updates
-import Iris.BI.DerivedLaws
 import Iris.BI.DerivedLawsLater
-import Iris.Std.DelabRule
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/BI/Extensions.lean
+++ b/Iris/Iris/BI/Extensions.lean
@@ -5,8 +5,8 @@ Authors: Lars König
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI.Classes
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/BI/Extensions.lean
+++ b/Iris/Iris/BI/Extensions.lean
@@ -6,7 +6,7 @@ Authors: Lars König
 module
 
 public import Iris.BI.Classes
-public import Iris.BI.BI
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/BI/Instances.lean
+++ b/Iris/Iris/BI/Instances.lean
@@ -6,10 +6,8 @@ Authors: Lars König, Mario Carneiro
 module
 
 public import Iris.BI.Classes
-public import Iris.BI.DerivedLaws
-public import Iris.BI.Extensions
-public import Iris.BI.BI
-public import Iris.Std.Classes
+import Iris.BI.DerivedLaws
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/BI/Instances.lean
+++ b/Iris/Iris/BI/Instances.lean
@@ -5,9 +5,9 @@ Authors: Lars König, Mario Carneiro
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI.Classes
 import Iris.BI.DerivedLaws
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/BI/InternalEq.lean
+++ b/Iris/Iris/BI/InternalEq.lean
@@ -8,6 +8,10 @@ module
 public import Iris.BI.Sbi
 public import Iris.Algebra.Csum
 public import Iris.Algebra.Excl
+import Iris.BI.DerivedLaws
+import Iris.BI.DerivedLawsLater
+import Iris.Std.DelabRule
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/BI/InternalEq.lean
+++ b/Iris/Iris/BI/InternalEq.lean
@@ -5,13 +5,12 @@ Authors: Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI.Sbi
 public import Iris.Algebra.Csum
 public import Iris.Algebra.Excl
 import Iris.BI.DerivedLaws
 import Iris.BI.DerivedLawsLater
-import Iris.Std.DelabRule
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/BI/Lib.lean
+++ b/Iris/Iris/BI/Lib.lean
@@ -1,5 +1,6 @@
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI.Lib.BUpdPlain
 public import Iris.BI.Lib.Core
 public import Iris.BI.Lib.Counterexamples

--- a/Iris/Iris/BI/Lib/BUpdPlain.lean
+++ b/Iris/Iris/BI/Lib/BUpdPlain.lean
@@ -1,11 +1,7 @@
 module
 
-public import Iris.Std
-public import Iris.Algebra.Updates
-public import Iris.ProofMode.Classes
-public import Iris.ProofMode.Tactics
-public import Iris.ProofMode.Display
-public import Iris.ProofMode.InstancesUpdates
+public import Iris.BI.Updates
+import Iris.ProofMode.InstancesUpdates
 
 @[expose] public section
 

--- a/Iris/Iris/BI/Lib/BUpdPlain.lean
+++ b/Iris/Iris/BI/Lib/BUpdPlain.lean
@@ -1,5 +1,6 @@
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI.Updates
 import Iris.ProofMode.InstancesUpdates
 

--- a/Iris/Iris/BI/Lib/Core.lean
+++ b/Iris/Iris/BI/Lib/Core.lean
@@ -6,8 +6,7 @@ Authors: Alvin Tang
 
 module
 
-public import Iris.BI
-public import Iris.ProofMode
+public import Iris.ProofMode -- shake: keep
 
 @[expose] public section
 

--- a/Iris/Iris/BI/Lib/Core.lean
+++ b/Iris/Iris/BI/Lib/Core.lean
@@ -6,6 +6,7 @@ Authors: Alvin Tang
 
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode -- shake: keep
 
 @[expose] public section

--- a/Iris/Iris/BI/Lib/Counterexamples.lean
+++ b/Iris/Iris/BI/Lib/Counterexamples.lean
@@ -5,6 +5,7 @@ Authors: Alvin Tang
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode -- shake: keep
 
 @[expose] public section

--- a/Iris/Iris/BI/Lib/Counterexamples.lean
+++ b/Iris/Iris/BI/Lib/Counterexamples.lean
@@ -5,8 +5,7 @@ Authors: Alvin Tang
 -/
 module
 
-public import Iris.BI
-public import Iris.ProofMode
+public import Iris.ProofMode -- shake: keep
 
 @[expose] public section
 

--- a/Iris/Iris/BI/Lib/Fixpoint.lean
+++ b/Iris/Iris/BI/Lib/Fixpoint.lean
@@ -5,6 +5,7 @@ Authors: Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode -- shake: keep
 
 @[expose] public section

--- a/Iris/Iris/BI/Lib/Fixpoint.lean
+++ b/Iris/Iris/BI/Lib/Fixpoint.lean
@@ -5,8 +5,7 @@ Authors: Markus de Medeiros
 -/
 module
 
-public import Iris.BI
-public import Iris.ProofMode
+public import Iris.ProofMode -- shake: keep
 
 @[expose] public section
 

--- a/Iris/Iris/BI/Lib/FixpointBanach.lean
+++ b/Iris/Iris/BI/Lib/FixpointBanach.lean
@@ -4,9 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI.DerivedLaws
 public import Iris.BI.Plainly
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/BI/Lib/FixpointBanach.lean
+++ b/Iris/Iris/BI/Lib/FixpointBanach.lean
@@ -4,7 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Iris.BI
+public import Iris.BI.DerivedLaws
+public import Iris.BI.Plainly
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/BI/Lib/Fractional.lean
+++ b/Iris/Iris/BI/Lib/Fractional.lean
@@ -6,6 +6,7 @@ Authors: Сухарик (@suhr)
 
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode -- shake: keep
 
 @[expose] public section

--- a/Iris/Iris/BI/Lib/Fractional.lean
+++ b/Iris/Iris/BI/Lib/Fractional.lean
@@ -6,8 +6,7 @@ Authors: Сухарик (@suhr)
 
 module
 
-public import Iris.BI
-public import Iris.ProofMode
+public import Iris.ProofMode -- shake: keep
 
 @[expose] public section
 

--- a/Iris/Iris/BI/Lib/GenHeap.lean
+++ b/Iris/Iris/BI/Lib/GenHeap.lean
@@ -1,5 +1,5 @@
 module
-public import Iris.Algebra.ReservationMap
+public import Iris.Init -- shake: keep
 public import Iris.Instances.Lib.GhostMap
 
 @[expose] public section

--- a/Iris/Iris/BI/Lib/GenHeap.lean
+++ b/Iris/Iris/BI/Lib/GenHeap.lean
@@ -1,11 +1,6 @@
 module
-public import Iris.Algebra
 public import Iris.Algebra.ReservationMap
-public import Iris.BI.Lib.Fractional
 public import Iris.Instances.Lib.GhostMap
-public import Iris.Instances.IProp
-public import Iris.Std.HeapInstances
-public import Iris.Std.Namespaces
 
 @[expose] public section
 

--- a/Iris/Iris/BI/Lib/Laterable.lean
+++ b/Iris/Iris/BI/Lib/Laterable.lean
@@ -6,6 +6,7 @@ Authors: Alvin Tang
 
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode -- shake: keep
 
 @[expose] public section

--- a/Iris/Iris/BI/Lib/Laterable.lean
+++ b/Iris/Iris/BI/Lib/Laterable.lean
@@ -6,9 +6,7 @@ Authors: Alvin Tang
 
 module
 
-public import Iris.BI
-public import Iris.ProofMode
-public import Iris.Std.TC
+public import Iris.ProofMode -- shake: keep
 
 @[expose] public section
 

--- a/Iris/Iris/BI/Lib/MonoList.lean
+++ b/Iris/Iris/BI/Lib/MonoList.lean
@@ -5,6 +5,7 @@ Authors: Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.Lib.MonoList
 public import Iris.BI.Lib.Fractional
 public import Iris.Instances.IProp.Instance

--- a/Iris/Iris/BI/Lib/MonoList.lean
+++ b/Iris/Iris/BI/Lib/MonoList.lean
@@ -6,10 +6,8 @@ Authors: Markus de Medeiros
 module
 
 public import Iris.Algebra.Lib.MonoList
-public import Iris.BI
 public import Iris.BI.Lib.Fractional
-public import Iris.ProofMode
-public import Iris.Instances.IProp
+public import Iris.Instances.IProp.Instance
 
 /-!
 # Ghost state for append-only lists

--- a/Iris/Iris/BI/Lib/MonoNat.lean
+++ b/Iris/Iris/BI/Lib/MonoNat.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.Lib.MonoNat
 public import Iris.BI.Lib.Fractional
 public import Iris.Instances.IProp.Instance

--- a/Iris/Iris/BI/Lib/MonoNat.lean
+++ b/Iris/Iris/BI/Lib/MonoNat.lean
@@ -5,11 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Iris.Algebra.Lib.MonoNat
-public import Iris.Algebra.Auth
-public import Iris.BI
 public import Iris.BI.Lib.Fractional
-public import Iris.ProofMode
-public import Iris.Instances.IProp
+public import Iris.Instances.IProp.Instance
 
 @[expose] public section
 

--- a/Iris/Iris/BI/Lib/MonoZ.lean
+++ b/Iris/Iris/BI/Lib/MonoZ.lean
@@ -5,6 +5,7 @@ Authors: Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI.Lib.MonoNat
 
 @[expose] public section

--- a/Iris/Iris/BI/Lib/ProphMap.lean
+++ b/Iris/Iris/BI/Lib/ProphMap.lean
@@ -5,6 +5,7 @@ Authors: Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Instances.Lib.GhostMap
 
 @[expose] public section

--- a/Iris/Iris/BI/Lib/ProphMap.lean
+++ b/Iris/Iris/BI/Lib/ProphMap.lean
@@ -6,7 +6,6 @@ Authors: Markus de Medeiros
 module
 
 public import Iris.Instances.Lib.GhostMap
-public import Iris.Std.GenSets
 
 @[expose] public section
 

--- a/Iris/Iris/BI/Lib/Relations.lean
+++ b/Iris/Iris/BI/Lib/Relations.lean
@@ -5,6 +5,7 @@ Authors: Zongyuan Liu
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI.Lib.Fixpoint
 
 @[expose] public section

--- a/Iris/Iris/BI/MonPred.lean
+++ b/Iris/Iris/BI/MonPred.lean
@@ -5,13 +5,12 @@ Authors: Haokun Li, Sergei Stepanenko
 -/
 module
 
-public import Iris.BI.DerivedLaws -- shake: keep
+public import Iris.Init -- shake: keep
 public import Iris.BI.DerivedLawsLater -- shake: keep
 public import Iris.BI.Embedding
 import Iris.BI.BigOp.BigSepList
 import Iris.BI.BigOp.BigSepMap
 import Iris.BI.BigOp.BigSepSet
-import Iris.Std.RocqPorting
 
 /-! ### TODO
 

--- a/Iris/Iris/BI/MonPred.lean
+++ b/Iris/Iris/BI/MonPred.lean
@@ -5,20 +5,13 @@ Authors: Haokun Li, Sergei Stepanenko
 -/
 module
 
-public import Iris.BI.BI
-public import Iris.BI.BIBase
-public import Iris.BI.DerivedLaws
-public import Iris.BI.DerivedLawsLater
-public import Iris.BI.Extensions
-public import Iris.BI.Classes
+public import Iris.BI.DerivedLaws -- shake: keep
+public import Iris.BI.DerivedLawsLater -- shake: keep
 public import Iris.BI.Embedding
-public import Iris.BI.Updates
-public import Iris.BI.Plainly
-public import Iris.BI.Sbi
-public import Iris.BI.BigOp.BigOp
-public import Iris.BI.BigOp.BigSepList
-public import Iris.BI.BigOp.BigSepMap
-public import Iris.BI.BigOp.BigSepSet
+import Iris.BI.BigOp.BigSepList
+import Iris.BI.BigOp.BigSepMap
+import Iris.BI.BigOp.BigSepSet
+import Iris.Std.RocqPorting
 
 /-! ### TODO
 

--- a/Iris/Iris/BI/Notation.lean
+++ b/Iris/Iris/BI/Notation.lean
@@ -5,9 +5,8 @@ Authors: Lars König, Alex Keizer
 -/
 module
 
-import Lean.Parser.Term
 public import Iris.Init -- shake: keep
-import Iris.Std.RocqPorting
+import Lean.Parser.Term
 
 public meta section
 

--- a/Iris/Iris/BI/Notation.lean
+++ b/Iris/Iris/BI/Notation.lean
@@ -6,7 +6,8 @@ Authors: Lars König, Alex Keizer
 module
 
 import Lean.Parser.Term
-public import Iris.Init
+public import Iris.Init -- shake: keep
+import Iris.Std.RocqPorting
 
 public meta section
 

--- a/Iris/Iris/BI/Plainly.lean
+++ b/Iris/Iris/BI/Plainly.lean
@@ -5,16 +5,13 @@ Authors: Markus de Medeiros, Fernando Leal
 -/
 module
 
-public import Iris.Algebra
-public import Iris.BI.Sbi
-public import Iris.BI.Classes
-public import Iris.BI.BigOp
-public import Iris.BI.BI
-public import Iris.BI.BIBase
-public import Iris.BI.DerivedLaws
-public import Iris.BI.DerivedLawsLater
 public import Iris.BI.InternalEq
 public import Iris.Std.Positives
+public import Iris.BI.BigOp.BigOp
+import Iris.BI.BigOp.BigSepList
+import Iris.BI.DerivedLaws
+import Iris.BI.DerivedLawsLater
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/BI/Plainly.lean
+++ b/Iris/Iris/BI/Plainly.lean
@@ -5,13 +5,13 @@ Authors: Markus de Medeiros, Fernando Leal
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI.InternalEq
 public import Iris.Std.Positives
 public import Iris.BI.BigOp.BigOp
 import Iris.BI.BigOp.BigSepList
 import Iris.BI.DerivedLaws
 import Iris.BI.DerivedLawsLater
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/BI/SIProp.lean
+++ b/Iris/Iris/BI/SIProp.lean
@@ -5,11 +5,10 @@ Authors: Markus de Medeiros
 -/
 module
 
-public import Iris.BI.BI
 public import Iris.BI.Extensions
-public import Iris.BI.Classes
-public import Iris.BI.DerivedLaws
 public import Iris.Algebra.CMRA
+public import Iris.Std.TC
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/BI/SIProp.lean
+++ b/Iris/Iris/BI/SIProp.lean
@@ -5,10 +5,10 @@ Authors: Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI.Extensions
 public import Iris.Algebra.CMRA
 public import Iris.Std.TC
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/BI/Sbi.lean
+++ b/Iris/Iris/BI/Sbi.lean
@@ -5,12 +5,11 @@ Authors:
 -/
 module
 
-public import Iris.BI.BI
-public import Iris.BI.Classes
-public import Iris.BI.DerivedLaws
-public import Iris.BI.DerivedLawsLater
-public import Iris.BI.Extensions
 public import Iris.BI.SIProp
+import Iris.BI.DerivedLaws
+import Iris.BI.DerivedLawsLater
+import Iris.Std.DelabRule
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/BI/Sbi.lean
+++ b/Iris/Iris/BI/Sbi.lean
@@ -5,11 +5,10 @@ Authors:
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI.SIProp
 import Iris.BI.DerivedLaws
 import Iris.BI.DerivedLawsLater
-import Iris.Std.DelabRule
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/BI/Updates.lean
+++ b/Iris/Iris/BI/Updates.lean
@@ -5,15 +5,13 @@ Authors: Markus de Medeiros, Remy Seassau, Yunsong Yang
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI.Plainly
-public import Iris.Std.CoPset
 import Iris.BI.BigOp.BigSepList
-import Iris.BI.DerivedLaws
+public import Iris.BI.DerivedLaws -- shake: keep
 import Iris.BI.DerivedLawsLater
-import Iris.Std.DelabRule
 import Iris.Std.Nat
-import Iris.Std.RocqPorting
-import Lean.PrettyPrinter.Delaborator.Basic
+public import Iris.Algebra -- shake: keep
 
 @[expose] public section
 

--- a/Iris/Iris/BI/Updates.lean
+++ b/Iris/Iris/BI/Updates.lean
@@ -5,14 +5,15 @@ Authors: Markus de Medeiros, Remy Seassau, Yunsong Yang
 -/
 module
 
-public import Iris.BI.BI
-public import Iris.BI.BIBase
-public import Iris.BI.Classes
-public import Iris.BI.DerivedLaws
-public import Iris.BI.Notation
-public import Iris.Algebra
 public import Iris.BI.Plainly
 public import Iris.Std.CoPset
+import Iris.BI.BigOp.BigSepList
+import Iris.BI.DerivedLaws
+import Iris.BI.DerivedLawsLater
+import Iris.Std.DelabRule
+import Iris.Std.Nat
+import Iris.Std.RocqPorting
+import Lean.PrettyPrinter.Delaborator.Basic
 
 @[expose] public section
 

--- a/Iris/Iris/BI/WeakestPre.lean
+++ b/Iris/Iris/BI/WeakestPre.lean
@@ -1,9 +1,9 @@
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Std.CoPset
 public import Iris.BI.Notation
 import Iris.BI.BIBase
-import Iris.Std.RocqPorting
 
 public section
 

--- a/Iris/Iris/BI/WeakestPre.lean
+++ b/Iris/Iris/BI/WeakestPre.lean
@@ -1,7 +1,9 @@
 module
 
 public import Iris.Std.CoPset
-public import Iris.BI.BI
+public import Iris.BI.Notation
+import Iris.BI.BIBase
+import Iris.Std.RocqPorting
 
 public section
 

--- a/Iris/Iris/Examples.lean
+++ b/Iris/Iris/Examples.lean
@@ -1,5 +1,6 @@
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Examples.ClosedProofs
 public import Iris.Examples.Fix
 public import Iris.Examples.HeapLang

--- a/Iris/Iris/Examples/ClosedProofs.lean
+++ b/Iris/Iris/Examples/ClosedProofs.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Instances.Lib.Invariants -- shake: keep
 
 @[expose] public section

--- a/Iris/Iris/Examples/ClosedProofs.lean
+++ b/Iris/Iris/Examples/ClosedProofs.lean
@@ -4,15 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Iris.ProofMode
-public import Iris.Algebra.IProp
-public import Iris.Algebra.Auth
-public import Iris.Instances.UPred.Instance
-public import Iris.Instances.IProp.Instance
-public import Iris.Instances.Lib.WSat
-public import Iris.Instances.Lib.LaterCredits
-public import Iris.Instances.Lib.Invariants
-public import Iris.Std.HeapInstances
+public import Iris.Instances.Lib.Invariants -- shake: keep
 
 @[expose] public section
 

--- a/Iris/Iris/Examples/Fix.lean
+++ b/Iris/Iris/Examples/Fix.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.COFESolver
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Examples/Fix.lean
+++ b/Iris/Iris/Examples/Fix.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Iris.Algebra.OFE
 public import Iris.Algebra.COFESolver
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Examples/HeapLang.lean
+++ b/Iris/Iris/Examples/HeapLang.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Iris.HeapLang
+public import Iris.HeapLang.Notation
 
 @[expose] public section
 namespace Iris.Examples.HeapLang

--- a/Iris/Iris/Examples/HeapLang.lean
+++ b/Iris/Iris/Examples/HeapLang.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.HeapLang.Notation
 
 @[expose] public section

--- a/Iris/Iris/Examples/IProp.lean
+++ b/Iris/Iris/Examples/IProp.lean
@@ -5,11 +5,8 @@ Authors: Markus de Medeiros
 -/
 module
 
-public import Iris.BI
-public import Iris.ProofMode
-public import Iris.Instances.IProp
-public import Iris.Algebra
-public import Iris.Std.HeapInstances
+public import Iris.ProofMode -- shake: keep
+public import Iris.Instances.IProp.Instance
 
 @[expose] public section
 

--- a/Iris/Iris/Examples/IProp.lean
+++ b/Iris/Iris/Examples/IProp.lean
@@ -5,6 +5,7 @@ Authors: Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode -- shake: keep
 public import Iris.Instances.IProp.Instance
 

--- a/Iris/Iris/Examples/Namesets.lean
+++ b/Iris/Iris/Examples/Namesets.lean
@@ -4,14 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Iris.ProofMode
-public import Iris.Algebra.IProp
+public import Iris.ProofMode -- shake: keep
 public import Iris.Algebra.LeibnizSet
 public import Iris.Instances.UPred.Instance
-public import Iris.Instances.IProp.Instance
-public import Iris.Std.GenSetsInstances
-public import Iris.Std.CoPset
-public import Iris.Std.GenSets
 
 @[expose] public section
 

--- a/Iris/Iris/Examples/Namesets.lean
+++ b/Iris/Iris/Examples/Namesets.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode -- shake: keep
-public import Iris.Algebra.LeibnizSet
 public import Iris.Instances.UPred.Instance
 
 @[expose] public section

--- a/Iris/Iris/Examples/Proofs.lean
+++ b/Iris/Iris/Examples/Proofs.lean
@@ -5,8 +5,7 @@ Authors: Lars König
 -/
 module
 
-public import Iris.BI
-public import Iris.ProofMode
+public import Iris.ProofMode -- shake: keep
 
 @[expose] public section
 

--- a/Iris/Iris/Examples/Proofs.lean
+++ b/Iris/Iris/Examples/Proofs.lean
@@ -5,6 +5,7 @@ Authors: Lars König
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode -- shake: keep
 
 @[expose] public section

--- a/Iris/Iris/Examples/Resources.lean
+++ b/Iris/Iris/Examples/Resources.lean
@@ -5,8 +5,8 @@ Authors: Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode -- shake: keep
-public import Iris.Algebra.IProp
 public import Iris.Instances.UPred.Instance
 
 @[expose] public section

--- a/Iris/Iris/Examples/Resources.lean
+++ b/Iris/Iris/Examples/Resources.lean
@@ -5,11 +5,9 @@ Authors: Markus de Medeiros
 -/
 module
 
-public import Iris.ProofMode
+public import Iris.ProofMode -- shake: keep
 public import Iris.Algebra.IProp
 public import Iris.Instances.UPred.Instance
-public import Iris.Instances.IProp.Instance
-public import Iris.Algebra.Agree
 
 @[expose] public section
 

--- a/Iris/Iris/HeapLang.lean
+++ b/Iris/Iris/HeapLang.lean
@@ -1,5 +1,6 @@
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.HeapLang.Completeness
 public import Iris.HeapLang.Instances
 public import Iris.HeapLang.Linter

--- a/Iris/Iris/HeapLang/Completeness.lean
+++ b/Iris/Iris/HeapLang/Completeness.lean
@@ -5,6 +5,7 @@ Authors: Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.HeapLang.PrimitiveLaws
 public import Iris.ProgramLogic.AbstractEctxLangCompleteness
 import Iris.ProgramLogic.Lifting

--- a/Iris/Iris/HeapLang/Completeness.lean
+++ b/Iris/Iris/HeapLang/Completeness.lean
@@ -6,14 +6,8 @@ Authors: Markus de Medeiros
 module
 
 public import Iris.HeapLang.PrimitiveLaws
-public import Iris.BI.BigOp.BigSepSet
-public import Iris.ProgramLogic.ThreadPool
-public import Iris.ProgramLogic.AbstractWeakestPre
-public import Iris.ProgramLogic.AbstractLangCompleteness
 public import Iris.ProgramLogic.AbstractEctxLangCompleteness
-public import Iris.Instances.Lib.CInvariants
-public import Iris.Instances.Lib.GhostMap
-public import Iris.ProofMode
+import Iris.ProgramLogic.Lifting
 
 /-! # HeapLang completeness
 

--- a/Iris/Iris/HeapLang/Instances.lean
+++ b/Iris/Iris/HeapLang/Instances.lean
@@ -5,10 +5,10 @@ Authors: Sergei Stepanenko, Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.HeapLang.Notation
 public import Iris.HeapLang.Semantics
 public import Iris.ProgramLogic.EctxiLanguage
-import Std.Tactic.BVDecide.Normalize.Prop
 
 @[expose] public section
 namespace Iris.HeapLang

--- a/Iris/Iris/HeapLang/Instances.lean
+++ b/Iris/Iris/HeapLang/Instances.lean
@@ -5,14 +5,10 @@ Authors: Sergei Stepanenko, Markus de Medeiros
 -/
 module
 
-public import Iris.HeapLang.Syntax
 public import Iris.HeapLang.Notation
 public import Iris.HeapLang.Semantics
 public import Iris.ProgramLogic.EctxiLanguage
-public import Std.Data.ExtTreeMap
-public import Std.Data.ExtTreeSet
-public import Iris.Std.FromMathlib
-public import Iris.Std.GenSetsInstances
+import Std.Tactic.BVDecide.Normalize.Prop
 
 @[expose] public section
 namespace Iris.HeapLang

--- a/Iris/Iris/HeapLang/Lib.lean
+++ b/Iris/Iris/HeapLang/Lib.lean
@@ -1,5 +1,6 @@
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.HeapLang.Lib.Arith
 public import Iris.HeapLang.Lib.Assert
 public import Iris.HeapLang.Lib.Diverge

--- a/Iris/Iris/HeapLang/Lib/Arith.lean
+++ b/Iris/Iris/HeapLang/Lib/Arith.lean
@@ -5,11 +5,8 @@ Authors: Markus de Medeiros
 -/
 module
 
-public import Iris.ProgramLogic.WeakestPre
-public import Iris.HeapLang.Notation
-public import Iris.HeapLang.Instances
 public import Iris.HeapLang.PrimitiveLaws
-public import Iris.HeapLang.ProofMode
+import Iris.HeapLang.ProofMode
 
 namespace Iris.HeapLang
 

--- a/Iris/Iris/HeapLang/Lib/Arith.lean
+++ b/Iris/Iris/HeapLang/Lib/Arith.lean
@@ -5,6 +5,7 @@ Authors: Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.HeapLang.PrimitiveLaws
 import Iris.HeapLang.ProofMode
 

--- a/Iris/Iris/HeapLang/Lib/Assert.lean
+++ b/Iris/Iris/HeapLang/Lib/Assert.lean
@@ -5,11 +5,8 @@ Authors: Markus de Medeiros
 -/
 module
 
-public import Iris.ProgramLogic.WeakestPre
-public import Iris.HeapLang.Notation
-public import Iris.HeapLang.Instances
 public import Iris.HeapLang.PrimitiveLaws
-public import Iris.HeapLang.ProofMode
+import Iris.HeapLang.ProofMode
 
 namespace Iris.HeapLang
 

--- a/Iris/Iris/HeapLang/Lib/Assert.lean
+++ b/Iris/Iris/HeapLang/Lib/Assert.lean
@@ -5,6 +5,7 @@ Authors: Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.HeapLang.PrimitiveLaws
 import Iris.HeapLang.ProofMode
 

--- a/Iris/Iris/HeapLang/Lib/Diverge.lean
+++ b/Iris/Iris/HeapLang/Lib/Diverge.lean
@@ -5,11 +5,8 @@ Authors: Markus de Medeiros
 -/
 module
 
-public import Iris.ProgramLogic.WeakestPre
-public import Iris.HeapLang.Notation
-public import Iris.HeapLang.Instances
 public import Iris.HeapLang.PrimitiveLaws
-public import Iris.HeapLang.ProofMode
+import Iris.HeapLang.ProofMode
 
 namespace Iris.HeapLang
 

--- a/Iris/Iris/HeapLang/Lib/Diverge.lean
+++ b/Iris/Iris/HeapLang/Lib/Diverge.lean
@@ -5,6 +5,7 @@ Authors: Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.HeapLang.PrimitiveLaws
 import Iris.HeapLang.ProofMode
 

--- a/Iris/Iris/HeapLang/Lib/LandinsKnot.lean
+++ b/Iris/Iris/HeapLang/Lib/LandinsKnot.lean
@@ -5,10 +5,9 @@ Authors: Alex Bai, Klaus Kraßnitzer
 -/
 module
 
-public import Iris.Instances.Lib.Invariants
-public import Iris.Std.Namespaces
 public import Iris.HeapLang.PrimitiveLaws
-public import Iris.HeapLang.ProofMode
+import Iris.HeapLang.ProofMode
+import Iris.Instances.Lib.Invariants
 
 namespace Iris.HeapLang
 

--- a/Iris/Iris/HeapLang/Lib/LandinsKnot.lean
+++ b/Iris/Iris/HeapLang/Lib/LandinsKnot.lean
@@ -5,6 +5,7 @@ Authors: Alex Bai, Klaus Kraßnitzer
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.HeapLang.PrimitiveLaws
 import Iris.HeapLang.ProofMode
 import Iris.Instances.Lib.Invariants

--- a/Iris/Iris/HeapLang/Lib/LazyCoin.lean
+++ b/Iris/Iris/HeapLang/Lib/LazyCoin.lean
@@ -1,8 +1,8 @@
 module
 
-public import Iris.HeapLang
-public import Iris.BI
-public import Iris.HeapLang.Lib.NondetBool
+public import Iris.HeapLang.PrimitiveLaws
+import Iris.HeapLang.Lib.NondetBool
+import Iris.HeapLang.ProofMode
 
 namespace Iris.HeapLang
 

--- a/Iris/Iris/HeapLang/Lib/LazyCoin.lean
+++ b/Iris/Iris/HeapLang/Lib/LazyCoin.lean
@@ -1,5 +1,6 @@
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.HeapLang.PrimitiveLaws
 import Iris.HeapLang.Lib.NondetBool
 import Iris.HeapLang.ProofMode

--- a/Iris/Iris/HeapLang/Lib/Lock.lean
+++ b/Iris/Iris/HeapLang/Lib/Lock.lean
@@ -1,7 +1,6 @@
 module
 
 public import Iris.ProgramLogic.WeakestPre
-public import Iris.HeapLang.Notation
 public import Iris.HeapLang.Instances
 
 namespace Iris.HeapLang

--- a/Iris/Iris/HeapLang/Lib/Lock.lean
+++ b/Iris/Iris/HeapLang/Lib/Lock.lean
@@ -1,5 +1,6 @@
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.ProgramLogic.WeakestPre
 public import Iris.HeapLang.Instances
 

--- a/Iris/Iris/HeapLang/Lib/NondetBool.lean
+++ b/Iris/Iris/HeapLang/Lib/NondetBool.lean
@@ -1,9 +1,8 @@
 module
 
-public import Iris.ProgramLogic.WeakestPre
-public import Iris.HeapLang.ProofMode
 public import Iris.HeapLang.PrimitiveLaws
-public import Iris.Instances.Lib.Invariants
+import Iris.HeapLang.ProofMode
+import Iris.Instances.Lib.Invariants
 
 namespace Iris.HeapLang
 

--- a/Iris/Iris/HeapLang/Lib/NondetBool.lean
+++ b/Iris/Iris/HeapLang/Lib/NondetBool.lean
@@ -1,5 +1,6 @@
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.HeapLang.PrimitiveLaws
 import Iris.HeapLang.ProofMode
 import Iris.Instances.Lib.Invariants

--- a/Iris/Iris/HeapLang/Lib/Par.lean
+++ b/Iris/Iris/HeapLang/Lib/Par.lean
@@ -5,8 +5,9 @@ Authors: Zongyuan Liu
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.HeapLang.Lib.Spawn
-import Iris.HeapLang.ProofMode
+public import Iris.HeapLang.ProofMode -- shake: keep
 
 namespace Iris.HeapLang
 

--- a/Iris/Iris/HeapLang/Lib/Par.lean
+++ b/Iris/Iris/HeapLang/Lib/Par.lean
@@ -6,9 +6,7 @@ Authors: Zongyuan Liu
 module
 
 public import Iris.HeapLang.Lib.Spawn
-public import Iris.Std.Namespaces
-public import Iris.HeapLang.PrimitiveLaws
-public import Iris.HeapLang.ProofMode
+import Iris.HeapLang.ProofMode
 
 namespace Iris.HeapLang
 

--- a/Iris/Iris/HeapLang/Lib/Quicksort.lean
+++ b/Iris/Iris/HeapLang/Lib/Quicksort.lean
@@ -6,7 +6,8 @@ Authors: Markus de Medeiros, Michael Sammler, Klaus Kraßnitzer
 module
 
 public import Iris.HeapLang.PrimitiveLaws
-public import Iris.HeapLang.ProofMode
+import Iris.HeapLang.ProofMode
+import Std.Tactic.BVDecide.Normalize.BitVec
 
 namespace Iris.HeapLang
 

--- a/Iris/Iris/HeapLang/Lib/Quicksort.lean
+++ b/Iris/Iris/HeapLang/Lib/Quicksort.lean
@@ -5,9 +5,9 @@ Authors: Markus de Medeiros, Michael Sammler, Klaus Kraßnitzer
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.HeapLang.PrimitiveLaws
 import Iris.HeapLang.ProofMode
-import Std.Tactic.BVDecide.Normalize.BitVec
 
 namespace Iris.HeapLang
 

--- a/Iris/Iris/HeapLang/Lib/Spawn.lean
+++ b/Iris/Iris/HeapLang/Lib/Spawn.lean
@@ -5,6 +5,7 @@ Authors: Zongyuan Liu, Klaus Kraßnitzer
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Instances.Lib.Token
 public import Iris.Instances.Lib.Invariants
 public import Iris.HeapLang.PrimitiveLaws

--- a/Iris/Iris/HeapLang/Lib/Spawn.lean
+++ b/Iris/Iris/HeapLang/Lib/Spawn.lean
@@ -7,9 +7,8 @@ module
 
 public import Iris.Instances.Lib.Token
 public import Iris.Instances.Lib.Invariants
-public import Iris.Std.Namespaces
 public import Iris.HeapLang.PrimitiveLaws
-public import Iris.HeapLang.ProofMode
+import Iris.HeapLang.ProofMode
 
 namespace Iris.HeapLang
 

--- a/Iris/Iris/HeapLang/Lib/SpinLock.lean
+++ b/Iris/Iris/HeapLang/Lib/SpinLock.lean
@@ -5,6 +5,7 @@ Authors: Michael Sammler, Fernando Leal, Klaus Kraßnitzer
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.HeapLang.Lib.Lock
 public import Iris.Instances.Lib.Token
 public import Iris.Instances.Lib.Invariants

--- a/Iris/Iris/HeapLang/Lib/SpinLock.lean
+++ b/Iris/Iris/HeapLang/Lib/SpinLock.lean
@@ -8,9 +8,8 @@ module
 public import Iris.HeapLang.Lib.Lock
 public import Iris.Instances.Lib.Token
 public import Iris.Instances.Lib.Invariants
-public import Iris.Std.Namespaces
 public import Iris.HeapLang.PrimitiveLaws
-public import Iris.HeapLang.ProofMode
+import Iris.HeapLang.ProofMode
 
 namespace Iris.HeapLang
 

--- a/Iris/Iris/HeapLang/Lib/Unwrap.lean
+++ b/Iris/Iris/HeapLang/Lib/Unwrap.lean
@@ -5,12 +5,8 @@ Authors: Markus de Medeiros
 -/
 module
 
-public import Iris.ProgramLogic.WeakestPre
-public import Iris.HeapLang.Notation
-public import Iris.HeapLang.Instances
 public import Iris.HeapLang.PrimitiveLaws
-public import Iris.HeapLang.ProofMode
-public import Iris.HeapLang.Lib.Assert
+import Iris.HeapLang.ProofMode
 
 namespace Iris.HeapLang
 

--- a/Iris/Iris/HeapLang/Lib/Unwrap.lean
+++ b/Iris/Iris/HeapLang/Lib/Unwrap.lean
@@ -5,6 +5,7 @@ Authors: Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.HeapLang.PrimitiveLaws
 import Iris.HeapLang.ProofMode
 

--- a/Iris/Iris/HeapLang/Linter.lean
+++ b/Iris/Iris/HeapLang/Linter.lean
@@ -4,9 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Iris.HeapLang.Notation
-public import Lean.Elab.Command
-public import Lean.Linter.Util
+public meta import Lean.Elab.Command
+import Iris.HeapLang.Notation
 
 public meta section
 namespace Iris.HeapLang.Linter

--- a/Iris/Iris/HeapLang/Linter.lean
+++ b/Iris/Iris/HeapLang/Linter.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public meta import Lean.Elab.Command
+public import Iris.Init -- shake: keep
 import Iris.HeapLang.Notation
 
 public meta section

--- a/Iris/Iris/HeapLang/Notation.lean
+++ b/Iris/Iris/HeapLang/Notation.lean
@@ -6,7 +6,6 @@ Authors: Michael Sammler
 module
 
 public import Iris.HeapLang.Syntax
-public import Lean.PrettyPrinter.Parenthesizer
 
 public meta section
 namespace Iris.HeapLang

--- a/Iris/Iris/HeapLang/Notation.lean
+++ b/Iris/Iris/HeapLang/Notation.lean
@@ -5,6 +5,7 @@ Authors: Michael Sammler
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.HeapLang.Syntax
 
 public meta section

--- a/Iris/Iris/HeapLang/Porting.lean
+++ b/Iris/Iris/HeapLang/Porting.lean
@@ -5,7 +5,8 @@ Authors: Markus de Medeiros
 -/
 module
 
-public import Iris.Init
+public import Iris.Init -- shake: keep
+import Iris.Std.RocqPorting
 
 /-!
 # HeapLang porting bookkeeping

--- a/Iris/Iris/HeapLang/Porting.lean
+++ b/Iris/Iris/HeapLang/Porting.lean
@@ -6,7 +6,6 @@ Authors: Markus de Medeiros
 module
 
 public import Iris.Init -- shake: keep
-import Iris.Std.RocqPorting
 
 /-!
 # HeapLang porting bookkeeping

--- a/Iris/Iris/HeapLang/PrimitiveLaws.lean
+++ b/Iris/Iris/HeapLang/PrimitiveLaws.lean
@@ -1,17 +1,11 @@
 module
 
-public import Iris.HeapLang.Syntax
-public import Iris.HeapLang.Semantics
-public import Iris.HeapLang.Notation
 public import Iris.HeapLang.Instances
-public import Iris.ProgramLogic.WeakestPre
 public import Iris.ProgramLogic.Adequacy
-public import Iris.ProgramLogic.Lifting
 public import Iris.BI.Lib.GenHeap
 public import Iris.BI.Lib.ProphMap
-public import Iris.Std.GenSetsInstances
-public import Iris.ProofMode
-public import Std.Data.ExtTreeMap
+import Iris.ProgramLogic.Lifting
+import Std.Tactic.BVDecide.Normalize.Prop
 
 @[expose] public section
 namespace Iris.HeapLang

--- a/Iris/Iris/HeapLang/PrimitiveLaws.lean
+++ b/Iris/Iris/HeapLang/PrimitiveLaws.lean
@@ -1,11 +1,11 @@
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.HeapLang.Instances
 public import Iris.ProgramLogic.Adequacy
 public import Iris.BI.Lib.GenHeap
 public import Iris.BI.Lib.ProphMap
 import Iris.ProgramLogic.Lifting
-import Std.Tactic.BVDecide.Normalize.Prop
 
 @[expose] public section
 namespace Iris.HeapLang

--- a/Iris/Iris/HeapLang/ProofMode.lean
+++ b/Iris/Iris/HeapLang/ProofMode.lean
@@ -5,16 +5,13 @@ Authors: Fernando Leal, Klaus Kraßnitzer
 -/
 module
 
-public import Iris.ProofMode
 public import Iris.HeapLang.Tactic
-public import Iris.HeapLang.Instances
 public import Iris.HeapLang.PrimitiveLaws
-public import Iris.ProgramLogic.WeakestPre
-public import Iris.ProgramLogic.Language
-public import Iris.ProgramLogic.EctxLanguage
-public import Iris.ProgramLogic.EctxiLanguage
-public import Iris.ProgramLogic.Lifting
-public import Lean.Elab.Tactic.Simp
+public meta import Lean.Meta.Tactic.Simp.BuiltinSimprocs.Core
+public meta import Lean.Meta.Tactic.Simp.BuiltinSimprocs.String
+public import Std.Tactic.BVDecide.Normalize.Prop
+import Iris.ProgramLogic.Lifting
+import Lean.Meta.Tactic.Simp.Simproc
 
 namespace Iris.ProofMode
 

--- a/Iris/Iris/HeapLang/ProofMode.lean
+++ b/Iris/Iris/HeapLang/ProofMode.lean
@@ -5,13 +5,10 @@ Authors: Fernando Leal, Klaus Kraßnitzer
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.HeapLang.Tactic
 public import Iris.HeapLang.PrimitiveLaws
-public meta import Lean.Meta.Tactic.Simp.BuiltinSimprocs.Core
-public meta import Lean.Meta.Tactic.Simp.BuiltinSimprocs.String
-public import Std.Tactic.BVDecide.Normalize.Prop
-import Iris.ProgramLogic.Lifting
-import Lean.Meta.Tactic.Simp.Simproc
+public import Iris.ProgramLogic.Lifting -- shake: keep
 
 namespace Iris.ProofMode
 

--- a/Iris/Iris/HeapLang/Semantics.lean
+++ b/Iris/Iris/HeapLang/Semantics.lean
@@ -4,8 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.HeapLang.Syntax
-import Std.Tactic.BVDecide.Normalize.Prop
+public import Iris.HeapLang.Linter -- shake: keep
 
 @[expose] public section
 namespace Iris.HeapLang

--- a/Iris/Iris/HeapLang/Semantics.lean
+++ b/Iris/Iris/HeapLang/Semantics.lean
@@ -5,13 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Iris.HeapLang.Syntax
-public import Iris.HeapLang.Linter
-public import Std.Data.ExtTreeMap
-public import Std.Data.ExtTreeSet
-public import Iris.Std.BitOp
-public import Iris.Std.PartialMap
-public import Iris.Std.HeapInstances
-import Iris.Std.List
+import Std.Tactic.BVDecide.Normalize.Prop
 
 @[expose] public section
 namespace Iris.HeapLang

--- a/Iris/Iris/HeapLang/Syntax.lean
+++ b/Iris/Iris/HeapLang/Syntax.lean
@@ -5,8 +5,8 @@ Authors: Michael Sammler
 -/
 module
 
-public import Iris.Std.Infinite
 public import Iris.ProgramLogic.Language
+import Std.Tactic.BVDecide.Normalize.Prop
 
 @[expose] public section
 namespace Iris.HeapLang

--- a/Iris/Iris/HeapLang/Syntax.lean
+++ b/Iris/Iris/HeapLang/Syntax.lean
@@ -5,8 +5,8 @@ Authors: Michael Sammler
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.ProgramLogic.Language
-import Std.Tactic.BVDecide.Normalize.Prop
 
 @[expose] public section
 namespace Iris.HeapLang

--- a/Iris/Iris/HeapLang/Tactic.lean
+++ b/Iris/Iris/HeapLang/Tactic.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.HeapLang.Instances -- shake: keep
-import Lean.Meta.Tactic.Simp.RegisterCommand
 
 namespace Iris.HeapLang
 

--- a/Iris/Iris/HeapLang/Tactic.lean
+++ b/Iris/Iris/HeapLang/Tactic.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Iris.HeapLang.Instances
+public import Iris.HeapLang.Instances -- shake: keep
+import Lean.Meta.Tactic.Simp.RegisterCommand
 
 namespace Iris.HeapLang
 

--- a/Iris/Iris/Init.lean
+++ b/Iris/Iris/Init.lean
@@ -1,4 +1,5 @@
 module
 
 public meta import Iris.Std.RocqPorting -- shake: keep
-import Iris.Std.RocqPorting
+public import Iris.Std.RocqPorting -- shake: keep
+

--- a/Iris/Iris/Init.lean
+++ b/Iris/Iris/Init.lean
@@ -1,3 +1,4 @@
 module
 
-public meta import Iris.Std.RocqPorting
+public meta import Iris.Std.RocqPorting -- shake: keep
+import Iris.Std.RocqPorting

--- a/Iris/Iris/Instances.lean
+++ b/Iris/Iris/Instances.lean
@@ -1,7 +1,7 @@
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Instances.Classical
 public import Iris.Instances.Data
 public import Iris.Instances.IProp
 public import Iris.Instances.UPred
-import Iris.Std.RocqPorting

--- a/Iris/Iris/Instances.lean
+++ b/Iris/Iris/Instances.lean
@@ -4,3 +4,4 @@ public import Iris.Instances.Classical
 public import Iris.Instances.Data
 public import Iris.Instances.IProp
 public import Iris.Instances.UPred
+import Iris.Std.RocqPorting

--- a/Iris/Iris/Instances/Classical.lean
+++ b/Iris/Iris/Instances/Classical.lean
@@ -2,3 +2,4 @@ module
 
 public import Iris.Instances.Classical.Instance
 public import Iris.Instances.Classical.Notation
+import Iris.Std.RocqPorting

--- a/Iris/Iris/Instances/Classical.lean
+++ b/Iris/Iris/Instances/Classical.lean
@@ -1,5 +1,5 @@
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Instances.Classical.Instance
 public import Iris.Instances.Classical.Notation
-import Iris.Std.RocqPorting

--- a/Iris/Iris/Instances/Classical/Instance.lean
+++ b/Iris/Iris/Instances/Classical/Instance.lean
@@ -5,9 +5,9 @@ Authors: Lars König
 -/
 module
 
-public import Iris.BI
-public import Iris.Instances.Data
-public import Iris.Std.Equivalence
+public import Iris.BI.BI
+public import Iris.Instances.Data.State
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Instances/Classical/Instance.lean
+++ b/Iris/Iris/Instances/Classical/Instance.lean
@@ -5,9 +5,9 @@ Authors: Lars König
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI.BI
 public import Iris.Instances.Data.State
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Instances/Classical/Notation.lean
+++ b/Iris/Iris/Instances/Classical/Notation.lean
@@ -6,6 +6,8 @@ Authors: Lars König
 module
 
 public import Iris.Instances.Classical.Instance
+import Iris.Std.DelabRule
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Instances/Classical/Notation.lean
+++ b/Iris/Iris/Instances/Classical/Notation.lean
@@ -5,9 +5,8 @@ Authors: Lars König
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Instances.Classical.Instance
-import Iris.Std.DelabRule
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Instances/Data.lean
+++ b/Iris/Iris/Instances/Data.lean
@@ -1,5 +1,5 @@
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Instances.Data.SetNotation
 public import Iris.Instances.Data.State
-import Iris.Std.RocqPorting

--- a/Iris/Iris/Instances/Data.lean
+++ b/Iris/Iris/Instances/Data.lean
@@ -2,3 +2,4 @@ module
 
 public import Iris.Instances.Data.SetNotation
 public import Iris.Instances.Data.State
+import Iris.Std.RocqPorting

--- a/Iris/Iris/Instances/Data/SetNotation.lean
+++ b/Iris/Iris/Instances/Data/SetNotation.lean
@@ -5,7 +5,8 @@ Authors: Lars König
 -/
 module
 
-public import Iris.Init
+public import Iris.Init -- shake: keep
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Instances/Data/SetNotation.lean
+++ b/Iris/Iris/Instances/Data/SetNotation.lean
@@ -6,7 +6,6 @@ Authors: Lars König
 module
 
 public import Iris.Init -- shake: keep
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Instances/Data/State.lean
+++ b/Iris/Iris/Instances/Data/State.lean
@@ -6,6 +6,8 @@ Authors: Lars König
 module
 
 public import Iris.Instances.Data.SetNotation
+import Iris.Std.RocqPorting
+import Std.Data.DTreeMap.Internal.Operations
 
 @[expose] public section
 

--- a/Iris/Iris/Instances/Data/State.lean
+++ b/Iris/Iris/Instances/Data/State.lean
@@ -5,8 +5,8 @@ Authors: Lars König
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Instances.Data.SetNotation
-import Iris.Std.RocqPorting
 import Std.Data.DTreeMap.Internal.Operations
 
 @[expose] public section

--- a/Iris/Iris/Instances/IProp.lean
+++ b/Iris/Iris/Instances/IProp.lean
@@ -1,3 +1,4 @@
 module
 
 public import Iris.Instances.IProp.Instance
+import Iris.Std.RocqPorting

--- a/Iris/Iris/Instances/IProp.lean
+++ b/Iris/Iris/Instances/IProp.lean
@@ -1,4 +1,4 @@
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Instances.IProp.Instance
-import Iris.Std.RocqPorting

--- a/Iris/Iris/Instances/IProp/Instance.lean
+++ b/Iris/Iris/Instances/IProp/Instance.lean
@@ -6,10 +6,10 @@ Authors: Markus de Medeiros, Zongyuan Liu, Remy Seassau
 module
 
 
-public import Iris.BI
-public import Iris.BI.BigOp
-public import Iris.Algebra
-public import Iris.Instances.UPred
+public import Iris.Algebra.IProp
+public import Iris.Instances.UPred.Instance
+public import Iris.ProofMode.Classes
+import Iris.Std.RocqPorting
 
 @[expose] public section
 namespace Iris

--- a/Iris/Iris/Instances/IProp/Instance.lean
+++ b/Iris/Iris/Instances/IProp/Instance.lean
@@ -6,10 +6,9 @@ Authors: Markus de Medeiros, Zongyuan Liu, Remy Seassau
 module
 
 
-public import Iris.Algebra.IProp
+public import Iris.Init -- shake: keep
 public import Iris.Instances.UPred.Instance
 public import Iris.ProofMode.Classes
-import Iris.Std.RocqPorting
 
 @[expose] public section
 namespace Iris

--- a/Iris/Iris/Instances/Lib.lean
+++ b/Iris/Iris/Instances/Lib.lean
@@ -1,5 +1,6 @@
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Instances.Lib.Boxes
 public import Iris.Instances.Lib.CInvariants
 public import Iris.Instances.Lib.FUpd

--- a/Iris/Iris/Instances/Lib/Boxes.lean
+++ b/Iris/Iris/Instances/Lib/Boxes.lean
@@ -5,13 +5,8 @@ Authors: Sergei Stepanenko, Xiaoyang Lu, Zongyuan Liu
 -/
 module
 
-public import Iris.Algebra
 public import Iris.Algebra.Lib.ExclAuth
-public import Iris.ProofMode
-public import Iris.Instances.IProp
 public import Iris.Instances.Lib.Invariants
-public import Iris.Std.PartialMap
-public import Iris.Std.Namespaces
 
 @[expose] public section
 

--- a/Iris/Iris/Instances/Lib/Boxes.lean
+++ b/Iris/Iris/Instances/Lib/Boxes.lean
@@ -5,6 +5,7 @@ Authors: Sergei Stepanenko, Xiaoyang Lu, Zongyuan Liu
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.Lib.ExclAuth
 public import Iris.Instances.Lib.Invariants
 

--- a/Iris/Iris/Instances/Lib/CInvariants.lean
+++ b/Iris/Iris/Instances/Lib/CInvariants.lean
@@ -5,16 +5,8 @@ Authors: Markus de Medeiros
 -/
 module
 
-public import Iris.ProofMode
-public import Iris.Instances.IProp.Instance
-public import Iris.Instances.Lib.FUpd
 public import Iris.Instances.Lib.Invariants
 public import Iris.BI.Lib.Fractional
-public import Iris.Algebra.Frac
-public import Iris.Algebra.Excl
-public import Iris.Std.Namespaces
-public import Iris.Std.CoPset
-public import Iris.Std.List
 
 @[expose] public section
 

--- a/Iris/Iris/Instances/Lib/CInvariants.lean
+++ b/Iris/Iris/Instances/Lib/CInvariants.lean
@@ -5,6 +5,7 @@ Authors: Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Instances.Lib.Invariants
 public import Iris.BI.Lib.Fractional
 

--- a/Iris/Iris/Instances/Lib/FUpd.lean
+++ b/Iris/Iris/Instances/Lib/FUpd.lean
@@ -5,17 +5,8 @@ Authors: Sergei Stepanenko, Zongyuan Liu
 -/
 module
 
-public import Iris.Algebra
-public import Iris.Algebra.Auth
-public import Iris.Algebra.Numbers
-public import Iris.ProofMode
-public import Iris.BI.Algebra
-public import Iris.BI.Notation
-public import Iris.Instances.IProp
 public import Iris.Instances.Lib.WSat
 public import Iris.Instances.Lib.LaterCredits
-public import Iris.BI.Plainly
-public import Iris.Std
 
 @[expose] public section
 

--- a/Iris/Iris/Instances/Lib/FUpd.lean
+++ b/Iris/Iris/Instances/Lib/FUpd.lean
@@ -5,6 +5,7 @@ Authors: Sergei Stepanenko, Zongyuan Liu
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Instances.Lib.WSat
 public import Iris.Instances.Lib.LaterCredits
 

--- a/Iris/Iris/Instances/Lib/FUpdFromViewShift.lean
+++ b/Iris/Iris/Instances/Lib/FUpdFromViewShift.lean
@@ -4,16 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Iris.Algebra
-public import Iris.Algebra.Auth
-public import Iris.Algebra.Numbers
-public import Iris.Algebra.UPred
-public import Iris.ProofMode
-public import Iris.BI.Algebra
-public import Iris.Instances.IProp
-public import Iris.Instances.Lib.WSat
-public import Iris.Instances.Lib.LaterCredits
-public import Iris.BI.Plainly
+public import Iris.ProofMode -- shake: keep
+public import Iris.Instances.UPred.Instance
 
 @[expose] public section
 

--- a/Iris/Iris/Instances/Lib/FUpdFromViewShift.lean
+++ b/Iris/Iris/Instances/Lib/FUpdFromViewShift.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode -- shake: keep
 public import Iris.Instances.UPred.Instance
 

--- a/Iris/Iris/Instances/Lib/GhostMap.lean
+++ b/Iris/Iris/Instances/Lib/GhostMap.lean
@@ -6,6 +6,7 @@ Authors: Сухарик (@suhr)
 
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI.Lib.Fractional
 public import Iris.Instances.IProp.Instance
 

--- a/Iris/Iris/Instances/Lib/GhostMap.lean
+++ b/Iris/Iris/Instances/Lib/GhostMap.lean
@@ -6,9 +6,8 @@ Authors: Сухарик (@suhr)
 
 module
 
-public import Iris.Instances.IProp
 public import Iris.BI.Lib.Fractional
-public import Iris.ProofMode
+public import Iris.Instances.IProp.Instance
 
 @[expose] public section
 

--- a/Iris/Iris/Instances/Lib/Invariants.lean
+++ b/Iris/Iris/Instances/Lib/Invariants.lean
@@ -4,14 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Iris.Algebra
-public import Iris.ProofMode
-public import Iris.BI.Algebra
-public import Iris.Std.Namespaces
-public import Iris.Instances.IProp
 public import Iris.Instances.Lib.FUpd
-public import Iris.Std.CoPset
-import Iris.Instances.Lib.WSat
 
 @[expose] public section
 

--- a/Iris/Iris/Instances/Lib/Invariants.lean
+++ b/Iris/Iris/Instances/Lib/Invariants.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Instances.Lib.FUpd
 
 @[expose] public section

--- a/Iris/Iris/Instances/Lib/LaterCredits.lean
+++ b/Iris/Iris/Instances/Lib/LaterCredits.lean
@@ -5,9 +5,9 @@ Authors: Sergei Stepanenko, Zongyuan Liu
 -/
 module
 
-public import Iris.Algebra.Numbers
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode -- shake: keep
-public import Iris.Instances.IProp.Instance
+public import Iris.Instances.IProp -- shake: keep
 
 @[expose] public section
 

--- a/Iris/Iris/Instances/Lib/LaterCredits.lean
+++ b/Iris/Iris/Instances/Lib/LaterCredits.lean
@@ -5,13 +5,9 @@ Authors: Sergei Stepanenko, Zongyuan Liu
 -/
 module
 
-public import Iris.Std.TC
-public import Iris.Algebra
-public import Iris.Algebra.Auth
 public import Iris.Algebra.Numbers
-public import Iris.ProofMode
-public import Iris.BI.Algebra
-public import Iris.Instances.IProp
+public import Iris.ProofMode -- shake: keep
+public import Iris.Instances.IProp.Instance
 
 @[expose] public section
 

--- a/Iris/Iris/Instances/Lib/NaInvariants.lean
+++ b/Iris/Iris/Instances/Lib/NaInvariants.lean
@@ -5,13 +5,7 @@ Authors: Markus de Medeiros
 -/
 module
 
-public import Iris.ProofMode
-public import Iris.Instances.IProp.Instance
-public import Iris.Instances.Lib.FUpd
 public import Iris.Instances.Lib.Invariants
-public import Iris.Algebra.LeibnizSet
-public import Iris.Std.Namespaces
-public import Iris.Std.CoPset
 
 @[expose] public section
 

--- a/Iris/Iris/Instances/Lib/NaInvariants.lean
+++ b/Iris/Iris/Instances/Lib/NaInvariants.lean
@@ -5,6 +5,7 @@ Authors: Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Instances.Lib.Invariants
 
 @[expose] public section

--- a/Iris/Iris/Instances/Lib/SavedProp.lean
+++ b/Iris/Iris/Instances/Lib/SavedProp.lean
@@ -5,6 +5,7 @@ Authors: Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI.Lib.Fractional
 public import Iris.Instances.IProp.Instance
 

--- a/Iris/Iris/Instances/Lib/SavedProp.lean
+++ b/Iris/Iris/Instances/Lib/SavedProp.lean
@@ -5,12 +5,8 @@ Authors: Markus de Medeiros
 -/
 module
 
-public import Iris.Instances.IProp
-public import Iris.Algebra.Lib.DFracAgree
 public import Iris.BI.Lib.Fractional
-public import Iris.BI.Algebra
-public import Iris.BI.InternalEq
-public import Iris.ProofMode
+public import Iris.Instances.IProp.Instance
 
 @[expose] public section
 

--- a/Iris/Iris/Instances/Lib/Token.lean
+++ b/Iris/Iris/Instances/Lib/Token.lean
@@ -5,6 +5,7 @@ Authors: Markus de Medeiros, Sergei Stepanenko
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode -- shake: keep
 public import Iris.Instances.IProp.Instance
 

--- a/Iris/Iris/Instances/Lib/Token.lean
+++ b/Iris/Iris/Instances/Lib/Token.lean
@@ -5,7 +5,7 @@ Authors: Markus de Medeiros, Sergei Stepanenko
 -/
 module
 
-public import Iris.ProofMode
+public import Iris.ProofMode -- shake: keep
 public import Iris.Instances.IProp.Instance
 
 @[expose] public section

--- a/Iris/Iris/Instances/Lib/WSat.lean
+++ b/Iris/Iris/Instances/Lib/WSat.lean
@@ -4,10 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode -- shake: keep
-public import Iris.Algebra.LeibnizSet
 public import Iris.Instances.IProp.Instance
-import Std.Tactic.BVDecide.Normalize.Prop
 
 @[expose] public section
 

--- a/Iris/Iris/Instances/Lib/WSat.lean
+++ b/Iris/Iris/Instances/Lib/WSat.lean
@@ -4,14 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Iris.Algebra
-public import Iris.ProofMode
-public import Iris.BI.InternalEq
-public import Iris.BI.BigOp.BigSepMap
-public import Iris.BI.Algebra
-public import Iris.Std.GenSetsInstances
-public import Iris.Std.HeapInstances
-public import Iris.Instances.IProp
+public import Iris.ProofMode -- shake: keep
+public import Iris.Algebra.LeibnizSet
+public import Iris.Instances.IProp.Instance
+import Std.Tactic.BVDecide.Normalize.Prop
 
 @[expose] public section
 

--- a/Iris/Iris/Instances/UPred.lean
+++ b/Iris/Iris/Instances/UPred.lean
@@ -1,4 +1,4 @@
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Instances.UPred.Instance
-import Iris.Std.RocqPorting

--- a/Iris/Iris/Instances/UPred.lean
+++ b/Iris/Iris/Instances/UPred.lean
@@ -1,3 +1,4 @@
 module
 
 public import Iris.Instances.UPred.Instance
+import Iris.Std.RocqPorting

--- a/Iris/Iris/Instances/UPred/Instance.lean
+++ b/Iris/Iris/Instances/UPred/Instance.lean
@@ -5,12 +5,13 @@ Authors: Markus de Medeiros, Mario Carneiro, Viet Anh Nguyen
 -/
 module
 
-public import Iris.BI
-public import Iris.Algebra.OFE
-public import Iris.Algebra.CMRA
 public import Iris.Algebra.UPred
-public import Iris.Algebra.Updates
 public import Iris.BI.Lib.BUpdPlain
+public import Iris.BI.Cmra
+import Iris.BI.DerivedLaws
+import Iris.BI.DerivedLawsLater
+import Iris.Std.RocqPorting
+import Std.Tactic.BVDecide.Normalize.Prop
 
 @[expose] public section
 

--- a/Iris/Iris/Instances/UPred/Instance.lean
+++ b/Iris/Iris/Instances/UPred/Instance.lean
@@ -5,13 +5,10 @@ Authors: Markus de Medeiros, Mario Carneiro, Viet Anh Nguyen
 -/
 module
 
-public import Iris.Algebra.UPred
+public import Iris.Init -- shake: keep
 public import Iris.BI.Lib.BUpdPlain
 public import Iris.BI.Cmra
-import Iris.BI.DerivedLaws
 import Iris.BI.DerivedLawsLater
-import Iris.Std.RocqPorting
-import Std.Tactic.BVDecide.Normalize.Prop
 
 @[expose] public section
 

--- a/Iris/Iris/ProgramLogic.lean
+++ b/Iris/Iris/ProgramLogic.lean
@@ -1,5 +1,6 @@
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.ProgramLogic.AbstractEctxLangCompleteness
 public import Iris.ProgramLogic.AbstractLangCompleteness
 public import Iris.ProgramLogic.AbstractWeakestPre

--- a/Iris/Iris/ProgramLogic/AbstractEctxLangCompleteness.lean
+++ b/Iris/Iris/ProgramLogic/AbstractEctxLangCompleteness.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.ProgramLogic.AbstractLangCompleteness
 
 namespace Iris.ProgramLogic

--- a/Iris/Iris/ProgramLogic/AbstractEctxLangCompleteness.lean
+++ b/Iris/Iris/ProgramLogic/AbstractEctxLangCompleteness.lean
@@ -4,19 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Iris.Algebra
-public import Iris.BI
-public import Iris.ProofMode
-public import Iris.ProgramLogic.Language
-public import Iris.ProgramLogic.EctxLanguage
-public import Iris.ProgramLogic.Adequacy
-public import Iris.ProgramLogic.ThreadPool
-public import Iris.ProgramLogic.AbstractWeakestPre
 public import Iris.ProgramLogic.AbstractLangCompleteness
-public import Iris.Instances.Lib.Invariants
-public import Iris.Instances.Lib.CInvariants
-public import Iris.Instances.Lib.GhostMap
-public import Iris.Std.FromMathlib
 
 namespace Iris.ProgramLogic
 

--- a/Iris/Iris/ProgramLogic/AbstractLangCompleteness.lean
+++ b/Iris/Iris/ProgramLogic/AbstractLangCompleteness.lean
@@ -4,17 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Iris.Algebra
-public import Iris.BI
-public import Iris.ProofMode
-public import Iris.ProgramLogic.Language
 public import Iris.ProgramLogic.Adequacy
 public import Iris.ProgramLogic.ThreadPool
 public import Iris.ProgramLogic.AbstractWeakestPre
-public import Iris.Instances.Lib.Invariants
 public import Iris.Instances.Lib.CInvariants
-public import Iris.Instances.Lib.GhostMap
-public import Iris.Std.FromMathlib
 
 namespace Iris.ProgramLogic
 

--- a/Iris/Iris/ProgramLogic/AbstractLangCompleteness.lean
+++ b/Iris/Iris/ProgramLogic/AbstractLangCompleteness.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.ProgramLogic.Adequacy
 public import Iris.ProgramLogic.ThreadPool
 public import Iris.ProgramLogic.AbstractWeakestPre

--- a/Iris/Iris/ProgramLogic/AbstractWeakestPre.lean
+++ b/Iris/Iris/ProgramLogic/AbstractWeakestPre.lean
@@ -4,15 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Iris.Algebra
-public import Iris.Instances.Lib.FUpd
 public import Iris.Instances.Lib.Invariants
-public import Iris.BI
-public import Iris.BI.WeakestPre
-public import Iris.ProofMode
-public import Iris.ProgramLogic.Language
 public import Iris.ProgramLogic.EctxLanguage
-public import Iris.Std.CoPset
 public import Iris.ProgramLogic.WeakestPre
 
 namespace Iris

--- a/Iris/Iris/ProgramLogic/AbstractWeakestPre.lean
+++ b/Iris/Iris/ProgramLogic/AbstractWeakestPre.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Instances.Lib.Invariants
 public import Iris.ProgramLogic.EctxLanguage
 public import Iris.ProgramLogic.WeakestPre

--- a/Iris/Iris/ProgramLogic/Adequacy.lean
+++ b/Iris/Iris/ProgramLogic/Adequacy.lean
@@ -5,11 +5,7 @@ Authors: Haokun Li, Sergei Stepanenko, Zongyuan Liu
 -/
 module
 
-public import Iris.Algebra
-public import Iris.BI
-public import Iris.ProofMode
 public import Iris.ProgramLogic.WeakestPre
-public import Iris.Std.FromMathlib
 
 namespace Iris.ProgramLogic
 

--- a/Iris/Iris/ProgramLogic/Adequacy.lean
+++ b/Iris/Iris/ProgramLogic/Adequacy.lean
@@ -5,6 +5,7 @@ Authors: Haokun Li, Sergei Stepanenko, Zongyuan Liu
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.ProgramLogic.WeakestPre
 
 namespace Iris.ProgramLogic

--- a/Iris/Iris/ProgramLogic/EctxLanguage.lean
+++ b/Iris/Iris/ProgramLogic/EctxLanguage.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.ProgramLogic.Language
 
 namespace Iris.ProgramLogic

--- a/Iris/Iris/ProgramLogic/EctxLifting.lean
+++ b/Iris/Iris/ProgramLogic/EctxLifting.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.ProgramLogic.EctxLanguage
 public import Iris.ProgramLogic.WeakestPre
 import Iris.ProgramLogic.Lifting

--- a/Iris/Iris/ProgramLogic/EctxLifting.lean
+++ b/Iris/Iris/ProgramLogic/EctxLifting.lean
@@ -4,8 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Iris.ProgramLogic.Lifting
-public import Iris.ProgramLogic.EctxiLanguage
+public import Iris.ProgramLogic.EctxLanguage
+public import Iris.ProgramLogic.WeakestPre
+import Iris.ProgramLogic.Lifting
 
 namespace Iris.ProgramLogic
 

--- a/Iris/Iris/ProgramLogic/EctxiLanguage.lean
+++ b/Iris/Iris/ProgramLogic/EctxiLanguage.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.ProgramLogic.EctxLanguage
-import Std.Tactic.BVDecide.Normalize.Prop
 
 namespace Iris.ProgramLogic
 

--- a/Iris/Iris/ProgramLogic/EctxiLanguage.lean
+++ b/Iris/Iris/ProgramLogic/EctxiLanguage.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Iris.ProgramLogic.Language
 public import Iris.ProgramLogic.EctxLanguage
+import Std.Tactic.BVDecide.Normalize.Prop
 
 namespace Iris.ProgramLogic
 

--- a/Iris/Iris/ProgramLogic/Language.lean
+++ b/Iris/Iris/ProgramLogic/Language.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode -- shake: keep
-import Std.Tactic.BVDecide.Normalize.Prop
 
 #rocq_ignore LanguageMixin "This feature was implemented differently using typeclasses"
 #rocq_ignore language      "This feature was implemented differently using typeclasses"

--- a/Iris/Iris/ProgramLogic/Language.lean
+++ b/Iris/Iris/ProgramLogic/Language.lean
@@ -4,9 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Iris.ProofMode
-public import Iris.Std.Relation
-public import Iris.BI.WeakestPre
+public import Iris.ProofMode -- shake: keep
+import Std.Tactic.BVDecide.Normalize.Prop
 
 #rocq_ignore LanguageMixin "This feature was implemented differently using typeclasses"
 #rocq_ignore language      "This feature was implemented differently using typeclasses"

--- a/Iris/Iris/ProgramLogic/Lifting.lean
+++ b/Iris/Iris/ProgramLogic/Lifting.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.ProgramLogic.WeakestPre
 
 public section

--- a/Iris/Iris/ProgramLogic/Lifting.lean
+++ b/Iris/Iris/ProgramLogic/Lifting.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Iris.ProofMode
 public import Iris.ProgramLogic.WeakestPre
 
 public section

--- a/Iris/Iris/ProgramLogic/ThreadPool.lean
+++ b/Iris/Iris/ProgramLogic/ThreadPool.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.ProgramLogic.Language
 public import Iris.Instances.Lib.GhostMap
 

--- a/Iris/Iris/ProgramLogic/ThreadPool.lean
+++ b/Iris/Iris/ProgramLogic/ThreadPool.lean
@@ -5,11 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Iris.ProgramLogic.Language
-public import Iris.ProgramLogic.EctxLanguage
-public import Iris.ProgramLogic.Adequacy
 public import Iris.Instances.Lib.GhostMap
-public import Iris.Std.FromMathlib
-public import Batteries.Data.List.Lemmas
 
 namespace Iris.ProgramLogic
 

--- a/Iris/Iris/ProgramLogic/WeakestPre.lean
+++ b/Iris/Iris/ProgramLogic/WeakestPre.lean
@@ -4,14 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Iris.Algebra
 public import Iris.Instances.Lib.FUpd
-public import Iris.BI
-public import Iris.BI.WeakestPre
-public import Iris.BI.DerivedLaws
-public import Iris.ProofMode
 public import Iris.ProgramLogic.Language
-public import Iris.Std.CoPset
 
 namespace Iris
 

--- a/Iris/Iris/ProgramLogic/WeakestPre.lean
+++ b/Iris/Iris/ProgramLogic/WeakestPre.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Instances.Lib.FUpd
 public import Iris.ProgramLogic.Language
 

--- a/Iris/Iris/ProofMode.lean
+++ b/Iris/Iris/ProofMode.lean
@@ -1,5 +1,6 @@
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode.Classes
 public import Iris.ProofMode.ClassesMake
 public import Iris.ProofMode.Display

--- a/Iris/Iris/ProofMode/Classes.lean
+++ b/Iris/Iris/ProofMode/Classes.lean
@@ -5,9 +5,9 @@ Authors: Lars König, Michael Sammler, Yunsong Yang, Alvin Tang
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.BI -- shake: keep
 public import Iris.ProofMode.Modalities -- shake: keep
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/ProofMode/Classes.lean
+++ b/Iris/Iris/ProofMode/Classes.lean
@@ -3,10 +3,11 @@ Copyright (c) 2022 Lars König. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Michael Sammler, Yunsong Yang, Alvin Tang
 -/
-module
+module -- shake: keep-all
 
-public import Iris.BI
-public import Iris.ProofMode.Modalities
+public import Iris.BI -- shake: keep
+public import Iris.ProofMode.Modalities -- shake: keep
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/ProofMode/ClassesMake.lean
+++ b/Iris/Iris/ProofMode/ClassesMake.lean
@@ -3,9 +3,10 @@ Copyright (c) 2026 Michael Sammler. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler, Yunsong Yang
 -/
-module
+module -- shake: keep-all
 
-public import Iris.BI
+public import Iris.BI -- shake: keep
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/ProofMode/ClassesMake.lean
+++ b/Iris/Iris/ProofMode/ClassesMake.lean
@@ -5,8 +5,8 @@ Authors: Michael Sammler, Yunsong Yang
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.BI -- shake: keep
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/ProofMode/Display.lean
+++ b/Iris/Iris/ProofMode/Display.lean
@@ -5,6 +5,7 @@ Authors: Lars König, Mario Carneiro
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode.Expr -- shake: keep
 public import Lean.PrettyPrinter.Delaborator.Basic
 meta import Iris.ProofMode.Expr

--- a/Iris/Iris/ProofMode/Display.lean
+++ b/Iris/Iris/ProofMode/Display.lean
@@ -3,9 +3,11 @@ Copyright (c) 2022 Lars König. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro
 -/
-module
+module -- shake: keep-all
 
-public import Iris.ProofMode.Expr
+public import Iris.ProofMode.Expr -- shake: keep
+public import Lean.PrettyPrinter.Delaborator.Basic
+meta import Iris.ProofMode.Expr
 
 public meta section
 

--- a/Iris/Iris/ProofMode/Expr.lean
+++ b/Iris/Iris/ProofMode/Expr.lean
@@ -3,12 +3,14 @@ Copyright (c) 2022 Lars König. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro, Michael Sammler, Yunsong Yang
 -/
-module
+module -- shake: keep-all
 
-public import Iris.BI
-public import Iris.ProofMode.Classes
-public import Iris.Std
-public meta import Iris.Std.Expr
+public import Iris.BI -- shake: keep
+public import Iris.ProofMode.Classes -- shake: keep
+public import Iris.Std -- shake: keep
+public meta import Iris.Std.Expr -- shake: keep
+public meta import Iris.BI.BI
+public meta import Iris.Std.Qq
 
 public meta section
 

--- a/Iris/Iris/ProofMode/Expr.lean
+++ b/Iris/Iris/ProofMode/Expr.lean
@@ -5,6 +5,7 @@ Authors: Lars König, Mario Carneiro, Michael Sammler, Yunsong Yang
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.BI -- shake: keep
 public import Iris.ProofMode.Classes -- shake: keep
 public import Iris.Std -- shake: keep

--- a/Iris/Iris/ProofMode/Instances.lean
+++ b/Iris/Iris/ProofMode/Instances.lean
@@ -3,16 +3,17 @@ Copyright (c) 2022 Lars König. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro, Michael Sammler, Alvin Tang
 -/
-module
+module -- shake: keep-all
 
-public import Iris.BI
-public import Iris.ProofMode.Classes
-public import Iris.ProofMode.ClassesMake
-public import Iris.ProofMode.ModalityInstances
-public import Iris.ProofMode.Expr
-public import Iris.Std.TC
-public import Iris.ProofMode.Tactics
-public import Iris.ProofMode.Display
+public import Iris.BI -- shake: keep
+public import Iris.ProofMode.Classes -- shake: keep
+public import Iris.ProofMode.ClassesMake -- shake: keep
+public import Iris.ProofMode.ModalityInstances -- shake: keep
+public import Iris.ProofMode.Expr -- shake: keep
+public import Iris.Std.TC -- shake: keep
+public import Iris.ProofMode.Tactics -- shake: keep
+public import Iris.ProofMode.Display -- shake: keep
+import Std.Tactic.BVDecide.Normalize.Prop
 
 @[expose] public section
 

--- a/Iris/Iris/ProofMode/Instances.lean
+++ b/Iris/Iris/ProofMode/Instances.lean
@@ -5,6 +5,7 @@ Authors: Lars König, Mario Carneiro, Michael Sammler, Alvin Tang
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.BI -- shake: keep
 public import Iris.ProofMode.Classes -- shake: keep
 public import Iris.ProofMode.ClassesMake -- shake: keep
@@ -13,7 +14,6 @@ public import Iris.ProofMode.Expr -- shake: keep
 public import Iris.Std.TC -- shake: keep
 public import Iris.ProofMode.Tactics -- shake: keep
 public import Iris.ProofMode.Display -- shake: keep
-import Std.Tactic.BVDecide.Normalize.Prop
 
 @[expose] public section
 

--- a/Iris/Iris/ProofMode/InstancesCmra.lean
+++ b/Iris/Iris/ProofMode/InstancesCmra.lean
@@ -3,10 +3,11 @@ Copyright (c) 2026 Michael Sammler. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler
 -/
-module
+module -- shake: keep-all
 
-public import Iris.Algebra.CMRA
-public import Iris.ProofMode.Classes
+public import Iris.Algebra.CMRA -- shake: keep
+public import Iris.ProofMode.Classes -- shake: keep
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/ProofMode/InstancesCmra.lean
+++ b/Iris/Iris/ProofMode/InstancesCmra.lean
@@ -5,9 +5,9 @@ Authors: Michael Sammler
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.Algebra.CMRA -- shake: keep
 public import Iris.ProofMode.Classes -- shake: keep
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/ProofMode/InstancesEmbedding.lean
+++ b/Iris/Iris/ProofMode/InstancesEmbedding.lean
@@ -5,10 +5,10 @@ Authors: Alvin Tang
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.BI -- shake: keep
 public import Iris.ProofMode.Classes -- shake: keep
 public import Iris.ProofMode.ModalityInstances -- shake: keep
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/ProofMode/InstancesEmbedding.lean
+++ b/Iris/Iris/ProofMode/InstancesEmbedding.lean
@@ -3,11 +3,12 @@ Copyright (c) 2026 Alvin Tang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alvin Tang
 -/
-module
+module -- shake: keep-all
 
-public import Iris.BI
-public import Iris.ProofMode.Classes
-public import Iris.ProofMode.ModalityInstances
+public import Iris.BI -- shake: keep
+public import Iris.ProofMode.Classes -- shake: keep
+public import Iris.ProofMode.ModalityInstances -- shake: keep
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/ProofMode/InstancesFrame.lean
+++ b/Iris/Iris/ProofMode/InstancesFrame.lean
@@ -5,6 +5,7 @@ Authors: Michael Sammler, Alvin Tang
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.BI -- shake: keep
 public import Iris.ProofMode.Classes -- shake: keep
 public import Iris.ProofMode.ClassesMake -- shake: keep

--- a/Iris/Iris/ProofMode/InstancesFrame.lean
+++ b/Iris/Iris/ProofMode/InstancesFrame.lean
@@ -3,14 +3,14 @@ Copyright (c) 2026 Michael Sammler. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler, Alvin Tang
 -/
-module
+module -- shake: keep-all
 
-public import Iris.BI
-public import Iris.ProofMode.Classes
-public import Iris.ProofMode.ClassesMake
-public import Iris.ProofMode.Expr
-public import Iris.ProofMode.SynthInstance
-public import Iris.Std.TC
+public import Iris.BI -- shake: keep
+public import Iris.ProofMode.Classes -- shake: keep
+public import Iris.ProofMode.ClassesMake -- shake: keep
+public import Iris.ProofMode.Expr -- shake: keep
+public import Iris.ProofMode.SynthInstance -- shake: keep
+public import Iris.Std.TC -- shake: keep
 
 public meta section
 

--- a/Iris/Iris/ProofMode/InstancesInternalEq.lean
+++ b/Iris/Iris/ProofMode/InstancesInternalEq.lean
@@ -5,10 +5,10 @@ Authors: Sergei Stepanenko, Michael Sammler
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode.Classes -- shake: keep
 public import Iris.ProofMode.ModalityInstances -- shake: keep
 public import Iris.ProofMode.NatCancel -- shake: keep
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/ProofMode/InstancesInternalEq.lean
+++ b/Iris/Iris/ProofMode/InstancesInternalEq.lean
@@ -3,11 +3,12 @@ Copyright (c) 2026 Sergei Stepanenko. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sergei Stepanenko, Michael Sammler
 -/
-module
+module -- shake: keep-all
 
-public import Iris.ProofMode.Classes
-public import Iris.ProofMode.ModalityInstances
-public import Iris.ProofMode.NatCancel
+public import Iris.ProofMode.Classes -- shake: keep
+public import Iris.ProofMode.ModalityInstances -- shake: keep
+public import Iris.ProofMode.NatCancel -- shake: keep
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/ProofMode/InstancesLater.lean
+++ b/Iris/Iris/ProofMode/InstancesLater.lean
@@ -5,12 +5,12 @@ Authors: Michael Sammler, Alvin Tang
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.BI -- shake: keep
 public import Iris.ProofMode.Classes -- shake: keep
 public import Iris.ProofMode.ClassesMake -- shake: keep
 public import Iris.ProofMode.ModalityInstances -- shake: keep
 public import Iris.ProofMode.NatCancel -- shake: keep
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/ProofMode/InstancesLater.lean
+++ b/Iris/Iris/ProofMode/InstancesLater.lean
@@ -3,13 +3,14 @@ Copyright (c) 2026 Michael Sammler. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler, Alvin Tang
 -/
-module
+module -- shake: keep-all
 
-public import Iris.BI
-public import Iris.ProofMode.Classes
-public import Iris.ProofMode.ClassesMake
-public import Iris.ProofMode.ModalityInstances
-public import Iris.ProofMode.NatCancel
+public import Iris.BI -- shake: keep
+public import Iris.ProofMode.Classes -- shake: keep
+public import Iris.ProofMode.ClassesMake -- shake: keep
+public import Iris.ProofMode.ModalityInstances -- shake: keep
+public import Iris.ProofMode.NatCancel -- shake: keep
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/ProofMode/InstancesMake.lean
+++ b/Iris/Iris/ProofMode/InstancesMake.lean
@@ -3,10 +3,11 @@ Copyright (c) 2026 Michael Sammler. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler, Yunsong Yang
 -/
-module
+module -- shake: keep-all
 
-public import Iris.BI
-public import Iris.ProofMode.ClassesMake
+public import Iris.BI -- shake: keep
+public import Iris.ProofMode.ClassesMake -- shake: keep
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/ProofMode/InstancesMake.lean
+++ b/Iris/Iris/ProofMode/InstancesMake.lean
@@ -5,9 +5,9 @@ Authors: Michael Sammler, Yunsong Yang
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.BI -- shake: keep
 public import Iris.ProofMode.ClassesMake -- shake: keep
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/ProofMode/InstancesPlainly.lean
+++ b/Iris/Iris/ProofMode/InstancesPlainly.lean
@@ -3,12 +3,13 @@ Copyright (c) 2026 Michael Sammler. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler
 -/
-module
+module -- shake: keep-all
 
-public import Iris.BI
-public import Iris.ProofMode.Classes
-public import Iris.ProofMode.ModalityInstances
-public import Iris.Std.TC
+public import Iris.BI -- shake: keep
+public import Iris.ProofMode.Classes -- shake: keep
+public import Iris.ProofMode.ModalityInstances -- shake: keep
+public import Iris.Std.TC -- shake: keep
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/ProofMode/InstancesPlainly.lean
+++ b/Iris/Iris/ProofMode/InstancesPlainly.lean
@@ -5,11 +5,11 @@ Authors: Michael Sammler
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.BI -- shake: keep
 public import Iris.ProofMode.Classes -- shake: keep
 public import Iris.ProofMode.ModalityInstances -- shake: keep
 public import Iris.Std.TC -- shake: keep
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/ProofMode/InstancesUpdates.lean
+++ b/Iris/Iris/ProofMode/InstancesUpdates.lean
@@ -5,6 +5,7 @@ Authors: Michael Sammler, Yunsong Yang, Alvin Tang
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.BI -- shake: keep
 public import Iris.ProofMode.Classes -- shake: keep
 public import Iris.ProofMode.Instances -- shake: keep

--- a/Iris/Iris/ProofMode/InstancesUpdates.lean
+++ b/Iris/Iris/ProofMode/InstancesUpdates.lean
@@ -3,14 +3,14 @@ Copyright (c) 2026 Michael Sammler. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler, Yunsong Yang, Alvin Tang
 -/
-module
+module -- shake: keep-all
 
-public import Iris.BI
-public import Iris.ProofMode.Classes
-public import Iris.ProofMode.Instances
-public import Iris.Std.TC
-public import Iris.ProofMode.Tactics
-public import Iris.ProofMode.Display
+public import Iris.BI -- shake: keep
+public import Iris.ProofMode.Classes -- shake: keep
+public import Iris.ProofMode.Instances -- shake: keep
+public import Iris.Std.TC -- shake: keep
+public import Iris.ProofMode.Tactics -- shake: keep
+public import Iris.ProofMode.Display -- shake: keep
 
 @[expose] public section
 

--- a/Iris/Iris/ProofMode/Modalities.lean
+++ b/Iris/Iris/ProofMode/Modalities.lean
@@ -5,9 +5,8 @@ Authors: Markus de Medeiros, Michael Sammler
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.BI -- shake: keep
-import Iris.Std.RocqPorting
-import Std.Tactic.BVDecide.Normalize.Prop
 
 @[expose] public section
 

--- a/Iris/Iris/ProofMode/Modalities.lean
+++ b/Iris/Iris/ProofMode/Modalities.lean
@@ -3,9 +3,11 @@ Copyright (c) 2025 Markus de Medeiros. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros, Michael Sammler
 -/
-module
+module -- shake: keep-all
 
-public import Iris.BI
+public import Iris.BI -- shake: keep
+import Iris.Std.RocqPorting
+import Std.Tactic.BVDecide.Normalize.Prop
 
 @[expose] public section
 

--- a/Iris/Iris/ProofMode/ModalityInstances.lean
+++ b/Iris/Iris/ProofMode/ModalityInstances.lean
@@ -5,9 +5,9 @@ Authors: Markus de Medeiros, Michael Sammler
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode.Classes -- shake: keep
 public import Iris.BI.Instances -- shake: keep
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/ProofMode/ModalityInstances.lean
+++ b/Iris/Iris/ProofMode/ModalityInstances.lean
@@ -3,9 +3,11 @@ Copyright (c) 2025 Markus de Medeiros. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros, Michael Sammler
 -/
-module
+module -- shake: keep-all
 
-public import Iris.ProofMode.Classes
+public import Iris.ProofMode.Classes -- shake: keep
+public import Iris.BI.Instances -- shake: keep
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/ProofMode/NatCancel.lean
+++ b/Iris/Iris/ProofMode/NatCancel.lean
@@ -3,9 +3,10 @@ Copyright (c) 2026 Alvin Tang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alvin Tang
 -/
-module
+module -- shake: keep-all
 
-public import Iris.ProofMode.SynthInstance
+public import Iris.ProofMode.SynthInstance -- shake: keep
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/ProofMode/NatCancel.lean
+++ b/Iris/Iris/ProofMode/NatCancel.lean
@@ -5,8 +5,8 @@ Authors: Alvin Tang
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode.SynthInstance -- shake: keep
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/ProofMode/Patterns.lean
+++ b/Iris/Iris/ProofMode/Patterns.lean
@@ -1,5 +1,6 @@
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode.Patterns.CasesPattern -- shake: keep
 public import Iris.ProofMode.Patterns.IntroPattern -- shake: keep
 public import Iris.ProofMode.Patterns.SelPattern -- shake: keep

--- a/Iris/Iris/ProofMode/Patterns.lean
+++ b/Iris/Iris/ProofMode/Patterns.lean
@@ -1,6 +1,6 @@
-module
+module -- shake: keep-all
 
-public import Iris.ProofMode.Patterns.CasesPattern
-public import Iris.ProofMode.Patterns.IntroPattern
-public import Iris.ProofMode.Patterns.SelPattern
-public import Iris.ProofMode.Patterns.SpecPattern
+public import Iris.ProofMode.Patterns.CasesPattern -- shake: keep
+public import Iris.ProofMode.Patterns.IntroPattern -- shake: keep
+public import Iris.ProofMode.Patterns.SelPattern -- shake: keep
+public import Iris.ProofMode.Patterns.SpecPattern -- shake: keep

--- a/Iris/Iris/ProofMode/Patterns/CasesPattern.lean
+++ b/Iris/Iris/ProofMode/Patterns/CasesPattern.lean
@@ -5,9 +5,8 @@ Authors: Lars König, Alvin Tang
 -/
 module -- shake: keep-all
 
-public import Lean.Data.Name -- shake: keep
 public import Iris.Init -- shake: keep
-import Iris.Std.RocqPorting
+public import Lean.Data.Name -- shake: keep
 
 @[expose] public section
 

--- a/Iris/Iris/ProofMode/Patterns/CasesPattern.lean
+++ b/Iris/Iris/ProofMode/Patterns/CasesPattern.lean
@@ -3,10 +3,11 @@ Copyright (c) 2022 Lars König. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Alvin Tang
 -/
-module
+module -- shake: keep-all
 
-public import Lean.Data.Name
-public import Iris.Init
+public import Lean.Data.Name -- shake: keep
+public import Iris.Init -- shake: keep
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/ProofMode/Patterns/IntroPattern.lean
+++ b/Iris/Iris/ProofMode/Patterns/IntroPattern.lean
@@ -3,12 +3,11 @@ Copyright (c) 2025 Michael Sammler. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler, Alvin Tang
 -/
-module
+module -- shake: keep-all
 
-public import Iris.ProofMode.Patterns.CasesPattern
-public import Iris.ProofMode.Patterns.SelPattern
-
-public import Lean.Syntax
+public import Iris.ProofMode.Patterns.CasesPattern -- shake: keep
+public import Iris.ProofMode.Patterns.SelPattern -- shake: keep
+public import Lean.Syntax -- shake: keep
 
 @[expose] public section
 

--- a/Iris/Iris/ProofMode/Patterns/IntroPattern.lean
+++ b/Iris/Iris/ProofMode/Patterns/IntroPattern.lean
@@ -5,6 +5,7 @@ Authors: Michael Sammler, Alvin Tang
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode.Patterns.CasesPattern -- shake: keep
 public import Iris.ProofMode.Patterns.SelPattern -- shake: keep
 public import Lean.Syntax -- shake: keep

--- a/Iris/Iris/ProofMode/Patterns/SelPattern.lean
+++ b/Iris/Iris/ProofMode/Patterns/SelPattern.lean
@@ -5,6 +5,7 @@ Authors: Yunsong Yang
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode.ProofModeM -- shake: keep
 
 @[expose] public section

--- a/Iris/Iris/ProofMode/Patterns/SelPattern.lean
+++ b/Iris/Iris/ProofMode/Patterns/SelPattern.lean
@@ -3,9 +3,9 @@ Copyright (c) 2026 Yunsong Yang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yunsong Yang
 -/
-module
+module -- shake: keep-all
 
-public import Iris.ProofMode.ProofModeM
+public import Iris.ProofMode.ProofModeM -- shake: keep
 
 @[expose] public section
 

--- a/Iris/Iris/ProofMode/Patterns/SpecPattern.lean
+++ b/Iris/Iris/ProofMode/Patterns/SpecPattern.lean
@@ -5,9 +5,8 @@ Authors: Oliver Soeser, Zongyuan Liu, Yunsong Yang, Michael Sammler, Alvin Tang
 -/
 module -- shake: keep-all
 
-public import Lean.Syntax -- shake: keep
 public import Iris.Init -- shake: keep
-import Iris.Std.RocqPorting
+public import Lean.Syntax -- shake: keep
 
 @[expose] public section
 

--- a/Iris/Iris/ProofMode/Patterns/SpecPattern.lean
+++ b/Iris/Iris/ProofMode/Patterns/SpecPattern.lean
@@ -3,10 +3,11 @@ Copyright (c) 2025 Oliver Soeser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Oliver Soeser, Zongyuan Liu, Yunsong Yang, Michael Sammler, Alvin Tang
 -/
-module
+module -- shake: keep-all
 
-public import Lean.Syntax
-public import Iris.Init
+public import Lean.Syntax -- shake: keep
+public import Iris.Init -- shake: keep
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/ProofMode/Porting.lean
+++ b/Iris/Iris/ProofMode/Porting.lean
@@ -5,8 +5,7 @@ Authors: Zongyuan Liu
 -/
 module -- shake: keep-all
 
-import Iris.Init -- shake: keep
-import Iris.Std.RocqPorting
+public import Iris.Init -- shake: keep
 
 #rocq_ignore_file proofmode "base.v" "Rocq-specific basic functionality"
 #rocq_ignore_file proofmode "coq_tactics.v" "Tracked via the Tactics concept"

--- a/Iris/Iris/ProofMode/Porting.lean
+++ b/Iris/Iris/ProofMode/Porting.lean
@@ -3,9 +3,10 @@ Copyright (c) 2026. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zongyuan Liu
 -/
-module
+module -- shake: keep-all
 
-import Iris.Init
+import Iris.Init -- shake: keep
+import Iris.Std.RocqPorting
 
 #rocq_ignore_file proofmode "base.v" "Rocq-specific basic functionality"
 #rocq_ignore_file proofmode "coq_tactics.v" "Tracked via the Tactics concept"

--- a/Iris/Iris/ProofMode/ProofModeM.lean
+++ b/Iris/Iris/ProofMode/ProofModeM.lean
@@ -5,6 +5,7 @@ Authors: Michael Sammler, Zongyuan Liu, Yunsong Yang, Alvin Tang
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public meta import Iris.ProofMode.Expr -- shake: keep
 public import Iris.ProofMode.SynthInstance -- shake: keep
 public import Iris.ProofMode.Classes -- shake: keep

--- a/Iris/Iris/ProofMode/ProofModeM.lean
+++ b/Iris/Iris/ProofMode/ProofModeM.lean
@@ -3,11 +3,14 @@ Copyright (c) 2025 Michael Sammler. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler, Zongyuan Liu, Yunsong Yang, Alvin Tang
 -/
-module
+module -- shake: keep-all
 
-public meta import Iris.ProofMode.Expr
-public import Iris.ProofMode.SynthInstance
-public import Iris.ProofMode.Classes
+public meta import Iris.ProofMode.Expr -- shake: keep
+public import Iris.ProofMode.SynthInstance -- shake: keep
+public import Iris.ProofMode.Classes -- shake: keep
+public import Iris.ProofMode.Expr
+public import Lean.Elab.Tactic.Basic
+public meta import Std.Do.Triple.SpecLemmas
 
 public meta section
 

--- a/Iris/Iris/ProofMode/SynthInstance.lean
+++ b/Iris/Iris/ProofMode/SynthInstance.lean
@@ -5,10 +5,10 @@ Authors: Michael Sammler
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.BI -- shake: keep
 public import Iris.ProofMode.SynthInstanceAttr -- shake: keep
 public meta import Iris.ProofMode.SynthInstanceAttr
-import Iris.Std.RocqPorting
 
 public meta section
 

--- a/Iris/Iris/ProofMode/SynthInstance.lean
+++ b/Iris/Iris/ProofMode/SynthInstance.lean
@@ -3,10 +3,12 @@ Copyright (c) 2025 Michael Sammler. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler
 -/
-module
+module -- shake: keep-all
 
-public import Iris.BI
-public import Iris.ProofMode.SynthInstanceAttr
+public import Iris.BI -- shake: keep
+public import Iris.ProofMode.SynthInstanceAttr -- shake: keep
+public meta import Iris.ProofMode.SynthInstanceAttr
+import Iris.Std.RocqPorting
 
 public meta section
 

--- a/Iris/Iris/ProofMode/SynthInstanceAttr.lean
+++ b/Iris/Iris/ProofMode/SynthInstanceAttr.lean
@@ -5,9 +5,9 @@ Authors: Michael Sammler, Alvin Tang
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Qq -- shake: keep
 public import Iris.BI.Notation -- shake: keep
-import Iris.Std.RocqPorting
 
 public meta section
 

--- a/Iris/Iris/ProofMode/SynthInstanceAttr.lean
+++ b/Iris/Iris/ProofMode/SynthInstanceAttr.lean
@@ -3,10 +3,11 @@ Copyright (c) 2026 Michael Sammler. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler, Alvin Tang
 -/
-module
+module -- shake: keep-all
 
-public import Qq
-public import Iris.BI.Notation
+public import Qq -- shake: keep
+public import Iris.BI.Notation -- shake: keep
+import Iris.Std.RocqPorting
 
 public meta section
 

--- a/Iris/Iris/ProofMode/Tactics.lean
+++ b/Iris/Iris/ProofMode/Tactics.lean
@@ -1,6 +1,7 @@
 /- A description of the tactics can be found in `tactics.md`. -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode.Tactics.Accu -- shake: keep
 public import Iris.ProofMode.Tactics.Apply -- shake: keep
 public import Iris.ProofMode.Tactics.Assumption -- shake: keep

--- a/Iris/Iris/ProofMode/Tactics.lean
+++ b/Iris/Iris/ProofMode/Tactics.lean
@@ -1,32 +1,32 @@
 /- A description of the tactics can be found in `tactics.md`. -/
-module
+module -- shake: keep-all
 
-public import Iris.ProofMode.Tactics.Accu
-public import Iris.ProofMode.Tactics.Apply
-public import Iris.ProofMode.Tactics.Assumption
-public import Iris.ProofMode.Tactics.Basic
-public import Iris.ProofMode.Tactics.Cases
-public import Iris.ProofMode.Tactics.Clear
-public import Iris.ProofMode.Tactics.Combine
-public import Iris.ProofMode.Tactics.Eval
-public import Iris.ProofMode.Tactics.Exact
-public import Iris.ProofMode.Tactics.ExFalso
-public import Iris.ProofMode.Tactics.Exists
-public import Iris.ProofMode.Tactics.Frame
-public import Iris.ProofMode.Tactics.Have
-public import Iris.ProofMode.Tactics.HaveCore
-public import Iris.ProofMode.Tactics.Induction
-public import Iris.ProofMode.Tactics.Intro
-public import Iris.ProofMode.Tactics.Inv
-public import Iris.ProofMode.Tactics.LeftRight
-public import Iris.ProofMode.Tactics.Loeb
-public import Iris.ProofMode.Tactics.Mod
-public import Iris.ProofMode.Tactics.ModIntro
-public import Iris.ProofMode.Tactics.Pure
-public import Iris.ProofMode.Tactics.Rename
-public import Iris.ProofMode.Tactics.Revert
-public import Iris.ProofMode.Tactics.RevertIntro
-public import Iris.ProofMode.Tactics.Rewrite
-public import Iris.ProofMode.Tactics.Specialize
-public import Iris.ProofMode.Tactics.Split
-public import Iris.ProofMode.Tactics.Trivial
+public import Iris.ProofMode.Tactics.Accu -- shake: keep
+public import Iris.ProofMode.Tactics.Apply -- shake: keep
+public import Iris.ProofMode.Tactics.Assumption -- shake: keep
+public import Iris.ProofMode.Tactics.Basic -- shake: keep
+public import Iris.ProofMode.Tactics.Cases -- shake: keep
+public import Iris.ProofMode.Tactics.Clear -- shake: keep
+public import Iris.ProofMode.Tactics.Combine -- shake: keep
+public import Iris.ProofMode.Tactics.Eval -- shake: keep
+public import Iris.ProofMode.Tactics.Exact -- shake: keep
+public import Iris.ProofMode.Tactics.ExFalso -- shake: keep
+public import Iris.ProofMode.Tactics.Exists -- shake: keep
+public import Iris.ProofMode.Tactics.Frame -- shake: keep
+public import Iris.ProofMode.Tactics.Have -- shake: keep
+public import Iris.ProofMode.Tactics.HaveCore -- shake: keep
+public import Iris.ProofMode.Tactics.Induction -- shake: keep
+public import Iris.ProofMode.Tactics.Intro -- shake: keep
+public import Iris.ProofMode.Tactics.Inv -- shake: keep
+public import Iris.ProofMode.Tactics.LeftRight -- shake: keep
+public import Iris.ProofMode.Tactics.Loeb -- shake: keep
+public import Iris.ProofMode.Tactics.Mod -- shake: keep
+public import Iris.ProofMode.Tactics.ModIntro -- shake: keep
+public import Iris.ProofMode.Tactics.Pure -- shake: keep
+public import Iris.ProofMode.Tactics.Rename -- shake: keep
+public import Iris.ProofMode.Tactics.Revert -- shake: keep
+public import Iris.ProofMode.Tactics.RevertIntro -- shake: keep
+public import Iris.ProofMode.Tactics.Rewrite -- shake: keep
+public import Iris.ProofMode.Tactics.Specialize -- shake: keep
+public import Iris.ProofMode.Tactics.Split -- shake: keep
+public import Iris.ProofMode.Tactics.Trivial -- shake: keep

--- a/Iris/Iris/ProofMode/Tactics/Accu.lean
+++ b/Iris/Iris/ProofMode/Tactics/Accu.lean
@@ -3,9 +3,9 @@ Copyright (c) 2026 Alvin Tang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler, Alvin Tang
 -/
-module
+module -- shake: keep-all
 
-public import Iris.ProofMode.ProofModeM
+public import Iris.ProofMode.ProofModeM -- shake: keep
 
 namespace Iris.ProofMode
 

--- a/Iris/Iris/ProofMode/Tactics/Accu.lean
+++ b/Iris/Iris/ProofMode/Tactics/Accu.lean
@@ -5,6 +5,7 @@ Authors: Michael Sammler, Alvin Tang
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode.ProofModeM -- shake: keep
 
 namespace Iris.ProofMode

--- a/Iris/Iris/ProofMode/Tactics/Apply.lean
+++ b/Iris/Iris/ProofMode/Tactics/Apply.lean
@@ -3,10 +3,10 @@ Copyright (c) 2025 Oliver Soeser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Oliver Soeser, Michael Sammler
 -/
-module
+module -- shake: keep-all
 
-public import Iris.BI
-public import Iris.ProofMode.Tactics.HaveCore
+public import Iris.BI -- shake: keep
+public import Iris.ProofMode.Tactics.HaveCore -- shake: keep
 
 namespace Iris.ProofMode
 

--- a/Iris/Iris/ProofMode/Tactics/Apply.lean
+++ b/Iris/Iris/ProofMode/Tactics/Apply.lean
@@ -5,6 +5,7 @@ Authors: Oliver Soeser, Michael Sammler
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.BI -- shake: keep
 public import Iris.ProofMode.Tactics.HaveCore -- shake: keep
 

--- a/Iris/Iris/ProofMode/Tactics/Assumption.lean
+++ b/Iris/Iris/ProofMode/Tactics/Assumption.lean
@@ -3,10 +3,9 @@ Copyright (c) 2022 Lars König. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro, Michael Sammler
 -/
-module
+module -- shake: keep-all
 
-import Iris.BI
-public import Iris.ProofMode.Tactics.Basic
+public import Iris.ProofMode.Tactics.Basic -- shake: keep
 
 namespace Iris.ProofMode
 public section

--- a/Iris/Iris/ProofMode/Tactics/Assumption.lean
+++ b/Iris/Iris/ProofMode/Tactics/Assumption.lean
@@ -5,6 +5,7 @@ Authors: Lars König, Mario Carneiro, Michael Sammler
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode.Tactics.Basic -- shake: keep
 
 namespace Iris.ProofMode

--- a/Iris/Iris/ProofMode/Tactics/Basic.lean
+++ b/Iris/Iris/ProofMode/Tactics/Basic.lean
@@ -3,12 +3,12 @@ Copyright (c) 2022 Lars König. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro, Michael Sammler
 -/
-module
+module -- shake: keep-all
 
-public import Iris.ProofMode.Classes
-public import Iris.ProofMode.Expr
-public import Iris.ProofMode.SynthInstance
-public import Iris.ProofMode.ProofModeM
+public import Iris.ProofMode.Classes -- shake: keep
+public import Iris.ProofMode.Expr -- shake: keep
+public import Iris.ProofMode.SynthInstance -- shake: keep
+public import Iris.ProofMode.ProofModeM -- shake: keep
 
 public section
 

--- a/Iris/Iris/ProofMode/Tactics/Basic.lean
+++ b/Iris/Iris/ProofMode/Tactics/Basic.lean
@@ -5,6 +5,7 @@ Authors: Lars König, Mario Carneiro, Michael Sammler
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode.Classes -- shake: keep
 public import Iris.ProofMode.Expr -- shake: keep
 public import Iris.ProofMode.SynthInstance -- shake: keep

--- a/Iris/Iris/ProofMode/Tactics/Cases.lean
+++ b/Iris/Iris/ProofMode/Tactics/Cases.lean
@@ -3,14 +3,14 @@ Copyright (c) 2022 Lars König. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro, Michael Sammler, Yunsong Yang, Alvin Tang
 -/
-module
+module -- shake: keep-all
 
-public import Iris.ProofMode.Tactics.Mod
-public import Iris.ProofMode.Tactics.Pure
-public import Iris.ProofMode.Tactics.Clear
-public import Iris.ProofMode.Tactics.Basic
-public import Iris.ProofMode.Tactics.HaveCore
-public import Iris.ProofMode.Tactics.Frame
+public import Iris.ProofMode.Tactics.Mod -- shake: keep
+public import Iris.ProofMode.Tactics.Pure -- shake: keep
+public import Iris.ProofMode.Tactics.Clear -- shake: keep
+public import Iris.ProofMode.Tactics.Basic -- shake: keep
+public import Iris.ProofMode.Tactics.HaveCore -- shake: keep
+public import Iris.ProofMode.Tactics.Frame -- shake: keep
 
 namespace Iris.ProofMode
 

--- a/Iris/Iris/ProofMode/Tactics/Cases.lean
+++ b/Iris/Iris/ProofMode/Tactics/Cases.lean
@@ -5,6 +5,7 @@ Authors: Lars König, Mario Carneiro, Michael Sammler, Yunsong Yang, Alvin Tang
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode.Tactics.Mod -- shake: keep
 public import Iris.ProofMode.Tactics.Pure -- shake: keep
 public import Iris.ProofMode.Tactics.Clear -- shake: keep

--- a/Iris/Iris/ProofMode/Tactics/Clear.lean
+++ b/Iris/Iris/ProofMode/Tactics/Clear.lean
@@ -5,6 +5,7 @@ Authors: Lars König, Mario Carneiro, Michael Sammler, Yunsong Yang
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public meta import Iris.ProofMode.Patterns.SelPattern -- shake: keep
 public import Iris.ProofMode.Patterns.SelPattern
 

--- a/Iris/Iris/ProofMode/Tactics/Clear.lean
+++ b/Iris/Iris/ProofMode/Tactics/Clear.lean
@@ -3,10 +3,10 @@ Copyright (c) 2022 Lars König. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro, Michael Sammler, Yunsong Yang
 -/
-module
+module -- shake: keep-all
 
-import Iris.BI
-public meta import Iris.ProofMode.Patterns.SelPattern
+public meta import Iris.ProofMode.Patterns.SelPattern -- shake: keep
+public import Iris.ProofMode.Patterns.SelPattern
 
 namespace Iris.ProofMode
 

--- a/Iris/Iris/ProofMode/Tactics/Combine.lean
+++ b/Iris/Iris/ProofMode/Tactics/Combine.lean
@@ -5,6 +5,7 @@ Authors: Alvin Tang, Michael Sammler
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode.Tactics.Cases -- shake: keep
 public import Iris.ProofMode.ClassesMake -- shake: keep
 

--- a/Iris/Iris/ProofMode/Tactics/Combine.lean
+++ b/Iris/Iris/ProofMode/Tactics/Combine.lean
@@ -3,10 +3,10 @@ Copyright (c) 2026 Alvin Tang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alvin Tang, Michael Sammler
 -/
-module
+module -- shake: keep-all
 
-public import Iris.ProofMode.Tactics.Cases
-public import Iris.ProofMode.ClassesMake
+public import Iris.ProofMode.Tactics.Cases -- shake: keep
+public import Iris.ProofMode.ClassesMake -- shake: keep
 
 namespace Iris.ProofMode
 

--- a/Iris/Iris/ProofMode/Tactics/Eval.lean
+++ b/Iris/Iris/ProofMode/Tactics/Eval.lean
@@ -3,9 +3,10 @@ Copyright (c) 2026 Alvin Tang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler, Alvin Tang
 -/
-module
+module -- shake: keep-all
 
-public meta import Iris.ProofMode.Patterns.SelPattern
+public meta import Iris.ProofMode.Patterns.SelPattern -- shake: keep
+public import Iris.ProofMode.Patterns.SelPattern
 
 namespace Iris.ProofMode
 

--- a/Iris/Iris/ProofMode/Tactics/Eval.lean
+++ b/Iris/Iris/ProofMode/Tactics/Eval.lean
@@ -5,6 +5,7 @@ Authors: Michael Sammler, Alvin Tang
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public meta import Iris.ProofMode.Patterns.SelPattern -- shake: keep
 public import Iris.ProofMode.Patterns.SelPattern
 

--- a/Iris/Iris/ProofMode/Tactics/ExFalso.lean
+++ b/Iris/Iris/ProofMode/Tactics/ExFalso.lean
@@ -5,6 +5,7 @@ Authors: Lars König, Mario Carneiro, Michael Sammler
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode.Tactics.Basic -- shake: keep
 
 namespace Iris.ProofMode

--- a/Iris/Iris/ProofMode/Tactics/ExFalso.lean
+++ b/Iris/Iris/ProofMode/Tactics/ExFalso.lean
@@ -3,9 +3,9 @@ Copyright (c) 2022 Lars König. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro, Michael Sammler
 -/
-module
+module -- shake: keep-all
 
-public import Iris.ProofMode.Tactics.Basic
+public import Iris.ProofMode.Tactics.Basic -- shake: keep
 
 namespace Iris.ProofMode
 

--- a/Iris/Iris/ProofMode/Tactics/Exact.lean
+++ b/Iris/Iris/ProofMode/Tactics/Exact.lean
@@ -3,9 +3,9 @@ Copyright (c) 2022 Lars König. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro, Michael Sammler
 -/
-module
+module -- shake: keep-all
 
-public import Iris.ProofMode.Tactics.Assumption
+public import Iris.ProofMode.Tactics.Assumption -- shake: keep
 
 namespace Iris.ProofMode
 

--- a/Iris/Iris/ProofMode/Tactics/Exact.lean
+++ b/Iris/Iris/ProofMode/Tactics/Exact.lean
@@ -5,6 +5,7 @@ Authors: Lars König, Mario Carneiro, Michael Sammler
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode.Tactics.Assumption -- shake: keep
 
 namespace Iris.ProofMode

--- a/Iris/Iris/ProofMode/Tactics/Exists.lean
+++ b/Iris/Iris/ProofMode/Tactics/Exists.lean
@@ -3,11 +3,11 @@ Copyright (c) 2022 Lars König. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro, Michael Sammler
 -/
-module
+module -- shake: keep-all
 
-public import Iris.BI
-public import Iris.ProofMode.Classes
-public import Iris.ProofMode.ProofModeM
+public import Iris.BI -- shake: keep
+public import Iris.ProofMode.Classes -- shake: keep
+public import Iris.ProofMode.ProofModeM -- shake: keep
 
 namespace Iris.ProofMode
 

--- a/Iris/Iris/ProofMode/Tactics/Exists.lean
+++ b/Iris/Iris/ProofMode/Tactics/Exists.lean
@@ -5,6 +5,7 @@ Authors: Lars König, Mario Carneiro, Michael Sammler
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.BI -- shake: keep
 public import Iris.ProofMode.Classes -- shake: keep
 public import Iris.ProofMode.ProofModeM -- shake: keep

--- a/Iris/Iris/ProofMode/Tactics/Frame.lean
+++ b/Iris/Iris/ProofMode/Tactics/Frame.lean
@@ -5,6 +5,7 @@ Authors: Michael Sammler
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public meta import Iris.ProofMode.Patterns.SelPattern -- shake: keep
 public import Iris.ProofMode.Patterns.SelPattern
 

--- a/Iris/Iris/ProofMode/Tactics/Frame.lean
+++ b/Iris/Iris/ProofMode/Tactics/Frame.lean
@@ -3,11 +3,10 @@ Copyright (c) 2026 Michael Sammler. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler
 -/
-module
+module -- shake: keep-all
 
-import Iris.BI
-import Iris.ProofMode.Classes
-public meta import Iris.ProofMode.Patterns.SelPattern
+public meta import Iris.ProofMode.Patterns.SelPattern -- shake: keep
+public import Iris.ProofMode.Patterns.SelPattern
 
 namespace Iris.ProofMode
 

--- a/Iris/Iris/ProofMode/Tactics/Have.lean
+++ b/Iris/Iris/ProofMode/Tactics/Have.lean
@@ -5,6 +5,7 @@ Authors: Michael Sammler
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public meta import Iris.ProofMode.Tactics.Cases -- shake: keep
 public import Iris.ProofMode.Tactics.Cases
 

--- a/Iris/Iris/ProofMode/Tactics/Have.lean
+++ b/Iris/Iris/ProofMode/Tactics/Have.lean
@@ -3,10 +3,10 @@ Copyright (c) 2025 Michael Sammler. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler
 -/
-module
+module -- shake: keep-all
 
-import Iris.BI
-public meta import Iris.ProofMode.Tactics.Cases
+public meta import Iris.ProofMode.Tactics.Cases -- shake: keep
+public import Iris.ProofMode.Tactics.Cases
 
 namespace Iris.ProofMode
 

--- a/Iris/Iris/ProofMode/Tactics/HaveCore.lean
+++ b/Iris/Iris/ProofMode/Tactics/HaveCore.lean
@@ -5,6 +5,7 @@ Authors: Michael Sammler, Zongyuan Liu
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public meta import Iris.ProofMode.Patterns.SpecPattern -- shake: keep
 public meta import Iris.ProofMode.Tactics.Specialize -- shake: keep
 public import Iris.ProofMode.Tactics.Specialize

--- a/Iris/Iris/ProofMode/Tactics/HaveCore.lean
+++ b/Iris/Iris/ProofMode/Tactics/HaveCore.lean
@@ -3,12 +3,11 @@ Copyright (c) 2025 Michael Sammler. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler, Zongyuan Liu
 -/
-module
+module -- shake: keep-all
 
-import Iris.BI
-import Iris.ProofMode.Classes
-public meta import Iris.ProofMode.Patterns.SpecPattern
-public meta import Iris.ProofMode.Tactics.Specialize
+public meta import Iris.ProofMode.Patterns.SpecPattern -- shake: keep
+public meta import Iris.ProofMode.Tactics.Specialize -- shake: keep
+public import Iris.ProofMode.Tactics.Specialize
 
 /-
   This file contains the `iHave` function for asserting a ProofModeTerm.

--- a/Iris/Iris/ProofMode/Tactics/Induction.lean
+++ b/Iris/Iris/ProofMode/Tactics/Induction.lean
@@ -3,9 +3,11 @@ Copyright (c) 2026 Yunsong Yang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yunsong Yang, Michael Sammler, Alvin Tang
 -/
-module
+module -- shake: keep-all
 
-public import Iris.ProofMode.Tactics.RevertIntro
+public import Iris.ProofMode.Tactics.RevertIntro -- shake: keep
+public meta import Lean.Meta.Tactic.ElimInfo -- shake: keep
+public meta import Lean.Meta.Tactic.Generalize -- shake: keep
 
 namespace Iris.ProofMode
 

--- a/Iris/Iris/ProofMode/Tactics/Induction.lean
+++ b/Iris/Iris/ProofMode/Tactics/Induction.lean
@@ -5,6 +5,7 @@ Authors: Yunsong Yang, Michael Sammler, Alvin Tang
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode.Tactics.RevertIntro -- shake: keep
 public meta import Lean.Meta.Tactic.ElimInfo -- shake: keep
 public meta import Lean.Meta.Tactic.Generalize -- shake: keep

--- a/Iris/Iris/ProofMode/Tactics/Intro.lean
+++ b/Iris/Iris/ProofMode/Tactics/Intro.lean
@@ -3,13 +3,15 @@ Copyright (c) 2022 Lars König. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro, Michael Sammler, Alvin Tang
 -/
-module
+module -- shake: keep-all
 
-public meta import Iris.ProofMode.Patterns.IntroPattern
-public import Iris.ProofMode.Tactics.Cases
-public import Iris.ProofMode.Tactics.Pure
-public import Iris.ProofMode.Tactics.ModIntro
-public import Iris.ProofMode.Tactics.Trivial
+public meta import Iris.ProofMode.Patterns.IntroPattern -- shake: keep
+public import Iris.ProofMode.Tactics.Cases -- shake: keep
+public import Iris.ProofMode.Tactics.Pure -- shake: keep
+public import Iris.ProofMode.Tactics.ModIntro -- shake: keep
+public import Iris.ProofMode.Tactics.Trivial -- shake: keep
+public import Iris.ProofMode.Patterns.IntroPattern
+public meta import Lean.Meta.Tactic.Simp.Main
 
 namespace Iris.ProofMode
 

--- a/Iris/Iris/ProofMode/Tactics/Intro.lean
+++ b/Iris/Iris/ProofMode/Tactics/Intro.lean
@@ -5,6 +5,7 @@ Authors: Lars König, Mario Carneiro, Michael Sammler, Alvin Tang
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public meta import Iris.ProofMode.Patterns.IntroPattern -- shake: keep
 public import Iris.ProofMode.Tactics.Cases -- shake: keep
 public import Iris.ProofMode.Tactics.Pure -- shake: keep

--- a/Iris/Iris/ProofMode/Tactics/Inv.lean
+++ b/Iris/Iris/ProofMode/Tactics/Inv.lean
@@ -3,9 +3,10 @@ Copyright (c) 2026 Alvin Tang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler, Alvin Tang
 -/
-module
+module -- shake: keep-all
 
-public import Iris.ProofMode.Tactics.Cases
+public import Iris.ProofMode.Tactics.Cases -- shake: keep
+public meta import Lean.Meta.Tactic.Simp.Main -- shake: keep
 
 namespace Iris.ProofMode
 

--- a/Iris/Iris/ProofMode/Tactics/Inv.lean
+++ b/Iris/Iris/ProofMode/Tactics/Inv.lean
@@ -5,6 +5,7 @@ Authors: Michael Sammler, Alvin Tang
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode.Tactics.Cases -- shake: keep
 public meta import Lean.Meta.Tactic.Simp.Main -- shake: keep
 

--- a/Iris/Iris/ProofMode/Tactics/LeftRight.lean
+++ b/Iris/Iris/ProofMode/Tactics/LeftRight.lean
@@ -3,11 +3,9 @@ Copyright (c) 2022 Lars König. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro, Michael Sammler
 -/
-module
+module -- shake: keep-all
 
-import Iris.BI
-import Iris.ProofMode.Classes
-public import Iris.ProofMode.ProofModeM
+public import Iris.ProofMode.ProofModeM -- shake: keep
 
 namespace Iris.ProofMode
 

--- a/Iris/Iris/ProofMode/Tactics/LeftRight.lean
+++ b/Iris/Iris/ProofMode/Tactics/LeftRight.lean
@@ -5,6 +5,7 @@ Authors: Lars König, Mario Carneiro, Michael Sammler
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode.ProofModeM -- shake: keep
 
 namespace Iris.ProofMode

--- a/Iris/Iris/ProofMode/Tactics/Loeb.lean
+++ b/Iris/Iris/ProofMode/Tactics/Loeb.lean
@@ -5,6 +5,7 @@ Authors: Fernando Leal
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode.Tactics.Revert -- shake: keep
 public import Iris.ProofMode.Tactics.RevertIntro -- shake: keep
 

--- a/Iris/Iris/ProofMode/Tactics/Loeb.lean
+++ b/Iris/Iris/ProofMode/Tactics/Loeb.lean
@@ -3,10 +3,10 @@ Copyright (c) 2026 Fernando Leal. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Fernando Leal
 -/
-module
+module -- shake: keep-all
 
-public import Iris.ProofMode.Tactics.Revert
-public import Iris.ProofMode.Tactics.RevertIntro
+public import Iris.ProofMode.Tactics.Revert -- shake: keep
+public import Iris.ProofMode.Tactics.RevertIntro -- shake: keep
 
 namespace Iris.ProofMode
 

--- a/Iris/Iris/ProofMode/Tactics/Mod.lean
+++ b/Iris/Iris/ProofMode/Tactics/Mod.lean
@@ -5,6 +5,7 @@ Authors: Michael Sammler
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode.Classes -- shake: keep
 public import Iris.ProofMode.Tactics.Basic -- shake: keep
 

--- a/Iris/Iris/ProofMode/Tactics/Mod.lean
+++ b/Iris/Iris/ProofMode/Tactics/Mod.lean
@@ -3,11 +3,10 @@ Copyright (c) 2026 Michael Sammler. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler
 -/
-module
+module -- shake: keep-all
 
-import Iris.BI
-public import Iris.ProofMode.Classes
-public import Iris.ProofMode.Tactics.Basic
+public import Iris.ProofMode.Classes -- shake: keep
+public import Iris.ProofMode.Tactics.Basic -- shake: keep
 
 namespace Iris.ProofMode
 

--- a/Iris/Iris/ProofMode/Tactics/ModIntro.lean
+++ b/Iris/Iris/ProofMode/Tactics/ModIntro.lean
@@ -5,9 +5,9 @@ Authors: Michael Sammler
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public meta import Iris.ProofMode.Tactics.Basic -- shake: keep
 public import Iris.ProofMode.Tactics.Basic
-import Std.Do.Triple.SpecLemmas
 
 namespace Iris.ProofMode
 

--- a/Iris/Iris/ProofMode/Tactics/ModIntro.lean
+++ b/Iris/Iris/ProofMode/Tactics/ModIntro.lean
@@ -3,10 +3,11 @@ Copyright (c) 2026 Michael Sammler. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler
 -/
-module
+module -- shake: keep-all
 
-import Iris.ProofMode.Modalities
-public meta import Iris.ProofMode.Tactics.Basic
+public meta import Iris.ProofMode.Tactics.Basic -- shake: keep
+public import Iris.ProofMode.Tactics.Basic
+import Std.Do.Triple.SpecLemmas
 
 namespace Iris.ProofMode
 

--- a/Iris/Iris/ProofMode/Tactics/Pure.lean
+++ b/Iris/Iris/ProofMode/Tactics/Pure.lean
@@ -3,9 +3,11 @@ Copyright (c) 2022 Lars König. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro, Michael Sammler
 -/
-module
+module -- shake: keep-all
 
-public import Iris.ProofMode.Tactics.Basic
+public import Iris.ProofMode.Tactics.Basic -- shake: keep
+public meta import Lean.Elab.Tactic.RCases
+import Lean.Elab.Tactic.RCases
 
 namespace Iris.ProofMode
 

--- a/Iris/Iris/ProofMode/Tactics/Pure.lean
+++ b/Iris/Iris/ProofMode/Tactics/Pure.lean
@@ -5,9 +5,9 @@ Authors: Lars König, Mario Carneiro, Michael Sammler
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode.Tactics.Basic -- shake: keep
 public meta import Lean.Elab.Tactic.RCases
-import Lean.Elab.Tactic.RCases
 
 namespace Iris.ProofMode
 

--- a/Iris/Iris/ProofMode/Tactics/Rename.lean
+++ b/Iris/Iris/ProofMode/Tactics/Rename.lean
@@ -5,6 +5,7 @@ Authors: Lars König, Mario Carneiro, Michael Sammler
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode.Tactics.Basic -- shake: keep
 
 namespace Iris.ProofMode

--- a/Iris/Iris/ProofMode/Tactics/Rename.lean
+++ b/Iris/Iris/ProofMode/Tactics/Rename.lean
@@ -3,9 +3,9 @@ Copyright (c) 2022 Lars König. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro, Michael Sammler
 -/
-module
+module -- shake: keep-all
 
-public import Iris.ProofMode.Tactics.Basic
+public import Iris.ProofMode.Tactics.Basic -- shake: keep
 
 namespace Iris.ProofMode
 

--- a/Iris/Iris/ProofMode/Tactics/Revert.lean
+++ b/Iris/Iris/ProofMode/Tactics/Revert.lean
@@ -5,6 +5,7 @@ Authors: Oliver Soeser, Yunsong Yang
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode.ClassesMake -- shake: keep
 public meta import Iris.ProofMode.Patterns.SelPattern -- shake: keep
 public import Iris.ProofMode.Patterns.SelPattern

--- a/Iris/Iris/ProofMode/Tactics/Revert.lean
+++ b/Iris/Iris/ProofMode/Tactics/Revert.lean
@@ -3,10 +3,12 @@ Copyright (c) 2025 Oliver Soeser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Oliver Soeser, Yunsong Yang
 -/
-module
+module -- shake: keep-all
 
-public import Iris.ProofMode.ClassesMake
-public meta import Iris.ProofMode.Patterns.SelPattern
+public import Iris.ProofMode.ClassesMake -- shake: keep
+public meta import Iris.ProofMode.Patterns.SelPattern -- shake: keep
+public import Iris.ProofMode.Patterns.SelPattern
+public meta import Lean.Meta.Tactic.TryThis
 
 namespace Iris.ProofMode
 

--- a/Iris/Iris/ProofMode/Tactics/RevertIntro.lean
+++ b/Iris/Iris/ProofMode/Tactics/RevertIntro.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Fernando Leal
 -/
 module -- shake: keep-all
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode.Tactics.Intro -- shake: keep
 public import Iris.ProofMode.Tactics.Revert -- shake: keep
 

--- a/Iris/Iris/ProofMode/Tactics/RevertIntro.lean
+++ b/Iris/Iris/ProofMode/Tactics/RevertIntro.lean
@@ -3,9 +3,9 @@ Copyright (c) 2026 Fernando Leal. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Fernando Leal
 -/
-module
-public import Iris.ProofMode.Tactics.Intro
-public import Iris.ProofMode.Tactics.Revert
+module -- shake: keep-all
+public import Iris.ProofMode.Tactics.Intro -- shake: keep
+public import Iris.ProofMode.Tactics.Revert -- shake: keep
 
 namespace Iris.ProofMode
 

--- a/Iris/Iris/ProofMode/Tactics/Rewrite.lean
+++ b/Iris/Iris/ProofMode/Tactics/Rewrite.lean
@@ -2,10 +2,12 @@
 Copyright (c) 2026 Sergei Stepanenko. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-module
+module -- shake: keep-all
 
-import Iris.BI
-public import Iris.ProofMode.Tactics.HaveCore
+public import Iris.ProofMode.Tactics.HaveCore -- shake: keep
+public meta import Lean.Elab.ConfigEval.MetaInstances -- shake: keep
+public meta import Lean.Elab.ConfigEval.DeriveEvalExpr -- shake: keep
+import Lean.Elab.ConfigEval.Commands
 
 namespace Iris.ProofMode
 

--- a/Iris/Iris/ProofMode/Tactics/Rewrite.lean
+++ b/Iris/Iris/ProofMode/Tactics/Rewrite.lean
@@ -4,10 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode.Tactics.HaveCore -- shake: keep
 public meta import Lean.Elab.ConfigEval.MetaInstances -- shake: keep
 public meta import Lean.Elab.ConfigEval.DeriveEvalExpr -- shake: keep
-import Lean.Elab.ConfigEval.Commands
 
 namespace Iris.ProofMode
 

--- a/Iris/Iris/ProofMode/Tactics/Specialize.lean
+++ b/Iris/Iris/ProofMode/Tactics/Specialize.lean
@@ -3,12 +3,14 @@ Copyright (c) 2022 Lars König. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro, Michael Sammler, Alvin Tang
 -/
-module
+module -- shake: keep-all
 
-public meta import Iris.ProofMode.Patterns.SpecPattern
-public import Iris.ProofMode.Patterns.CasesPattern
-public import Iris.ProofMode.Tactics.Trivial
-public import Iris.ProofMode.Tactics.Frame
+public meta import Iris.ProofMode.Patterns.SpecPattern -- shake: keep
+public import Iris.ProofMode.Patterns.CasesPattern -- shake: keep
+public import Iris.ProofMode.Tactics.Trivial -- shake: keep
+public import Iris.ProofMode.Tactics.Frame -- shake: keep
+public meta import Iris.ProofMode.Patterns.CasesPattern
+public import Iris.ProofMode.Patterns.SpecPattern
 
 namespace Iris.ProofMode
 

--- a/Iris/Iris/ProofMode/Tactics/Specialize.lean
+++ b/Iris/Iris/ProofMode/Tactics/Specialize.lean
@@ -5,6 +5,7 @@ Authors: Lars König, Mario Carneiro, Michael Sammler, Alvin Tang
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public meta import Iris.ProofMode.Patterns.SpecPattern -- shake: keep
 public import Iris.ProofMode.Patterns.CasesPattern -- shake: keep
 public import Iris.ProofMode.Tactics.Trivial -- shake: keep

--- a/Iris/Iris/ProofMode/Tactics/Split.lean
+++ b/Iris/Iris/ProofMode/Tactics/Split.lean
@@ -3,11 +3,9 @@ Copyright (c) 2022 Lars König. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro, Michael Sammler
 -/
-module
+module -- shake: keep-all
 
-import Iris.BI
-import Iris.ProofMode.Classes
-public import Iris.ProofMode.ProofModeM
+public import Iris.ProofMode.ProofModeM -- shake: keep
 
 namespace Iris.ProofMode
 

--- a/Iris/Iris/ProofMode/Tactics/Split.lean
+++ b/Iris/Iris/ProofMode/Tactics/Split.lean
@@ -5,6 +5,7 @@ Authors: Lars König, Mario Carneiro, Michael Sammler
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode.ProofModeM -- shake: keep
 
 namespace Iris.ProofMode

--- a/Iris/Iris/ProofMode/Tactics/Trivial.lean
+++ b/Iris/Iris/ProofMode/Tactics/Trivial.lean
@@ -5,6 +5,7 @@ Authors: Michael Sammler
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode.Classes -- shake: keep
 public import Iris.ProofMode.Tactics.Basic -- shake: keep
 

--- a/Iris/Iris/ProofMode/Tactics/Trivial.lean
+++ b/Iris/Iris/ProofMode/Tactics/Trivial.lean
@@ -3,11 +3,10 @@ Copyright (c) 2026 Michael Sammler. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler
 -/
-module
+module -- shake: keep-all
 
-import Iris.BI
-public import Iris.ProofMode.Classes
-public import Iris.ProofMode.Tactics.Basic
+public import Iris.ProofMode.Classes -- shake: keep
+public import Iris.ProofMode.Tactics.Basic -- shake: keep
 
 namespace Iris.ProofMode
 

--- a/Iris/Iris/ProofMode/UnifHints.lean
+++ b/Iris/Iris/ProofMode/UnifHints.lean
@@ -3,9 +3,10 @@ Copyright (c) 2022 Lars König. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König
 -/
-module
+module -- shake: keep-all
 
-public import Iris.BI
+public import Iris.BI -- shake: keep
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/ProofMode/UnifHints.lean
+++ b/Iris/Iris/ProofMode/UnifHints.lean
@@ -5,8 +5,8 @@ Authors: Lars König
 -/
 module -- shake: keep-all
 
+public import Iris.Init -- shake: keep
 public import Iris.BI -- shake: keep
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Std.lean
+++ b/Iris/Iris/Std.lean
@@ -1,5 +1,6 @@
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Std.BigOp
 public import Iris.Std.BitOp
 public import Iris.Std.Classes
@@ -24,7 +25,6 @@ public import Iris.Std.Prod
 public import Iris.Std.Qq
 public import Iris.Std.Relation
 public import Iris.Std.Rewrite
-public import Iris.Std.RocqPorting
 public import Iris.Std.Set
 public import Iris.Std.Tactic
 public import Iris.Std.TC

--- a/Iris/Iris/Std/BigOp.lean
+++ b/Iris/Iris/Std/BigOp.lean
@@ -5,7 +5,8 @@ Authors: Lars König, Mario Carneiro
 -/
 module
 
-public import Iris.Init
+public import Iris.Init -- shake: keep
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Std/BigOp.lean
+++ b/Iris/Iris/Std/BigOp.lean
@@ -6,7 +6,6 @@ Authors: Lars König, Mario Carneiro
 module
 
 public import Iris.Init -- shake: keep
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Std/BitOp.lean
+++ b/Iris/Iris/Std/BitOp.lean
@@ -1,9 +1,8 @@
 module
 
-public import Batteries.Data.Int
-public import Batteries.Data.Nat.Bitwise
 import all Init.Data.Nat.Bitwise.Basic
-public import Iris.Init
+public import Iris.Init -- shake: keep
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Std/BitOp.lean
+++ b/Iris/Iris/Std/BitOp.lean
@@ -1,8 +1,9 @@
 module
 
-import all Init.Data.Nat.Bitwise.Basic
 public import Iris.Init -- shake: keep
-import Iris.Std.RocqPorting
+import all Init.Data.Nat.Bitwise.Basic
+public import Batteries.Data.Int -- shake: keep
+public import Batteries.Data.Nat.Bitwise -- shake: keep
 
 @[expose] public section
 

--- a/Iris/Iris/Std/Classes.lean
+++ b/Iris/Iris/Std/Classes.lean
@@ -5,7 +5,8 @@ Authors: Lars König
 -/
 module
 
-public import Iris.Init
+public import Iris.Init -- shake: keep
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Std/Classes.lean
+++ b/Iris/Iris/Std/Classes.lean
@@ -6,7 +6,6 @@ Authors: Lars König
 module
 
 public import Iris.Init -- shake: keep
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Std/CoPset.lean
+++ b/Iris/Iris/Std/CoPset.lean
@@ -6,9 +6,9 @@ Authors: Remy Seassau, Markus de Medeiros, Sergei Stepanenko
 module
 
 public import Iris.Std.Positives
-public import Iris.Std.Classes
 public import Iris.Std.GenSets
-import Iris.Std.List
+import Iris.Std.RocqPorting
+import Std.Data.DTreeMap.Internal.Operations
 
 @[expose] public section
 

--- a/Iris/Iris/Std/CoPset.lean
+++ b/Iris/Iris/Std/CoPset.lean
@@ -5,9 +5,9 @@ Authors: Remy Seassau, Markus de Medeiros, Sergei Stepanenko
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Std.Positives
 public import Iris.Std.GenSets
-import Iris.Std.RocqPorting
 import Std.Data.DTreeMap.Internal.Operations
 
 @[expose] public section

--- a/Iris/Iris/Std/DelabRule.lean
+++ b/Iris/Iris/Std/DelabRule.lean
@@ -6,7 +6,8 @@ Authors: Lars König
 module
 
 public import Iris.Init -- shake: keep
-import Iris.Std.RocqPorting
+public import Lean.PrettyPrinter.Delaborator -- shake: keep
+public import Lean.Parser.Term -- shake: keep
 
 public meta section
 

--- a/Iris/Iris/Std/DelabRule.lean
+++ b/Iris/Iris/Std/DelabRule.lean
@@ -5,9 +5,8 @@ Authors: Lars König
 -/
 module
 
-public import Lean.PrettyPrinter.Delaborator
-public import Lean.Parser.Term
-public import Iris.Init
+public import Iris.Init -- shake: keep
+import Iris.Std.RocqPorting
 
 public meta section
 

--- a/Iris/Iris/Std/Equivalence.lean
+++ b/Iris/Iris/Std/Equivalence.lean
@@ -5,7 +5,8 @@ Authors: Mario Carneiro
 -/
 module
 
-public import Iris.Init
+public import Iris.Init -- shake: keep
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Std/Equivalence.lean
+++ b/Iris/Iris/Std/Equivalence.lean
@@ -6,7 +6,6 @@ Authors: Mario Carneiro
 module
 
 public import Iris.Init -- shake: keep
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Std/Expr.lean
+++ b/Iris/Iris/Std/Expr.lean
@@ -6,8 +6,7 @@ Authors: Lars König
 module
 
 public import Iris.Init -- shake: keep
-public import Lean.Expr
-import Iris.Std.RocqPorting
+public import Lean.Meta -- shake: keep
 
 @[expose] public section
 

--- a/Iris/Iris/Std/Expr.lean
+++ b/Iris/Iris/Std/Expr.lean
@@ -5,8 +5,9 @@ Authors: Lars König
 -/
 module
 
-public import Lean.Meta
-public import Iris.Init
+public import Iris.Init -- shake: keep
+public import Lean.Expr
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Std/FromMathlib.lean
+++ b/Iris/Iris/Std/FromMathlib.lean
@@ -5,7 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Batteries.Data.List.Basic
-public import Iris.Init
+public import Iris.Init -- shake: keep
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Std/FromMathlib.lean
+++ b/Iris/Iris/Std/FromMathlib.lean
@@ -4,9 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Batteries.Data.List.Basic
 public import Iris.Init -- shake: keep
-import Iris.Std.RocqPorting
+public import Batteries.Data.List.Basic
 
 @[expose] public section
 

--- a/Iris/Iris/Std/GenMultiSets.lean
+++ b/Iris/Iris/Std/GenMultiSets.lean
@@ -5,8 +5,9 @@ Authors: Haokun Li, Markus de Medeiros
 -/
 module
 
-public import Iris.Std.GenSets
-public import Batteries.Data.List.Perm
+public import Batteries.Data.List.Perm -- shake: keep
+import Iris.Init -- shake: keep
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Std/GenMultiSets.lean
+++ b/Iris/Iris/Std/GenMultiSets.lean
@@ -5,9 +5,9 @@ Authors: Haokun Li, Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Batteries.Data.List.Perm -- shake: keep
-import Iris.Init -- shake: keep
-import Iris.Std.RocqPorting
+public import Iris.Std.GenSets -- shake: keep
 
 @[expose] public section
 

--- a/Iris/Iris/Std/GenMultiSetsInstances.lean
+++ b/Iris/Iris/Std/GenMultiSetsInstances.lean
@@ -6,6 +6,8 @@ Authors: Haokun Li
 module
 
 public import Iris.Std.GenMultiSets
+import Iris.Init -- shake: keep
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Std/GenMultiSetsInstances.lean
+++ b/Iris/Iris/Std/GenMultiSetsInstances.lean
@@ -5,9 +5,8 @@ Authors: Haokun Li
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Std.GenMultiSets
-import Iris.Init -- shake: keep
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Std/GenSets.lean
+++ b/Iris/Iris/Std/GenSets.lean
@@ -5,11 +5,11 @@ Authors: Zongyuan Liu, Sergei Stepanenko
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Std.Classes
 public import Iris.Std.Infinite
 import Batteries.Data.List.Perm
 import Iris.Std.List
-import Iris.Std.RocqPorting
 import Std.Data.DTreeMap.Internal.Operations
 
 @[expose] public section

--- a/Iris/Iris/Std/GenSets.lean
+++ b/Iris/Iris/Std/GenSets.lean
@@ -9,6 +9,8 @@ public import Iris.Std.Classes
 public import Iris.Std.Infinite
 import Batteries.Data.List.Perm
 import Iris.Std.List
+import Iris.Std.RocqPorting
+import Std.Data.DTreeMap.Internal.Operations
 
 @[expose] public section
 

--- a/Iris/Iris/Std/GenSetsInstances.lean
+++ b/Iris/Iris/Std/GenSetsInstances.lean
@@ -5,9 +5,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 
 module
 
-public import Iris.Std.GenSets
-public import Std.Data.ExtTreeSet.Lemmas
-import Iris.Std.RocqPorting
+public import Iris.Init -- shake: keep
+public import Std.Data.ExtTreeSet -- shake: keep
+public import Iris.Std.CoPset -- shake: keep
 
 @[expose] public section
 

--- a/Iris/Iris/Std/GenSetsInstances.lean
+++ b/Iris/Iris/Std/GenSetsInstances.lean
@@ -5,8 +5,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 
 module
 
-public import Std.Data.ExtTreeSet
-public import Iris.Std.CoPset
+public import Iris.Std.GenSets
+public import Std.Data.ExtTreeSet.Lemmas
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Std/HeapInstances.lean
+++ b/Iris/Iris/Std/HeapInstances.lean
@@ -6,8 +6,10 @@ Authors: Alok Singh, Markus de Medeiros
 module
 
 public import Iris.Std.PartialMap
-public import Std.Data.TreeMap
-public import Std.Data.ExtTreeMap
+public import Std.Data.TreeMap -- shake: keep
+public import Std.Data.ExtTreeMap -- shake: keep
+import Batteries.Data.List.Lemmas
+import Iris.Std.RocqPorting
 
 /-!
 # Heap Instances for Standard Types

--- a/Iris/Iris/Std/HeapInstances.lean
+++ b/Iris/Iris/Std/HeapInstances.lean
@@ -5,11 +5,11 @@ Authors: Alok Singh, Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Std.PartialMap
 public import Std.Data.TreeMap -- shake: keep
 public import Std.Data.ExtTreeMap -- shake: keep
 import Batteries.Data.List.Lemmas
-import Iris.Std.RocqPorting
 
 /-!
 # Heap Instances for Standard Types

--- a/Iris/Iris/Std/Infinite.lean
+++ b/Iris/Iris/Std/Infinite.lean
@@ -5,8 +5,9 @@ Authors: Markus de Medeiros
 -/
 module
 
-public import Iris.Std.List
 import Batteries.Data.List.Perm
+import Iris.Std.List
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Std/Infinite.lean
+++ b/Iris/Iris/Std/Infinite.lean
@@ -5,9 +5,9 @@ Authors: Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 import Batteries.Data.List.Perm
 import Iris.Std.List
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Std/List.lean
+++ b/Iris/Iris/Std/List.lean
@@ -5,11 +5,12 @@ Authors: Zongyuan Liu, Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Std.Option
-public import Batteries.Data.List.Basic
 import Batteries.Data.List.Lemmas
-import Iris.Std.RocqPorting
 import Std.Data.DTreeMap.Internal.Operations
+public import Iris.Std.FromMathlib -- shake: keep
+public import Iris.Std.Classes -- shake: keep
 
 /-! # List Lemmas -/
 

--- a/Iris/Iris/Std/List.lean
+++ b/Iris/Iris/Std/List.lean
@@ -5,11 +5,11 @@ Authors: Zongyuan Liu, Markus de Medeiros
 -/
 module
 
-public import Iris.Std.FromMathlib
-public import Iris.Std.Classes
 public import Iris.Std.Option
-import Batteries.Data.List.Basic
-import Batteries.Data.List.Perm
+public import Batteries.Data.List.Basic
+import Batteries.Data.List.Lemmas
+import Iris.Std.RocqPorting
+import Std.Data.DTreeMap.Internal.Operations
 
 /-! # List Lemmas -/
 

--- a/Iris/Iris/Std/Namespaces.lean
+++ b/Iris/Iris/Std/Namespaces.lean
@@ -6,8 +6,8 @@ Authors: Remy Seassau, Markus de Medeiros, Sergei Stepanenko
 module
 
 public import Iris.Std.CoPset
-public import Iris.Std.Positives
-public import Iris.Std.GenSets
+import Iris.Std.RocqPorting
+import Std.Data.DTreeMap.Internal.Operations
 
 @[expose] public section
 

--- a/Iris/Iris/Std/Namespaces.lean
+++ b/Iris/Iris/Std/Namespaces.lean
@@ -5,8 +5,8 @@ Authors: Remy Seassau, Markus de Medeiros, Sergei Stepanenko
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Std.CoPset
-import Iris.Std.RocqPorting
 import Std.Data.DTreeMap.Internal.Operations
 
 @[expose] public section

--- a/Iris/Iris/Std/Nat.lean
+++ b/Iris/Iris/Std/Nat.lean
@@ -6,7 +6,6 @@ Authors: Markus de Medeiros
 module
 
 public import Iris.Init -- shake: keep
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Std/Nat.lean
+++ b/Iris/Iris/Std/Nat.lean
@@ -5,7 +5,8 @@ Authors: Markus de Medeiros
 -/
 module
 
-public import Iris.Init
+public import Iris.Init -- shake: keep
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Std/Option.lean
+++ b/Iris/Iris/Std/Option.lean
@@ -7,7 +7,6 @@ Authors: Markus de Medeiros
 module
 
 public import Iris.Init -- shake: keep
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Std/Option.lean
+++ b/Iris/Iris/Std/Option.lean
@@ -6,7 +6,8 @@ Authors: Markus de Medeiros
 
 module
 
-public import Iris.Init
+public import Iris.Init -- shake: keep
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Std/PartialMap.lean
+++ b/Iris/Iris/Std/PartialMap.lean
@@ -5,10 +5,10 @@ Authors: Zongyuan Liu, Markus de Medeiros
 -/
 module
 
+public import Iris.Init -- shake: keep
 import Batteries.Data.List.Perm
 import Iris.Std.FromMathlib
 public import Iris.Std.GenSets
-import Iris.Std.RocqPorting
 import Std.Data.DTreeMap.Internal.Operations
 
 /-! ## Partial Maps

--- a/Iris/Iris/Std/PartialMap.lean
+++ b/Iris/Iris/Std/PartialMap.lean
@@ -8,6 +8,8 @@ module
 import Batteries.Data.List.Perm
 import Iris.Std.FromMathlib
 public import Iris.Std.GenSets
+import Iris.Std.RocqPorting
+import Std.Data.DTreeMap.Internal.Operations
 
 /-! ## Partial Maps
 

--- a/Iris/Iris/Std/Positives.lean
+++ b/Iris/Iris/Std/Positives.lean
@@ -5,9 +5,8 @@ Authors: Remy Seassau, Markus de Medeiros, Sergei Stepanenko
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Std.Infinite
-import Iris.Init -- shake: keep
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Std/Positives.lean
+++ b/Iris/Iris/Std/Positives.lean
@@ -6,6 +6,8 @@ Authors: Remy Seassau, Markus de Medeiros, Sergei Stepanenko
 module
 
 public import Iris.Std.Infinite
+import Iris.Init -- shake: keep
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Std/Prod.lean
+++ b/Iris/Iris/Std/Prod.lean
@@ -5,7 +5,8 @@ Authors: Lars König
 -/
 module
 
-public import Iris.Init
+public import Iris.Init -- shake: keep
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Std/Prod.lean
+++ b/Iris/Iris/Std/Prod.lean
@@ -6,7 +6,6 @@ Authors: Lars König
 module
 
 public import Iris.Init -- shake: keep
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Std/Qq.lean
+++ b/Iris/Iris/Std/Qq.lean
@@ -5,8 +5,9 @@ Authors: Mario Carneiro
 -/
 module
 
-public import Qq
-public import Iris.Init
+public import Iris.Init -- shake: keep
+public import Qq.MetaM
+import Iris.Std.RocqPorting
 
 @[expose] public section
 open Qq Lean

--- a/Iris/Iris/Std/Qq.lean
+++ b/Iris/Iris/Std/Qq.lean
@@ -6,8 +6,7 @@ Authors: Mario Carneiro
 module
 
 public import Iris.Init -- shake: keep
-public import Qq.MetaM
-import Iris.Std.RocqPorting
+public import Qq -- shake: keep
 
 @[expose] public section
 open Qq Lean

--- a/Iris/Iris/Std/Relation.lean
+++ b/Iris/Iris/Std/Relation.lean
@@ -1,6 +1,7 @@
 module
 
 public import Iris.Std.FromMathlib
+import Iris.Std.RocqPorting
 
 open FromMathlib
 

--- a/Iris/Iris/Std/Relation.lean
+++ b/Iris/Iris/Std/Relation.lean
@@ -1,7 +1,7 @@
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Std.FromMathlib
-import Iris.Std.RocqPorting
 
 open FromMathlib
 

--- a/Iris/Iris/Std/Rewrite.lean
+++ b/Iris/Iris/Std/Rewrite.lean
@@ -5,7 +5,9 @@ Authors: Lars König
 -/
 module
 
-public import Iris.Std.Tactic
+public import Iris.Std.Tactic -- shake: keep
+import Iris.Std.RocqPorting
+import Lean.Attributes
 
 public meta section
 

--- a/Iris/Iris/Std/Rewrite.lean
+++ b/Iris/Iris/Std/Rewrite.lean
@@ -5,9 +5,8 @@ Authors: Lars König
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.Std.Tactic -- shake: keep
-import Iris.Std.RocqPorting
-import Lean.Attributes
 
 public meta section
 

--- a/Iris/Iris/Std/RocqPorting.lean
+++ b/Iris/Iris/Std/RocqPorting.lean
@@ -3,7 +3,7 @@ Copyright (c) 2025. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros, Zongyuan Liu
 -/
-module
+module -- shake: keep-downstream
 
 import Lean.Elab.DeclarationRange
 public meta import Lean.Elab.Command

--- a/Iris/Iris/Std/Set.lean
+++ b/Iris/Iris/Std/Set.lean
@@ -6,7 +6,6 @@ Authors: Markus de Medeiros
 module
 
 public import Iris.Init -- shake: keep
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Std/Set.lean
+++ b/Iris/Iris/Std/Set.lean
@@ -5,7 +5,8 @@ Authors: Markus de Medeiros
 -/
 module
 
-public import Iris.Init
+public import Iris.Init -- shake: keep
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Std/TC.lean
+++ b/Iris/Iris/Std/TC.lean
@@ -5,7 +5,8 @@ Authors: Lars König
 -/
 module
 
-public import Iris.Init
+public import Iris.Init -- shake: keep
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Std/TC.lean
+++ b/Iris/Iris/Std/TC.lean
@@ -6,7 +6,6 @@ Authors: Lars König
 module
 
 public import Iris.Init -- shake: keep
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Std/Tactic.lean
+++ b/Iris/Iris/Std/Tactic.lean
@@ -5,9 +5,9 @@ Authors: Lars König
 -/
 module
 
-meta import Lean.Elab.Tactic.ElabTerm
-public import Lean.Elab.Tactic
-public import Iris.Init
+public import Iris.Init -- shake: keep
+public meta import Lean.Elab.Tactic.ElabTerm
+import Iris.Std.RocqPorting
 
 public meta section
 

--- a/Iris/Iris/Std/Tactic.lean
+++ b/Iris/Iris/Std/Tactic.lean
@@ -7,7 +7,7 @@ module
 
 public import Iris.Init -- shake: keep
 public meta import Lean.Elab.Tactic.ElabTerm
-import Iris.Std.RocqPorting
+public import Lean.Elab.Tactic -- shake: keep
 
 public meta section
 

--- a/Iris/Iris/Std/Try.lean
+++ b/Iris/Iris/Std/Try.lean
@@ -5,7 +5,8 @@ Authors: Mario Carneiro
 -/
 module
 
-public import Iris.Init
+public import Iris.Init -- shake: keep
+import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/Iris/Std/Try.lean
+++ b/Iris/Iris/Std/Try.lean
@@ -6,7 +6,6 @@ Authors: Mario Carneiro
 module
 
 public import Iris.Init -- shake: keep
-import Iris.Std.RocqPorting
 
 @[expose] public section
 

--- a/Iris/IrisTest/Display.lean
+++ b/Iris/IrisTest/Display.lean
@@ -6,6 +6,7 @@ Authors: Alvin Tang
 
 module
 
+public import Iris.Init -- shake: keep
 import Lean
 public import Iris.ProofMode
 

--- a/Iris/IrisTest/HeapLang.lean
+++ b/Iris/IrisTest/HeapLang.lean
@@ -1,5 +1,6 @@
 module
 
+public import Iris.Init -- shake: keep
 public import IrisTest.HeapLang.Linter
 public import IrisTest.HeapLang.Notation
 public import IrisTest.HeapLang.WeakestPre

--- a/Iris/IrisTest/HeapLang/HeapTactics.lean
+++ b/Iris/IrisTest/HeapLang/HeapTactics.lean
@@ -5,6 +5,7 @@ Authors: Klaus Kraßnitzer
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI
 public import Iris.Instances
 public import Iris.HeapLang.Notation

--- a/Iris/IrisTest/HeapLang/Linter.lean
+++ b/Iris/IrisTest/HeapLang/Linter.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.HeapLang
 
 @[expose] public section

--- a/Iris/IrisTest/HeapLang/Notation.lean
+++ b/Iris/IrisTest/HeapLang/Notation.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.HeapLang
 
 @[expose] public section

--- a/Iris/IrisTest/HeapLang/Par.lean
+++ b/Iris/IrisTest/HeapLang/Par.lean
@@ -5,6 +5,7 @@ Authors: Klaus Kraßnitzer
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.HeapLang.Lib.Par
 
 @[expose] public section

--- a/Iris/IrisTest/HeapLang/Tactics.lean
+++ b/Iris/IrisTest/HeapLang/Tactics.lean
@@ -5,6 +5,7 @@ Authors: Alvin Tang
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.ProofMode
 public import Iris.HeapLang
 

--- a/Iris/IrisTest/HeapLang/WeakestPre.lean
+++ b/Iris/IrisTest/HeapLang/WeakestPre.lean
@@ -5,6 +5,7 @@ Authors: Fernando Leal, Klaus Kraßnitzer
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI
 public import Iris.Instances
 public import Iris.HeapLang.Notation

--- a/Iris/IrisTest/Instances.lean
+++ b/Iris/IrisTest/Instances.lean
@@ -5,6 +5,7 @@ Authors: Michael Sammler
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI
 public import Iris.ProofMode.SynthInstance
 public import Iris.ProofMode.Instances

--- a/Iris/IrisTest/InstancesImport.lean
+++ b/Iris/IrisTest/InstancesImport.lean
@@ -5,6 +5,7 @@ Authors: Michael Sammler
 -/
 module
 
+public import Iris.Init -- shake: keep
 import IrisTest.Instances
 
 /- This file tests that IPM tactic instances declared in other files are imported and applied correctly. -/

--- a/Iris/IrisTest/Language.lean
+++ b/Iris/IrisTest/Language.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.ProgramLogic.Language
 
 @[expose] public section

--- a/Iris/IrisTest/Notation.lean
+++ b/Iris/IrisTest/Notation.lean
@@ -5,6 +5,7 @@ Authors: Lars König, Alex Keizer
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI.BIBase
 public import Iris.BI.Updates
 

--- a/Iris/IrisTest/Tactics.lean
+++ b/Iris/IrisTest/Tactics.lean
@@ -5,6 +5,7 @@ Authors: Lars König, Oliver Soeser, Michael Sammler, Yunsong Yang, Alvin Tang
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI
 public import Iris.ProofMode
 public import Iris.Instances.IProp

--- a/Iris/IrisTest/Updates.lean
+++ b/Iris/IrisTest/Updates.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.BI.Updates
 
 open Iris

--- a/Iris/IrisTest/WeakestPre.lean
+++ b/Iris/IrisTest/WeakestPre.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Iris.Init -- shake: keep
 public import Iris.ProgramLogic.WeakestPre
 public import Iris.HeapLang
 

--- a/scripts/shake-check.sh
+++ b/scripts/shake-check.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Dry run: report each import `lake shake` thinks is unused, one per line, showing the
+# actual import. Skips our deliberate `import Iris.Init` invariant (shake flags those as
+# "implied", but we keep them on purpose). No edits are applied.
+lake shake --gh-style "$@" 2>&1 | grep 'warning: unused import' | cut -d: -f1,2 |
+while IFS=: read -r file line; do
+  src=$(sed -n "${line}p" "$file")
+  case $src in *"import Iris.Init"*) continue ;; esac
+  echo "$file:$line: $src"
+done


### PR DESCRIPTION
This is stable (enough ``-- shake: keep`` annotations have been added to make `lake shake` idempotent). We will see now if it is any faster. 