### PR TITLE
feat: `BIFUpdateSbi` and remaining instances in `InstancesUpdates.lean`

### DIFF
--- a/Iris/Iris/BI/Embedding.lean
+++ b/Iris/Iris/BI/Embedding.lean
@@ -94,9 +94,9 @@ class BiEmbedFUpd (PROP1 PROP2 : Type _) [BI PROP1] [BI PROP2] [BiEmbed PROP1 PR
 @[rocq_alias BiEmbedSbi]
 class BiEmbedSbi (PROP1 PROP2 : Type _) [BI PROP1] [BI PROP2] [BiEmbed PROP1 PROP2]
     [Sbi PROP1] [Sbi PROP2] where
-  embed_si_emp_valid : ∀ (P : PROP1),
+  embed_siEmpValid : ∀ (P : PROP1),
     SiEmpValid.siEmpValid (embed P : PROP2) ⊣⊢ SiEmpValid.siEmpValid P
-  embed_si_pure_1 : ∀ (Pi : SiProp),
+  embed_siPure_1 : ∀ (Pi : SiProp),
     (embed (SiPure.siPure Pi : PROP1) : PROP2) ⊢ (SiPure.siPure Pi : PROP2)
 
 /-! ## Projections -/
@@ -435,24 +435,24 @@ section
 variable {P1 P2 : Type _} [Sbi P1] [Sbi P2] [BiEmbed P1 P2] [BiEmbedSbi P1 P2]
 
 @[rocq_alias embed_si_pure]
-theorem embed_si_pure (Pi : SiProp) :
+theorem embed_siPure (Pi : SiProp) :
     (embed (SiPure.siPure Pi : P1) : P2) ⊣⊢ SiPure.siPure Pi :=
-  ⟨BiEmbedSbi.embed_si_pure_1 Pi,
-   (siPure_mono ((BiEmbedSbi.embed_si_emp_valid _).trans siEmpValid_siPure).mpr).trans
+  ⟨BiEmbedSbi.embed_siPure_1 Pi,
+   (siPure_mono ((BiEmbedSbi.embed_siEmpValid _).trans siEmpValid_siPure).mpr).trans
      siPure_siEmpValid_elim⟩
 
 @[rocq_alias embed_internal_eq]
 theorem embed_internal_eq {A : Type _} [OFE A] (x y : A) :
     (embed (iprop(x ≡ y) : P1) : P2) ⊣⊢ x ≡ y :=
-  embed_si_pure (SiProp.internalEq x y)
+  embed_siPure (SiProp.internalEq x y)
 
 @[rocq_alias embed_plainly]
 theorem embed_plainly (P : P1) : (⎡■ P⎤ : P2) ⊣⊢ ■ ⎡P⎤ := by
   show (embed (SiPure.siPure (SiEmpValid.siEmpValid P)) : P2)
       ⊣⊢ SiPure.siPure (SiEmpValid.siEmpValid (embed P))
-  exact (embed_si_pure _).trans
-    ⟨siPure_mono (BiEmbedSbi.embed_si_emp_valid P).mpr,
-     siPure_mono (BiEmbedSbi.embed_si_emp_valid P).mp⟩
+  exact (embed_siPure _).trans
+    ⟨siPure_mono (BiEmbedSbi.embed_siEmpValid P).mpr,
+     siPure_mono (BiEmbedSbi.embed_siEmpValid P).mp⟩
 
 @[rocq_alias embed_plainly_if]
 theorem embed_plainly_if (p : Bool) (P : P1) :
@@ -475,8 +475,8 @@ theorem embed_internal_inj {P3 : Type _} [Sbi P3] (P Q : P1) :
     _ ⊢ <si_emp_valid> (P -∗ Q) ∧ <si_emp_valid> (Q -∗ P)         := and_mono ?_ ?_
     _ ⊢ <si_emp_valid> ((P -∗ Q) ∧ (Q -∗ P))                      := siEmpValid_and.mpr
     _ ⊢ SiProp.internalEq P Q                                     := (prop_ext_siEmpValid_equiv P Q).mpr
-  exact (siEmpValid_mono (embed_wand_2 P Q)).trans (BiEmbedSbi.embed_si_emp_valid iprop(P -∗ Q)).mp
-  exact (siEmpValid_mono (embed_wand_2 Q P)).trans (BiEmbedSbi.embed_si_emp_valid iprop(Q -∗ P)).mp
+  exact (siEmpValid_mono (embed_wand_2 P Q)).trans (BiEmbedSbi.embed_siEmpValid iprop(P -∗ Q)).mp
+  exact (siEmpValid_mono (embed_wand_2 Q P)).trans (BiEmbedSbi.embed_siEmpValid iprop(Q -∗ P)).mp
 
 end
 
@@ -578,13 +578,13 @@ variable {QA QB QC : Type _} [Sbi QA] [Sbi QB] [Sbi QC]
 @[rocq_alias embed_embed_sbi]
 theorem embed_embed_sbi : @BiEmbedSbi QA QC _ _ (embedBiEmbed QB) _ _ :=
   letI : BiEmbed QA QC := embedBiEmbed QB
-  { embed_si_emp_valid := fun P =>
-      (BiEmbedSbi.embed_si_emp_valid (PROP1 := QB) (PROP2 := QC) (embed (A := QA) (B := QB) P)).trans
-        (BiEmbedSbi.embed_si_emp_valid (PROP1 := QA) (PROP2 := QB) P)
-    embed_si_pure_1 := fun Pi =>
+  { embed_siEmpValid := fun P =>
+      (BiEmbedSbi.embed_siEmpValid (PROP1 := QB) (PROP2 := QC) (embed (A := QA) (B := QB) P)).trans
+        (BiEmbedSbi.embed_siEmpValid (PROP1 := QA) (PROP2 := QB) P)
+    embed_siPure_1 := fun Pi =>
       (embed_mono (PROP1 := QB) (PROP2 := QC)
-          (BiEmbedSbi.embed_si_pure_1 (PROP1 := QA) (PROP2 := QB) Pi)).trans
-        (BiEmbedSbi.embed_si_pure_1 (PROP1 := QB) (PROP2 := QC) Pi) }
+          (BiEmbedSbi.embed_siPure_1 (PROP1 := QA) (PROP2 := QB) Pi)).trans
+        (BiEmbedSbi.embed_siPure_1 (PROP1 := QB) (PROP2 := QC) Pi) }
 
 end
 

--- a/Iris/Iris/BI/MonPred.lean
+++ b/Iris/Iris/BI/MonPred.lean
@@ -1581,21 +1581,19 @@ instance monPred_bi_bupd_sbi [BIUpdate PROP] [BIBUpdateSbi PROP] :
   bupd_si_pure Pi := entails_at.mpr fun _ => BIBUpdateSbi.bupd_si_pure Pi
 
 @[rocq_alias monPred_bi_fupd_sbi]
-instance monPred_bi_fupd_sbi [BIFUpdate PROP] [BIFUpdatePlainly PROP] :
-    BIFUpdatePlainly (MonPred I PROP) where
+instance monPred_bi_fupd_sbi [BIFUpdate PROP] [BIFUpdateSbi PROP] :
+    BIFUpdateSbi (MonPred I PROP) where
   fupd_keep_si_pure E' Pi R := entails_at.mpr fun i => by
     refine (and_mono_right
       (monPred_wand_force i (SiPure.siPure Pi : MonPred I PROP) (iprop(|={_}=> R)))).trans ?_
-    exact BIFUpdatePlainly.fupd_keep_si_pure E' Pi (R.monPred_at i)
-  fupd_plainly_later E P := entails_at.mpr fun i => by
-    refine (later_mono
-      (BIFUpdate.mono ((monPred_at_plainly i P).mp.trans (forall_elim i)))).trans ?_
-    exact BIFUpdatePlainly.fupd_plainly_later E (P.monPred_at i)
-  fupd_plainly_sForall_2 E Φ := entails_at.mpr fun i => by
-    refine (BIFUpdate.mono
-      ((monPred_at_plainly i (BIBase.sForall Φ)).mp.trans (forall_elim i))).trans ?_
-    exact BIFUpdatePlainly.fupd_plainly_sForall_2 E
-      (fun p => ∃ q : MonPred I PROP, Φ q ∧ q.monPred_at i = p)
+    exact BIFUpdateSbi.fupd_keep_si_pure E' Pi (R.monPred_at i)
+  fupd_si_pure_later E P := entails_at.mpr fun i => BIFUpdateSbi.fupd_si_pure_later E P
+  fupd_si_pure_sForall_2 E Φ := entails_at.mpr fun i => by
+    refine .trans ?_ (BIFUpdateSbi.fupd_si_pure_sForall_2 (PROP := PROP) E Φ)
+    refine (monPred_at_forall i
+      (fun q : SiProp => iprop(⌜Φ q⌝ → |={E}=> <si_pure> q))).mp.trans ?_
+    exact forall_mono fun q =>
+      monPred_impl_force i (iprop(⌜Φ q⌝)) (iprop(|={E}=> <si_pure> q) : MonPred I PROP)
 
 end Sbi
 

--- a/Iris/Iris/BI/MonPred.lean
+++ b/Iris/Iris/BI/MonPred.lean
@@ -1409,12 +1409,12 @@ instance : SiEmpValid (MonPred I PROP) where
 #rocq_ignore monPred_si_emp_valid_unseal "Rocq unsealing lemma."
 
 @[rocq_alias monPred_si_pure_unfold]
-theorem monPred_si_pure_unfold :
+theorem monPred_siPure_unfold :
     (SiPure.siPure : SiProp → MonPred I PROP) =
       fun Pi => (iprop(⎡(<si_pure> Pi : PROP)⎤) : MonPred I PROP) := rfl
 
 @[rocq_alias monPred_si_emp_valid_unfold]
-theorem monPred_si_emp_valid_unfold :
+theorem monPred_siEmpValid_unfold :
     (SiEmpValid.siEmpValid : MonPred I PROP → SiProp) =
       fun P => SiEmpValid.siEmpValid (iprop(∀ i, P.monPred_at i) : PROP) := rfl
 
@@ -1514,7 +1514,7 @@ theorem monPred_equivI {PROP' : Type _} [Sbi PROP'] (P Q : MonPred I PROP) :
 /-! ### Objective and plain instances -/
 
 @[rocq_alias si_pure_objective]
-instance si_pure_objective (Pi : SiProp) : Objective (iprop(<si_pure> Pi) : MonPred I PROP) where
+instance siPure_objective (Pi : SiProp) : Objective (iprop(<si_pure> Pi) : MonPred I PROP) where
   objective_at _ _ := .rfl
 
 @[rocq_alias internal_eq_objective]
@@ -1570,26 +1570,26 @@ theorem monPred_sbi_emp_valid_exist {bot : I.car} [BiIndexBottom I bot] [SbiEmpV
 
 @[rocq_alias monPred_bi_embed_sbi]
 instance monPred_bi_embed_sbi : BiEmbedSbi PROP (MonPred I PROP) where
-  embed_si_emp_valid _P :=
+  embed_siEmpValid _P :=
     ⟨siEmpValid_mono (forall_elim (default : I.car)),
      siEmpValid_mono (forall_intro fun _ => .rfl)⟩
-  embed_si_pure_1 _ := .rfl
+  embed_siPure_1 _ := .rfl
 
 @[rocq_alias monPred_bi_bupd_sbi]
 instance monPred_bi_bupd_sbi [BIUpdate PROP] [BIBUpdateSbi PROP] :
     BIBUpdateSbi (MonPred I PROP) where
-  bupd_si_pure Pi := entails_at.mpr fun _ => BIBUpdateSbi.bupd_si_pure Pi
+  bupd_siPure Pi := entails_at.mpr fun _ => BIBUpdateSbi.bupd_siPure Pi
 
 @[rocq_alias monPred_bi_fupd_sbi]
 instance monPred_bi_fupd_sbi [BIFUpdate PROP] [BIFUpdateSbi PROP] :
     BIFUpdateSbi (MonPred I PROP) where
-  fupd_keep_si_pure E' Pi R := entails_at.mpr fun i => by
+  fupd_keep_siPure E' Pi R := entails_at.mpr fun i => by
     refine (and_mono_right
       (monPred_wand_force i (SiPure.siPure Pi : MonPred I PROP) (iprop(|={_}=> R)))).trans ?_
-    exact BIFUpdateSbi.fupd_keep_si_pure E' Pi (R.monPred_at i)
-  fupd_si_pure_later E P := entails_at.mpr fun i => BIFUpdateSbi.fupd_si_pure_later E P
-  fupd_si_pure_sForall_2 E Φ := entails_at.mpr fun i => by
-    refine .trans ?_ (BIFUpdateSbi.fupd_si_pure_sForall_2 (PROP := PROP) E Φ)
+    exact BIFUpdateSbi.fupd_keep_siPure E' Pi (R.monPred_at i)
+  fupd_siPure_later E P := entails_at.mpr fun i => BIFUpdateSbi.fupd_siPure_later E P
+  fupd_siPure_sForall_2 E Φ := entails_at.mpr fun i => by
+    refine .trans ?_ (BIFUpdateSbi.fupd_siPure_sForall_2 (PROP := PROP) E Φ)
     refine (monPred_at_forall i
       (fun q : SiProp => iprop(⌜Φ q⌝ → |={E}=> <si_pure> q))).mp.trans ?_
     exact forall_mono fun q =>

--- a/Iris/Iris/BI/Plainly.lean
+++ b/Iris/Iris/BI/Plainly.lean
@@ -636,11 +636,11 @@ instance from_option_plain {A : Type _} (P : PROP)  (Ψ : A → PROP) (x? : Opti
   match x? with | (x : A) => hΨ x | .none => hP
 
 @[rocq_alias si_pure_plain]
-instance si_pure_plain (P : SiProp) : Plain (PROP := PROP) (siPure P) where
+instance siPure_plain (P : SiProp) : Plain (PROP := PROP) (siPure P) where
   plain := plainly_siPure.2
 
 @[rocq_alias si_emp_valid_plain]
-instance si_emp_valid_plain (P : PROP) : Plain (siEmpValid P) where
+instance siEmpValid_plain (P : PROP) : Plain (siEmpValid P) where
   plain := .rfl
 
 @[rocq_alias big_sepL_nil_plain]

--- a/Iris/Iris/BI/Plainly.lean
+++ b/Iris/Iris/BI/Plainly.lean
@@ -580,11 +580,11 @@ instance or_plain (P Q : PROP)[Plain P] [Plain Q]: Plain iprop(P ∨ Q) where
   plain := .trans (or_mono plain plain) plainly_or_mpr
 
 @[rocq_alias forall_plain]
-instance forall_plain {A} (Ψ : A → PROP) : [∀ x, Plain (Ψ x)] → Plain iprop(∀ x, Ψ x) where
+instance forall_plain {A : Sort _} (Ψ : A → PROP) : [∀ x, Plain (Ψ x)] → Plain iprop(∀ x, Ψ x) where
   plain := .trans (forall_mono (fun _ => plain)) plainly_forall_mpr
 
 @[rocq_alias exist_plain]
-instance exists_plain (Ψ : A → PROP) : [∀ x, Plain (Ψ x)] → Plain iprop(∃ x, Ψ x) where
+instance exists_plain {A : Sort _} (Ψ : A → PROP) : [∀ x, Plain (Ψ x)] → Plain iprop(∃ x, Ψ x) where
   plain := .trans (exists_mono (fun _ => plain)) plainly_exists_mpr
 
 @[rocq_alias impl_plain]

--- a/Iris/Iris/BI/Plainly.lean
+++ b/Iris/Iris/BI/Plainly.lean
@@ -580,11 +580,11 @@ instance or_plain (P Q : PROP)[Plain P] [Plain Q]: Plain iprop(P ∨ Q) where
   plain := .trans (or_mono plain plain) plainly_or_mpr
 
 @[rocq_alias forall_plain]
-instance forall_plain {A : Type _} (Ψ : A → PROP) : [∀ x, Plain (Ψ x)] → Plain iprop(∀ x, Ψ x) where
+instance forall_plain {A} (Ψ : A → PROP) : [∀ x, Plain (Ψ x)] → Plain iprop(∀ x, Ψ x) where
   plain := .trans (forall_mono (fun _ => plain)) plainly_forall_mpr
 
 @[rocq_alias exist_plain]
-instance exists_plain {A : Type _} (Ψ : A → PROP) : [∀ x, Plain (Ψ x)] → Plain iprop(∃ x, Ψ x) where
+instance exists_plain (Ψ : A → PROP) : [∀ x, Plain (Ψ x)] → Plain iprop(∃ x, Ψ x) where
   plain := .trans (exists_mono (fun _ => plain)) plainly_exists_mpr
 
 @[rocq_alias impl_plain]

--- a/Iris/Iris/BI/Sbi.lean
+++ b/Iris/Iris/BI/Sbi.lean
@@ -93,7 +93,7 @@ export Sbi (siPure_mono siEmpValid_mono siEmpValid_siPure siPure_siEmpValid siPu
 
 /-- Alias for `Sbi.siEmpValid_affinely_mpr` field. -/
 @[rocq_alias si_emp_valid_affinely_2]
-theorem si_emp_valid_affinely_2 [Sbi PROP] {P : PROP} :
+theorem siEmpValid_affinely_2 [Sbi PROP] {P : PROP} :
     <si_emp_valid> P ⊢@{SiProp} <si_emp_valid> (<affine> P) :=
   Sbi.siEmpValid_affinely_mpr
 

--- a/Iris/Iris/BI/Updates.lean
+++ b/Iris/Iris/BI/Updates.lean
@@ -790,18 +790,20 @@ theorem sForall_eq_forall {Φ : α → PROP} :
   ⟨forall_intro fun a => sForall_elim ⟨a, rfl⟩,
    sForall_intro fun _ ⟨a, hp⟩ => hp ▸ forall_elim a⟩
 
+@[rocq_alias fupd_si_pure_forall_2]
+theorem fupd_siPure_forall_2 {E : CoPset} {A : Sort _} {Φi : A → SiProp} :
+    (∀ x, |={E}=> <si_pure> Φi x) ⊢@{PROP} |={E}=> ∀ x, <si_pure> Φi x := calc
+  _ ⊢ ∀ q, ⌜∃ x, q = Φi x⌝ → |={E}=> <si_pure> q :=
+      forall_intro fun _ => imp_intro_swap <| pure_elim_left fun ⟨x, hx⟩ => hx ▸ forall_elim x
+  _ ⊢@{PROP} |={E}=> <si_pure> (sForall fun q => ∃ x, q = Φi x) :=
+      BIFUpdateSbi.fupd_si_pure_sForall_2 E _
+  _ ⊢ |={E}=> ∀ x, <si_pure> Φi x :=
+      mono <| forall_intro fun x => siPure_mono (sForall_elim ⟨x, rfl⟩)
+
 @[rocq_alias fupd_plainly_forall_2]
 theorem fupd_plainly_forall_2 [BIAffine PROP] {E : CoPset} {Φ : α → PROP} :
     (∀ a, |={E}=> ■ Φ a) ⊢ |={E}=> ∀ a, Φ a :=
-  let Ψi : SiProp → Prop := fun q => ∃ a, q = iprop(<si_emp_valid> (Φ a))
-  have h : (∀ a, |={E}=> ■ Φ a) ⊢ ∀ q, ⌜Ψi q⌝ → |={E}=> <si_pure> q :=
-    forall_intro fun _ => imp_intro <| pure_elim_right fun ⟨a, hq⟩ => hq ▸ forall_elim a
-  calc
-    _ ⊢ ∀ q, ⌜Ψi q⌝ → |={E}=> <si_pure> q := h
-    _ ⊢ |={E}=> <si_pure> sForall Ψi      := BIFUpdateSbi.fupd_si_pure_sForall_2 E Ψi
-    _ ⊢ |={E}=> ∀ a, Φ a                  :=
-        mono <| forall_intro fun a =>
-          (siPure_mono (sForall_elim ⟨a, rfl⟩)).trans siPure_siEmpValid_elim
+  fupd_siPure_forall_2.trans <| mono <| forall_mono fun _ => siPure_siEmpValid_elim
 
 @[rocq_alias fupd_plain_forall_2]
 theorem fupd_plain_forall_2 [BIAffine PROP] {E : CoPset} {Φ : α → PROP} [∀ a, Plain (Φ a)] :

--- a/Iris/Iris/BI/Updates.lean
+++ b/Iris/Iris/BI/Updates.lean
@@ -796,8 +796,12 @@ theorem fupd_plainly_forall_2 [BIAffine PROP] {E : CoPset} {Φ : α → PROP} :
   let Ψi : SiProp → Prop := fun q => ∃ a, q = iprop(<si_emp_valid> (Φ a))
   have h : (∀ a, |={E}=> ■ Φ a) ⊢ ∀ q, ⌜Ψi q⌝ → |={E}=> <si_pure> q :=
     forall_intro fun _ => imp_intro <| pure_elim_right fun ⟨a, hq⟩ => hq ▸ forall_elim a
-  (h.trans (BIFUpdateSbi.fupd_si_pure_sForall_2 E Ψi)).trans <| mono <|
-    forall_intro fun a => (siPure_mono (sForall_elim ⟨a, rfl⟩)).trans siPure_siEmpValid_elim
+  calc
+    _ ⊢ ∀ q, ⌜Ψi q⌝ → |={E}=> <si_pure> q := h
+    _ ⊢ |={E}=> <si_pure> sForall Ψi      := BIFUpdateSbi.fupd_si_pure_sForall_2 E Ψi
+    _ ⊢ |={E}=> ∀ a, Φ a                  :=
+        mono <| forall_intro fun a =>
+          (siPure_mono (sForall_elim ⟨a, rfl⟩)).trans siPure_siEmpValid_elim
 
 @[rocq_alias fupd_plainly_elim]
 theorem fupd_plainly_elim [BIAffine PROP] {E : CoPset} {P : PROP} : ■ P ⊢ |={E}=> P :=
@@ -811,27 +815,33 @@ theorem fupd_plain_forall_2 [BIAffine PROP] {E : CoPset} {Φ : α → PROP} [∀
 @[rocq_alias fupd_plain_forall]
 theorem fupd_plain_forall [BIAffine PROP] {E1 E2 : CoPset} {Φ : α → PROP}
     [inst : ∀ a, Plain (Φ a)] (h : E2 ⊆ E1) :
-    (|={E1,E2}=> ∀ a, Φ a) ⊣⊢ ∀ a, |={E1,E2}=> Φ a :=
-  ⟨fupd_forall, calc
-    _ ⊢ ∀ a, |={E1}=> Φ a    := forall_mono fun _ => fupd_plain_mask
-    _ ⊢ |={E1}=> ∀ a, Φ a    := fupd_plain_forall_2
-    _ ⊢ |={E1,E2}=> ∀ a, Φ a := fupd_elim <| calc
-          _ ⊢ ■ (∀ a, Φ a)             := sorry -- Plain.plain
-          _ ⊢ |={E1,E2}=> ■ (∀ a, Φ a) := fupd_mask_intro_discard h
-          _ ⊢ |={E1,E2}=> |={E2}=> _   := mono fupd_plainly_elim
-          _ ⊢ |={E1,E2}=> ∀ a, Φ a     := trans⟩
+    (|={E1,E2}=> ∀ a, Φ a) ⊣⊢ ∀ a, |={E1,E2}=> Φ a := by
+  constructor
+  · exact fupd_forall
+  · calc
+      _ ⊢ ∀ a, |={E1}=> Φ a    := forall_mono fun _ => fupd_plain_mask
+      _ ⊢ |={E1}=> ∀ a, Φ a    := fupd_plain_forall_2
+      _ ⊢ |={E1,E2}=> ∀ a, Φ a := fupd_elim ?_
+    calc
+      _ ⊢ ■ (∀ a, Φ a)             := (forall_mono (fun a => (inst a).plain)).trans plainly_forall_mpr
+      _ ⊢ |={E1,E2}=> ■ (∀ a, Φ a) := fupd_mask_intro_discard h
+      _ ⊢ |={E1,E2}=> |={E2}=> _   := mono fupd_plainly_elim
+      _ ⊢ |={E1,E2}=> ∀ a, Φ a     := trans
 
 @[rocq_alias step_fupd_plain_forall]
 theorem step_fupd_plain_forall [BIAffine PROP] {Eo Ei : CoPset} {Φ : α → PROP}
     [∀ a, Plain (Φ a)] (h : Ei ⊆ Eo) :
-    (|={Eo}[Ei]▷=> ∀ a, Φ a) ⊣⊢ ∀ a, |={Eo}[Ei]▷=> Φ a :=
-  ⟨forall_intro fun a => step_fupd_mono (forall_elim a), calc
-    _ ⊢ ∀ a, |={Eo}=> ▷ ◇ Φ a    := forall_mono fun _ => step_fupd_plain
-    _ ⊢ |={Eo}=> ∀ a, ▷ ◇ Φ a    := (fupd_plain_forall LawfulSet.subset_refl).mpr
-    _ ⊢ |={Eo}[Ei]▷=> ∀ a, Φ a   := fupd_elim <| calc
-          _ ⊢ ▷ ∀ a, ◇ Φ a               := later_forall.mpr
-          _ ⊢ ▷ ◇ ∀ a, Φ a               := later_mono except0_forall.mpr
-          _ ⊢ |={Eo}[Ei]▷=> ◇ ∀ a, Φ a   := step_fupd_intro h
-          _ ⊢ |={Eo}[Ei]▷=> ∀ a, Φ a     := mono (later_mono fupd_except0)⟩
+    (|={Eo}[Ei]▷=> ∀ a, Φ a) ⊣⊢ ∀ a, |={Eo}[Ei]▷=> Φ a := by
+  constructor
+  · exact forall_intro fun a => step_fupd_mono (forall_elim a)
+  · calc
+      _ ⊢ ∀ a, |={Eo}=> ▷ ◇ Φ a := forall_mono fun _ => step_fupd_plain
+      _ ⊢ |={Eo}=> ∀ a, ▷ ◇ Φ a := (fupd_plain_forall LawfulSet.subset_refl).mpr
+      _ ⊢ |={Eo}[Ei]▷=> ∀ a, Φ a := fupd_elim ?_
+    calc
+      _ ⊢ ▷ ∀ a, ◇ Φ a              := later_forall.mpr
+      _ ⊢ ▷ ◇ ∀ a, Φ a              := later_mono except0_forall.mpr
+      _ ⊢ |={Eo}[Ei]▷=> ◇ ∀ a, Φ a  := step_fupd_intro h
+      _ ⊢ |={Eo}[Ei]▷=> ∀ a, Φ a     := mono <| later_mono fupd_except0
 
 end StepFUpdPlainlyLaws

--- a/Iris/Iris/BI/Updates.lean
+++ b/Iris/Iris/BI/Updates.lean
@@ -823,7 +823,7 @@ theorem fupd_plain_forall [BIAffine PROP] {E1 E2 : CoPset} {Φ : α → PROP}
       _ ⊢ |={E1}=> ∀ a, Φ a    := fupd_plain_forall_2
       _ ⊢ |={E1,E2}=> ∀ a, Φ a := fupd_elim ?_
     calc
-      _ ⊢ ■ (∀ a, Φ a)             := (forall_mono (fun a => (inst a).plain)).trans plainly_forall_mpr
+      _ ⊢ ■ (∀ a, Φ a)             := Plain.plain
       _ ⊢ |={E1,E2}=> ■ (∀ a, Φ a) := fupd_mask_intro_discard h
       _ ⊢ |={E1,E2}=> |={E2}=> _   := mono fupd_plainly_elim
       _ ⊢ |={E1,E2}=> ∀ a, Φ a     := trans

--- a/Iris/Iris/BI/Updates.lean
+++ b/Iris/Iris/BI/Updates.lean
@@ -227,12 +227,14 @@ class BIFUpdate (PROP : Type _) [BI PROP] extends FUpd PROP where
 class BIUpdateFUpdate (PROP : Type _) [BI PROP] [BIUpdate PROP] [BIFUpdate PROP] where
   fupd_of_bupd {P : PROP} {E : CoPset} : (|==> P) ⊢ |={E}=> P
 
-class BIFUpdatePlainly (PROP : Type _) [BI PROP] [BIFUpdate PROP] [Sbi PROP] where
+@[rocq_alias BiFUpdSbi]
+class BIFUpdateSbi (PROP : Type _) [BI PROP] [BIFUpdate PROP] [Sbi PROP] where
   fupd_keep_si_pure {E} E' Pi (R : PROP) :
     (|={E,E'}=> <si_pure> Pi) ∧ (<si_pure> Pi ={E}=∗ R) ⊢ |={E}=> R
-  fupd_plainly_later (E : CoPset) (P : PROP) : (▷ |={E}=> ■ P) ⊢ |={E}=> ▷ ◇ P
-  fupd_plainly_sForall_2 (E : CoPset) (Φ : PROP → Prop) :
-    (|={E}=> ■ sForall Φ) ⊢ |={E}=> sForall Φ
+  fupd_si_pure_later (E : CoPset) (Pi : SiProp) :
+    (▷ |={E}=> <si_pure> Pi) ⊢@{PROP} |={E}=> ▷ ◇ <si_pure> Pi
+  fupd_si_pure_sForall_2 (E : CoPset) (Ψi : SiProp → Prop) :
+    (∀ q, ⌜Ψi q⌝ → |={E}=> <si_pure> q) ⊢@{PROP} |={E}=> <si_pure> (sForall Ψi)
 
 @[rocq_alias BiBUpdSbi]
 class BIBUpdateSbi (PROP : Type _) [BI PROP] [BIUpdate PROP] [Sbi PROP] where
@@ -713,15 +715,18 @@ end StepFUpdLaws
 
 section StepFUpdPlainlyLaws
 
-variable [Sbi PROP] [BIFUpdate PROP] [BIFUpdatePlainly PROP]
+variable [Sbi PROP] [BIFUpdate PROP] [BIFUpdateSbi PROP]
 
-open BIFUpdate BIFUpdatePlainly
+open BIFUpdate BIFUpdateSbi
 
 @[rocq_alias fupd_keep_si_pure]
 theorem fupd_keep_si_pure {E1 E2 : CoPset} E2' Pi {R : PROP} :
-  (|={E1,E2'}=> <si_pure> Pi) ∧ (<si_pure> Pi ={E1,E2}=∗ R) ⊢ |={E1,E2}=> R :=
-  (and_mono_right (wand_mono_right fupd_intro)).trans <|
-    (BIFUpdatePlainly.fupd_keep_si_pure E2' Pi iprop(|={E1,E2}=> R)).trans trans
+    (|={E1,E2'}=> <si_pure> Pi) ∧ (<si_pure> Pi ={E1,E2}=∗ R) ⊢ |={E1,E2}=> R := calc
+  _ ⊢ (|={E1, E2'}=> <si_pure> Pi) ∧ (<si_pure> Pi ={E1}=∗ |={E1, E2}=> R) :=
+      and_mono_right <| wand_mono_right fupd_intro
+  _ ⊢ |={E1}=> |={E1, E2}=> R :=
+      BIFUpdateSbi.fupd_keep_si_pure E2' Pi iprop(|={E1,E2}=> R)
+  _ ⊢ |={E1, E2}=> R := trans
 
 @[rocq_alias fupd_keep_plainly]
 theorem fupd_keep_plainly [BIAffine PROP] {E1 E2 : CoPset} E2' (P : PROP) {R : PROP} :
@@ -730,8 +735,10 @@ theorem fupd_keep_plainly [BIAffine PROP] {E1 E2 : CoPset} E2' (P : PROP) {R : P
     fupd_keep_si_pure E2' (SiEmpValid.siEmpValid P)
 
 @[rocq_alias fupd_plainly_later]
-theorem fupd_plainly_later (E : CoPset) (P : PROP) : (▷ |={E}=> ■ P) ⊢ |={E}=> ▷ ◇ P :=
-  BIFUpdatePlainly.fupd_plainly_later E P
+theorem fupd_plainly_later [BIAffine PROP] (E : CoPset) (P : PROP) :
+    (▷ |={E}=> ■ P) ⊢ |={E}=> ▷ ◇ P :=
+  (BIFUpdateSbi.fupd_si_pure_later E iprop(<si_emp_valid> P)).trans <|
+    mono <| later_mono <| except0_mono siPure_siEmpValid_elim
 
 @[rocq_alias fupd_keep_plain]
 theorem fupd_keep_plain [BIAffine PROP] {E1 E2 : CoPset} E2' (P R : PROP) [Plain P] :
@@ -749,7 +756,7 @@ theorem fupd_plain_mask [BIAffine PROP] {E E' : CoPset} {P : PROP} [Plain P] :
   (mono Plain.plain).trans (fupd_plainly_mask E E')
 
 @[rocq_alias fupd_plain_later]
-theorem fupd_plain_later {E : CoPset} {P : PROP} [Plain P] : (▷ |={E}=> P) ⊢ |={E}=> ▷ ◇ P :=
+theorem fupd_plain_later [BIAffine PROP] {E : CoPset} {P : PROP} [Plain P] : (▷ |={E}=> P) ⊢ |={E}=> ▷ ◇ P :=
   (later_mono (mono Plain.plain)).trans (fupd_plainly_later E P)
 
 @[rocq_alias fupd_keep_plain_sep]
@@ -776,5 +783,55 @@ theorem step_fupdN_plain [BIAffine PROP] {E1 E2 : CoPset} {n : Nat} {P : PROP} [
       _ ⊢ |={E1}=> ▷ ◇ ▷^[n] ◇ P          := step_fupd_plain
       _ ⊢ |={E1}=> ▷ ▷^[n] ◇ ◇ P          := mono <| later_mono <| except0_laterN n
       _ ⊢ |={E1}=> ▷^[n + 1] ◇ P            := mono <| laterN_mono (n + 1) except0_idem.mp
+
+omit [BIFUpdate PROP] [BIFUpdateSbi PROP] in
+theorem sForall_eq_forall {Φ : α → PROP} :
+    sForall (fun p => ∃ a, p = Φ a) ⊣⊢ ∀ a, Φ a :=
+  ⟨forall_intro fun a => sForall_elim ⟨a, rfl⟩,
+   sForall_intro fun _ ⟨a, hp⟩ => hp ▸ forall_elim a⟩
+
+@[rocq_alias fupd_plainly_forall_2]
+theorem fupd_plainly_forall_2 [BIAffine PROP] {E : CoPset} {Φ : α → PROP} :
+    (∀ a, |={E}=> ■ Φ a) ⊢ |={E}=> ∀ a, Φ a :=
+  let Ψi : SiProp → Prop := fun q => ∃ a, q = iprop(<si_emp_valid> (Φ a))
+  have h : (∀ a, |={E}=> ■ Φ a) ⊢ ∀ q, ⌜Ψi q⌝ → |={E}=> <si_pure> q :=
+    forall_intro fun _ => imp_intro <| pure_elim_right fun ⟨a, hq⟩ => hq ▸ forall_elim a
+  (h.trans (BIFUpdateSbi.fupd_si_pure_sForall_2 E Ψi)).trans <| mono <|
+    forall_intro fun a => (siPure_mono (sForall_elim ⟨a, rfl⟩)).trans siPure_siEmpValid_elim
+
+@[rocq_alias fupd_plainly_elim]
+theorem fupd_plainly_elim [BIAffine PROP] {E : CoPset} {P : PROP} : ■ P ⊢ |={E}=> P :=
+  fupd_intro.trans (fupd_plainly_mask E E)
+
+@[rocq_alias fupd_plain_forall_2]
+theorem fupd_plain_forall_2 [BIAffine PROP] {E : CoPset} {Φ : α → PROP} [∀ a, Plain (Φ a)] :
+    (∀ a, |={E}=> Φ a) ⊢ |={E}=> ∀ a, Φ a :=
+  (forall_mono fun _ => mono Plain.plain).trans fupd_plainly_forall_2
+
+@[rocq_alias fupd_plain_forall]
+theorem fupd_plain_forall [BIAffine PROP] {E1 E2 : CoPset} {Φ : α → PROP}
+    [inst : ∀ a, Plain (Φ a)] (h : E2 ⊆ E1) :
+    (|={E1,E2}=> ∀ a, Φ a) ⊣⊢ ∀ a, |={E1,E2}=> Φ a :=
+  ⟨fupd_forall, calc
+    _ ⊢ ∀ a, |={E1}=> Φ a    := forall_mono fun _ => fupd_plain_mask
+    _ ⊢ |={E1}=> ∀ a, Φ a    := fupd_plain_forall_2
+    _ ⊢ |={E1,E2}=> ∀ a, Φ a := fupd_elim <| calc
+          _ ⊢ ■ (∀ a, Φ a)             := sorry -- Plain.plain
+          _ ⊢ |={E1,E2}=> ■ (∀ a, Φ a) := fupd_mask_intro_discard h
+          _ ⊢ |={E1,E2}=> |={E2}=> _   := mono fupd_plainly_elim
+          _ ⊢ |={E1,E2}=> ∀ a, Φ a     := trans⟩
+
+@[rocq_alias step_fupd_plain_forall]
+theorem step_fupd_plain_forall [BIAffine PROP] {Eo Ei : CoPset} {Φ : α → PROP}
+    [∀ a, Plain (Φ a)] (h : Ei ⊆ Eo) :
+    (|={Eo}[Ei]▷=> ∀ a, Φ a) ⊣⊢ ∀ a, |={Eo}[Ei]▷=> Φ a :=
+  ⟨forall_intro fun a => step_fupd_mono (forall_elim a), calc
+    _ ⊢ ∀ a, |={Eo}=> ▷ ◇ Φ a    := forall_mono fun _ => step_fupd_plain
+    _ ⊢ |={Eo}=> ∀ a, ▷ ◇ Φ a    := (fupd_plain_forall LawfulSet.subset_refl).mpr
+    _ ⊢ |={Eo}[Ei]▷=> ∀ a, Φ a   := fupd_elim <| calc
+          _ ⊢ ▷ ∀ a, ◇ Φ a               := later_forall.mpr
+          _ ⊢ ▷ ◇ ∀ a, Φ a               := later_mono except0_forall.mpr
+          _ ⊢ |={Eo}[Ei]▷=> ◇ ∀ a, Φ a   := step_fupd_intro h
+          _ ⊢ |={Eo}[Ei]▷=> ∀ a, Φ a     := mono (later_mono fupd_except0)⟩
 
 end StepFUpdPlainlyLaws

--- a/Iris/Iris/BI/Updates.lean
+++ b/Iris/Iris/BI/Updates.lean
@@ -803,10 +803,6 @@ theorem fupd_plainly_forall_2 [BIAffine PROP] {E : CoPset} {Φ : α → PROP} :
         mono <| forall_intro fun a =>
           (siPure_mono (sForall_elim ⟨a, rfl⟩)).trans siPure_siEmpValid_elim
 
-@[rocq_alias fupd_plainly_elim]
-theorem fupd_plainly_elim [BIAffine PROP] {E : CoPset} {P : PROP} : ■ P ⊢ |={E}=> P :=
-  fupd_intro.trans (fupd_plainly_mask E E)
-
 @[rocq_alias fupd_plain_forall_2]
 theorem fupd_plain_forall_2 [BIAffine PROP] {E : CoPset} {Φ : α → PROP} [∀ a, Plain (Φ a)] :
     (∀ a, |={E}=> Φ a) ⊢ |={E}=> ∀ a, Φ a :=
@@ -825,7 +821,7 @@ theorem fupd_plain_forall [BIAffine PROP] {E1 E2 : CoPset} {Φ : α → PROP}
     calc
       _ ⊢ ■ (∀ a, Φ a)             := Plain.plain
       _ ⊢ |={E1,E2}=> ■ (∀ a, Φ a) := fupd_mask_intro_discard h
-      _ ⊢ |={E1,E2}=> |={E2}=> _   := mono fupd_plainly_elim
+      _ ⊢ |={E1,E2}=> |={E2}=> _   := mono <| fupd_intro.trans (fupd_plainly_mask E E)
       _ ⊢ |={E1,E2}=> ∀ a, Φ a     := trans
 
 @[rocq_alias step_fupd_plain_forall]

--- a/Iris/Iris/BI/Updates.lean
+++ b/Iris/Iris/BI/Updates.lean
@@ -229,16 +229,16 @@ class BIUpdateFUpdate (PROP : Type _) [BI PROP] [BIUpdate PROP] [BIFUpdate PROP]
 
 @[rocq_alias BiFUpdSbi]
 class BIFUpdateSbi (PROP : Type _) [BI PROP] [BIFUpdate PROP] [Sbi PROP] where
-  fupd_keep_si_pure {E} E' Pi (R : PROP) :
+  fupd_keep_siPure {E} E' Pi (R : PROP) :
     (|={E,E'}=> <si_pure> Pi) ∧ (<si_pure> Pi ={E}=∗ R) ⊢ |={E}=> R
-  fupd_si_pure_later (E : CoPset) (Pi : SiProp) :
+  fupd_siPure_later (E : CoPset) (Pi : SiProp) :
     (▷ |={E}=> <si_pure> Pi) ⊢@{PROP} |={E}=> ▷ ◇ <si_pure> Pi
-  fupd_si_pure_sForall_2 (E : CoPset) (Ψi : SiProp → Prop) :
+  fupd_siPure_sForall_2 (E : CoPset) (Ψi : SiProp → Prop) :
     (∀ q, ⌜Ψi q⌝ → |={E}=> <si_pure> q) ⊢@{PROP} |={E}=> <si_pure> (sForall Ψi)
 
 @[rocq_alias BiBUpdSbi]
 class BIBUpdateSbi (PROP : Type _) [BI PROP] [BIUpdate PROP] [Sbi PROP] where
-  bupd_si_pure (Pi : SiProp) : iprop(|==> <si_pure> Pi ⊢@{PROP} <si_pure> Pi)
+  bupd_siPure (Pi : SiProp) : iprop(|==> <si_pure> Pi ⊢@{PROP} <si_pure> Pi)
 
 section BUpdLaws
 
@@ -337,7 +337,7 @@ open BIUpdate
 
 @[rocq_alias bupd_plainly]
 theorem bupd_plainly {P : PROP} : (|==> ■ P) ⊢ ■ P :=
-  BIBUpdateSbi.bupd_si_pure (SiEmpValid.siEmpValid P)
+  BIBUpdateSbi.bupd_siPure (SiEmpValid.siEmpValid P)
 
 @[rocq_alias bupd_plainly_elim]
 theorem bupd_plainly_elim {P : PROP} [Absorbing P] : (|==> ■ P) ⊢ P :=
@@ -720,24 +720,24 @@ variable [Sbi PROP] [BIFUpdate PROP] [BIFUpdateSbi PROP]
 open BIFUpdate BIFUpdateSbi
 
 @[rocq_alias fupd_keep_si_pure]
-theorem fupd_keep_si_pure {E1 E2 : CoPset} E2' Pi {R : PROP} :
+theorem fupd_keep_siPure {E1 E2 : CoPset} E2' Pi {R : PROP} :
     (|={E1,E2'}=> <si_pure> Pi) ∧ (<si_pure> Pi ={E1,E2}=∗ R) ⊢ |={E1,E2}=> R := calc
   _ ⊢ (|={E1, E2'}=> <si_pure> Pi) ∧ (<si_pure> Pi ={E1}=∗ |={E1, E2}=> R) :=
       and_mono_right <| wand_mono_right fupd_intro
   _ ⊢ |={E1}=> |={E1, E2}=> R :=
-      BIFUpdateSbi.fupd_keep_si_pure E2' Pi iprop(|={E1,E2}=> R)
+      BIFUpdateSbi.fupd_keep_siPure E2' Pi iprop(|={E1,E2}=> R)
   _ ⊢ |={E1, E2}=> R := trans
 
 @[rocq_alias fupd_keep_plainly]
 theorem fupd_keep_plainly [BIAffine PROP] {E1 E2 : CoPset} E2' (P : PROP) {R : PROP} :
   (|={E1,E2'}=> ■ P) ∧ (P ={E1,E2}=∗ R) ⊢ |={E1,E2}=> R :=
   (and_mono_right (wand_mono_left siPure_siEmpValid_elim)).trans <|
-    fupd_keep_si_pure E2' (SiEmpValid.siEmpValid P)
+    fupd_keep_siPure E2' (SiEmpValid.siEmpValid P)
 
 @[rocq_alias fupd_plainly_later]
 theorem fupd_plainly_later [BIAffine PROP] (E : CoPset) (P : PROP) :
     (▷ |={E}=> ■ P) ⊢ |={E}=> ▷ ◇ P :=
-  (BIFUpdateSbi.fupd_si_pure_later E iprop(<si_emp_valid> P)).trans <|
+  (BIFUpdateSbi.fupd_siPure_later E iprop(<si_emp_valid> P)).trans <|
     mono <| later_mono <| except0_mono siPure_siEmpValid_elim
 
 @[rocq_alias fupd_keep_plain]
@@ -791,15 +791,15 @@ theorem sForall_eq_forall {Φ : α → PROP} :
    sForall_intro fun _ ⟨a, hp⟩ => hp ▸ forall_elim a⟩
 
 /--
-  Proves that the Rocq class field `fupd_siPure_forall_2` for `BIFUpdSbi`
-  follows from `BIFUpdateSbi.fupd_si_pure_sForall_2`.
+  Proves that the Rocq class field `fupd_si_pure_forall_2` for `BIFUpdSbi`
+  follows from `BIFUpdateSbi.fupd_siPure_sForall_2`.
 -/
 theorem fupd_siPure_forall_2 {E : CoPset} {A : Sort _} {Φi : A → SiProp} :
     (∀ x, |={E}=> <si_pure> Φi x) ⊢@{PROP} |={E}=> ∀ x, <si_pure> Φi x := calc
   _ ⊢ ∀ q, ⌜∃ x, q = Φi x⌝ → |={E}=> <si_pure> q :=
       forall_intro fun _ => imp_intro_swap <| pure_elim_left fun ⟨x, hx⟩ => hx ▸ forall_elim x
   _ ⊢@{PROP} |={E}=> <si_pure> (sForall fun q => ∃ x, q = Φi x) :=
-      BIFUpdateSbi.fupd_si_pure_sForall_2 E _
+      BIFUpdateSbi.fupd_siPure_sForall_2 E _
   _ ⊢ |={E}=> ∀ x, <si_pure> Φi x :=
       mono <| forall_intro fun x => siPure_mono (sForall_elim ⟨x, rfl⟩)
 

--- a/Iris/Iris/BI/Updates.lean
+++ b/Iris/Iris/BI/Updates.lean
@@ -790,7 +790,10 @@ theorem sForall_eq_forall {Φ : α → PROP} :
   ⟨forall_intro fun a => sForall_elim ⟨a, rfl⟩,
    sForall_intro fun _ ⟨a, hp⟩ => hp ▸ forall_elim a⟩
 
-@[rocq_alias fupd_si_pure_forall_2]
+/--
+  Proves that the Rocq class field `fupd_siPure_forall_2` for `BIFUpdSbi`
+  follows from `BIFUpdateSbi.fupd_si_pure_sForall_2`.
+-/
 theorem fupd_siPure_forall_2 {E : CoPset} {A : Sort _} {Φi : A → SiProp} :
     (∀ x, |={E}=> <si_pure> Φi x) ⊢@{PROP} |={E}=> ∀ x, <si_pure> Φi x := calc
   _ ⊢ ∀ q, ⌜∃ x, q = Φi x⌝ → |={E}=> <si_pure> q :=

--- a/Iris/Iris/BI/Updates.lean
+++ b/Iris/Iris/BI/Updates.lean
@@ -821,7 +821,7 @@ theorem fupd_plain_forall [BIAffine PROP] {E1 E2 : CoPset} {Φ : α → PROP}
     calc
       _ ⊢ ■ (∀ a, Φ a)             := Plain.plain
       _ ⊢ |={E1,E2}=> ■ (∀ a, Φ a) := fupd_mask_intro_discard h
-      _ ⊢ |={E1,E2}=> |={E2}=> _   := mono <| fupd_intro.trans (fupd_plainly_mask E E)
+      _ ⊢ |={E1,E2}=> |={E2}=> _   := mono <| fupd_intro.trans <| fupd_plainly_mask E2 E2
       _ ⊢ |={E1,E2}=> ∀ a, Φ a     := trans
 
 @[rocq_alias step_fupd_plain_forall]

--- a/Iris/Iris/Instances/Lib/FUpd.lean
+++ b/Iris/Iris/Instances/Lib/FUpd.lean
@@ -359,10 +359,10 @@ instance uPred_bi_fupd_plainly_no_lc {GF : BundledGFunctors} [INV : InvGS_gen .h
       iapply fupd_finally_forall
       iintro %hq
       iapply fupd_fupd_finally
+      -- TODO: replace with `imod H $$ %q %hq with #Hq` once `intoForall_imp_pure` is available
       have h : ⊢@{IProp GF} ⌜Ψi q⌝ := by ipureintro; exact hq
       ihave Hq := h
-      ispecialize H $$ %q Hq
-      imod H with #Hq
+      imod H $$ %q Hq with #Hq
       imodintro
       iapply fupd_finally_intro
       iintro !> //

--- a/Iris/Iris/Instances/Lib/FUpd.lean
+++ b/Iris/Iris/Instances/Lib/FUpd.lean
@@ -326,7 +326,7 @@ theorem fupd_finally_keep {E : CoPset} (P : IProp GF) {Q : IProp GF} [TCOr (TCEq
 
 @[rocq_alias uPred_bi_fupd_sbi_no_lc]
 instance uPred_bi_fupd_plainly_no_lc {GF : BundledGFunctors} [INV : InvGS_gen .hasNoLC GF] :
-    BIFUpdatePlainly (IProp GF) where
+    BIFUpdateSbi (IProp GF) where
   fupd_keep_si_pure E' Pi R := by
     iintro H
     iapply fupd_keep iprop(<si_pure> Pi)
@@ -336,10 +336,10 @@ instance uPred_bi_fupd_plainly_no_lc {GF : BundledGFunctors} [INV : InvGS_gen .h
       iapply BIFUpdate.mono (fupd_finally_intro E' iprop(<si_pure> Pi))
       iapply BIFUpdate.mono Plain.plain $$ H
     · icases H with ⟨-, $⟩
-  fupd_plainly_later _ P := by
+  fupd_si_pure_later _ P := by
     simp only [fupd, uPred_fupd]
     iintro H ⟨Hwsat, HE⟩
-    ihave #HP : ▷ ◇ ■ P $$ [H Hwsat HE]
+    ihave #HP : ▷ ◇ <si_pure> P $$ [H Hwsat HE]
     · inext
       ihave H := H $$ [$]
       icases le_upd_unfold_no_le.mp $$ H with H
@@ -347,18 +347,27 @@ instance uPred_bi_fupd_plainly_no_lc {GF : BundledGFunctors} [INV : InvGS_gen .h
     imodintro
     iframe
     inext; imod HP; imodintro
-    iapply plainly_elim $$ HP
-  fupd_plainly_sForall_2 E P := by
-    simp only [fupd, uPred_fupd]
-    iintro H ⟨Hwsat, HE⟩
-    ihave #HP : ◇ ■ sForall P $$ [H Hwsat HE]
-    · ihave H := H $$ [$]
-      icases le_upd_unfold_no_le.mp $$ H with H
-      imod H with ⟨_, _, $⟩
-    imod HP; imodintro
-    iframe
-    iclear H
-    iapply plainly_elim $$ HP
+    iexact HP
+  fupd_si_pure_sForall_2 E Ψi := by
+    iintro H
+    iapply fupd_keep iprop(<si_pure> (sForall Ψi))
+    isplit
+    · iapply fupd_finally_mono (siPure_sForall_mpr (Ψi := Ψi))
+      iapply fupd_finally_forall
+      iintro %q
+      iapply fupd_finally_mono pure_imp_forall.mpr
+      iapply fupd_finally_forall
+      iintro %hq
+      iapply fupd_fupd_finally
+      have h : ⊢@{IProp GF} ⌜Ψi q⌝ := by ipureintro; exact hq
+      ihave Hq := h
+      ispecialize H $$ %q Hq
+      imod H with #Hq
+      imodintro
+      iapply fupd_finally_intro
+      iintro !> //
+    · iintro Hall
+      iapply fupd_mask_intro_discard LawfulSet.subset_refl $$ Hall
 
 @[rocq_alias fupd_finally_mask_mono]
 theorem fupd_finally_mask_mono (E1 E2 : CoPset) (P : IProp GF) (H : E1 ⊆ E2) :
@@ -528,7 +537,7 @@ end Soundness
 
 section StepIndexed
 
-open Iris Std LawfulSet BIFUpdatePlainly
+open Iris Std LawfulSet BIFUpdateSbi
 
 variable {GF : BundledGFunctors}
 

--- a/Iris/Iris/Instances/Lib/FUpd.lean
+++ b/Iris/Iris/Instances/Lib/FUpd.lean
@@ -327,7 +327,7 @@ theorem fupd_finally_keep {E : CoPset} (P : IProp GF) {Q : IProp GF} [TCOr (TCEq
 @[rocq_alias uPred_bi_fupd_sbi_no_lc]
 instance uPred_bi_fupd_plainly_no_lc {GF : BundledGFunctors} [INV : InvGS_gen .hasNoLC GF] :
     BIFUpdateSbi (IProp GF) where
-  fupd_keep_si_pure E' Pi R := by
+  fupd_keep_siPure E' Pi R := by
     iintro H
     iapply fupd_keep iprop(<si_pure> Pi)
     isplit
@@ -336,7 +336,7 @@ instance uPred_bi_fupd_plainly_no_lc {GF : BundledGFunctors} [INV : InvGS_gen .h
       iapply BIFUpdate.mono (fupd_finally_intro E' iprop(<si_pure> Pi))
       iapply BIFUpdate.mono Plain.plain $$ H
     · icases H with ⟨-, $⟩
-  fupd_si_pure_later _ P := by
+  fupd_siPure_later _ P := by
     simp only [fupd, uPred_fupd]
     iintro H ⟨Hwsat, HE⟩
     ihave #HP : ▷ ◇ <si_pure> P $$ [H Hwsat HE]
@@ -348,7 +348,7 @@ instance uPred_bi_fupd_plainly_no_lc {GF : BundledGFunctors} [INV : InvGS_gen .h
     iframe
     inext; imod HP; imodintro
     iexact HP
-  fupd_si_pure_sForall_2 E Ψi := by
+  fupd_siPure_sForall_2 E Ψi := by
     iintro H
     iapply fupd_keep iprop(<si_pure> (sForall Ψi))
     isplit

--- a/Iris/Iris/Instances/Lib/FUpd.lean
+++ b/Iris/Iris/Instances/Lib/FUpd.lean
@@ -359,10 +359,7 @@ instance uPred_bi_fupd_plainly_no_lc {GF : BundledGFunctors} [INV : InvGS_gen .h
       iapply fupd_finally_forall
       iintro %hq
       iapply fupd_fupd_finally
-      -- TODO: replace with `imod H $$ %q %hq with #Hq` once `intoForall_imp_pure` is available
-      have h : ⊢@{IProp GF} ⌜Ψi q⌝ := by ipureintro; exact hq
-      ihave Hq := h
-      imod H $$ %q Hq with #Hq
+      imod H $$ %q %hq with #Hq
       imodintro
       iapply fupd_finally_intro
       iintro !> //

--- a/Iris/Iris/Instances/UPred/Instance.lean
+++ b/Iris/Iris/Instances/UPred/Instance.lean
@@ -650,7 +650,7 @@ instance : BIUpdate (UPred M) where
 #rocq_ignore uPred_bupd_mixin "Inlined in BIUpdate instance construction"
 
 @[rocq_alias uPred_primitive.bupd_si_pure]
-theorem bupd_si_pure (Pi : SiProp) : (|==> <si_pure> Pi : UPred M) ⊢ <si_pure> Pi := by
+theorem bupd_siPure (Pi : SiProp) : (|==> <si_pure> Pi : UPred M) ⊢ <si_pure> Pi := by
   intro n x Hv
   have L : ✓{n} x.val • unit := unit_right_id.symm.dist.validN.1 x.property
   let ⟨_, _, Hv'⟩ := Hv n unit n.le_refl L
@@ -658,7 +658,7 @@ theorem bupd_si_pure (Pi : SiProp) : (|==> <si_pure> Pi : UPred M) ⊢ <si_pure>
 
 @[rocq_alias uPred_bi_bupd_sbi]
 instance : BIBUpdateSbi (UPred M) where
-  bupd_si_pure := bupd_si_pure
+  bupd_siPure := bupd_siPure
 
 @[rocq_alias uPred_primitive.ownM_valid, rocq_alias uPred.ownM_valid]
 theorem ownM_valid (m : M) : ownM m ⊢ internalCmraValid m := fun _ h hp => hp.validN h.property

--- a/Iris/Iris/ProofMode.lean
+++ b/Iris/Iris/ProofMode.lean
@@ -19,6 +19,7 @@ public import Iris.ProofMode.NatCancel
 public import Iris.ProofMode.Patterns
 public import Iris.ProofMode.Porting
 public import Iris.ProofMode.ProofModeM
+public import Iris.ProofMode.SolveSideCondition
 public import Iris.ProofMode.SynthInstance
 public import Iris.ProofMode.SynthInstanceAttr
 public import Iris.ProofMode.Tactics

--- a/Iris/Iris/ProofMode/InstancesUpdates.lean
+++ b/Iris/Iris/ProofMode/InstancesUpdates.lean
@@ -303,20 +303,27 @@ end BIFancyUpdate
 
 section SBIFancyUpdate
 
-variable {PROP} [Sbi PROP] [BIFUpdate PROP] [BIFUpdatePlainly PROP] [BIAffine PROP]
+variable {PROP} [Sbi PROP] [BIFUpdate PROP] [BIFUpdateSbi PROP] [BIAffine PROP]
 
--- TODO:
--- `fromForall_fupd` needs a derived plain/fupd/forall lemma.
--- `fromForall_stepFupd` additionally needs a step-fupd/forall theorem in `BI/Updates.lean`.
--- instance fromForall_fupd E1 E2 (P : PROP) {α : Type _} (Φ : α → PROP)
---     [hmask : TCOr (E1 = E2) (TCOr (E1 = ⊤) (E2 = ∅))]
---     [h : FromForall P Φ] [∀ a, Plain (Φ a)] :
---     FromForall iprop(|={E1,E2}=> P) (fun a => iprop(|={E1,E2}=> Φ a)) where
---   from_forall := sorry
+private theorem subset {E1 E2 : CoPset}
+    (inst : TCOr (TCEq E1 E2) (TCOr (TCEq E1 ⊤) (TCEq E2 ∅))) : E2 ⊆ E1 := by
+  match inst with
+  | @TCOr.l _ _ instEq               => rw [instEq.to_eq]
+  | @TCOr.r _ _ (@TCOr.l _ _ instEq) => rw [instEq.to_eq]; exact CoPset.subseteq_top
+  | @TCOr.r _ _ (@TCOr.r _ _ instEq) => rw [instEq.to_eq]; exact LawfulSet.empty_subset
 
--- instance fromForall_stepFupd E (P : PROP) (Φ : α → PROP)
---     [h : FromForall P Φ] [∀ a, Plain (Φ a)] :
---     FromForall iprop(|={E}▷=> P) (fun a => iprop(|={E}▷=> Φ a)) where
---   from_forall := sorry
+@[ipm_backtrack, rocq_alias from_forall_fupd]
+instance fromForall_fupd E1 E2 (P : PROP) {α : Type _} (Φ : α → PROP)
+    [hm : TCOr (TCEq E1 E2) (TCOr (TCEq E1 ⊤) (TCEq E2 ∅))]
+    [h : FromForall P Φ] [∀ a, Plain (Φ a)] :
+    FromForall iprop(|={E1,E2}=> P) (fun a => iprop(|={E1,E2}=> Φ a)) where
+  from_forall := (fupd_plain_forall (subset hm)).mpr.trans (mono h.from_forall)
+
+@[ipm_backtrack, rocq_alias from_forall_step_fupd]
+instance fromForall_stepFupd E1 E2 (P : PROP) (Φ : α → PROP)
+    [hm : TCOr (TCEq E1 E2) (TCOr (TCEq E1 ⊤) (TCEq E2 ∅))]
+    [h : FromForall P Φ] [∀ a, Plain (Φ a)] :
+    FromForall iprop(|={E1}[E2]▷=> P) (fun a => iprop(|={E1}[E2]▷=> Φ a)) where
+  from_forall := (step_fupd_plain_forall (subset hm)).mpr.trans (step_fupd_mono h.from_forall)
 
 end SBIFancyUpdate

--- a/Iris/Iris/ProofMode/InstancesUpdates.lean
+++ b/Iris/Iris/ProofMode/InstancesUpdates.lean
@@ -305,26 +305,18 @@ section SBIFancyUpdate
 
 variable {PROP} [Sbi PROP] [BIFUpdate PROP] [BIFUpdateSbi PROP] [BIAffine PROP]
 
-private theorem subset {E1 E2 : CoPset}
-    (inst : TCOr (TCEq E1 E2) (TCOr (TCEq E1 ⊤) (TCEq E2 ∅))) : E2 ⊆ E1 := by
-  match inst with
-  | @TCOr.l _ _ instEq               => rw [instEq.to_eq]
-  | @TCOr.r _ _ (@TCOr.l _ _ instEq) => rw [instEq.to_eq]; exact CoPset.subseteq_top
-  | @TCOr.r _ _ (@TCOr.r _ _ instEq) => rw [instEq.to_eq]; exact LawfulSet.empty_subset
-
 @[ipm_backtrack, rocq_alias from_forall_fupd]
 instance fromForall_fupd E1 E2 (P : PROP) {α : Type _} (Φ : α → PROP)
-    -- TODO: generalize this to `TCSidecondition (E1 ⊆ E2)`, which uses iSolveSidecondition
-    [hm : TCOr (TCEq E1 E2) (TCOr (TCEq E1 ⊤) (TCEq E2 ∅))]
+    [inst : TCSideCondition (E2 ⊆ E1)]
     [h : FromForall P Φ] [∀ a, Plain (Φ a)] :
     FromForall iprop(|={E1,E2}=> P) (fun a => iprop(|={E1,E2}=> Φ a)) where
-  from_forall := (fupd_plain_forall (subset hm)).mpr.trans (mono h.from_forall)
+  from_forall := (fupd_plain_forall inst.sidecondition).mpr.trans (mono h.from_forall)
 
 @[ipm_backtrack, rocq_alias from_forall_step_fupd]
 instance fromForall_stepFupd E1 E2 (P : PROP) (Φ : α → PROP)
-    [hm : TCOr (TCEq E1 E2) (TCOr (TCEq E1 ⊤) (TCEq E2 ∅))]
+    [inst : TCSideCondition (E2 ⊆ E1)]
     [h : FromForall P Φ] [∀ a, Plain (Φ a)] :
     FromForall iprop(|={E1}[E2]▷=> P) (fun a => iprop(|={E1}[E2]▷=> Φ a)) where
-  from_forall := (step_fupd_plain_forall (subset hm)).mpr.trans (step_fupd_mono h.from_forall)
+  from_forall := (step_fupd_plain_forall inst.sidecondition).mpr.trans (step_fupd_mono h.from_forall)
 
 end SBIFancyUpdate

--- a/Iris/Iris/ProofMode/InstancesUpdates.lean
+++ b/Iris/Iris/ProofMode/InstancesUpdates.lean
@@ -314,6 +314,7 @@ private theorem subset {E1 E2 : CoPset}
 
 @[ipm_backtrack, rocq_alias from_forall_fupd]
 instance fromForall_fupd E1 E2 (P : PROP) {α : Type _} (Φ : α → PROP)
+    -- TODO: generalize this to `TCSidecondition (E1 ⊆ E2)`, which uses iSolveSidecondition
     [hm : TCOr (TCEq E1 E2) (TCOr (TCEq E1 ⊤) (TCEq E2 ∅))]
     [h : FromForall P Φ] [∀ a, Plain (Φ a)] :
     FromForall iprop(|={E1,E2}=> P) (fun a => iprop(|={E1,E2}=> Φ a)) where

--- a/Iris/Iris/ProofMode/SolveSideCondition.lean
+++ b/Iris/Iris/ProofMode/SolveSideCondition.lean
@@ -1,0 +1,74 @@
+/-
+Copyright (c) 2026 Alvin Tang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alvin Tang
+-/
+module
+
+public import Iris.ProofMode.ProofModeM
+public import Iris.ProofMode.SynthInstance
+
+@[expose] public section
+
+namespace Iris.ProofMode
+
+public meta section
+open Lean Elab Tactic Term Meta Qq
+
+/-- Check for `PMError` and create the goal for `target`. Throws on `PMError`. -/
+def mkSideConditionGoal (target : Q(Prop)) : MetaM Q($target) := do
+  match ← instantiateMVars target with
+  | .app (.const ``PMError _) (.lit (.strVal msg)) => throwError "{msg}"
+  | _ => mkFreshExprSyntheticOpaqueMVar q($target)
+
+/--
+  Attempts to solve the side condition `target`.
+
+  When `failOnUnsolved` is set as `true`, this function throws an error when
+  the side condition cannot be solved automatically.
+
+  Otherwise, when `failOnUnsolved` is set as `false`, the unsolved subgoals
+  are added to the proof state for the user.
+-/
+def iSolveSidecondition (target : Q(Prop)) (failOnUnsolved := true) : ProofModeM Q($target) := do
+  let pf ← mkSideConditionGoal target
+  let tac ← `(tactic| (and_intros <;> (first | trivial | infer_instance | (simp [*] <;> done))))
+  let gs ← (observing? <| evalTacticAt tac pf.mvarId!) <&> (·.getD [pf.mvarId!])
+  if !gs.isEmpty then
+    if failOnUnsolved then
+      throwIPMError "failed to solve side condition {target}"
+    else
+      for g in gs do addMVarGoal g
+  return pf
+
+end
+
+public meta section
+open Lean Elab Tactic Term Meta Qq
+
+/-- For side conditions in IPM type classes to be discharged automatically. -/
+@[ipm_class]
+class TCSideCondition (φ : Prop) : Prop where
+  sidecondition : φ
+
+def runTacticOn (mvarId : MVarId) (tac : TSyntax `tactic) : MetaM (List MVarId) :=
+  TermElabM.run' (Lean.Elab.Tactic.run mvarId (evalTactic tac))
+
+@[ipm_tactic_instance TCSideCondition _]
+def solveTCSideCondition : SynthTactic := fun e => do
+  let_expr TCSideCondition φ := e | return .continue
+  have φ : Q(Prop) := φ
+  if (← instantiateMVars φ).hasExprMVar then
+    return .continue
+  let s ← saveState
+  let pf ← mkSideConditionGoal φ
+  let tac ← `(tactic| (and_intros <;> (first | trivial | infer_instance | (simp [*] <;> done))))
+  let gs ← (observing? <| runTacticOn pf.mvarId! tac) <&> (·.getD [pf.mvarId!])
+  -- Successful TC synthesis if and only if the side condition is completely solved
+  if gs.isEmpty then
+    return .success q(⟨$pf⟩ : TCSideCondition $φ)
+  else
+    s.restore
+    return .continue
+
+end

--- a/Iris/Iris/ProofMode/SolveSideCondition.lean
+++ b/Iris/Iris/ProofMode/SolveSideCondition.lean
@@ -21,6 +21,10 @@ def mkSideConditionGoal (target : Q(Prop)) : MetaM Q($target) := do
   | .app (.const ``PMError _) (.lit (.strVal msg)) => throwError "{msg}"
   | _ => mkFreshExprSyntheticOpaqueMVar q($target)
 
+def sideconditionTactic : MetaM (TSyntax `tactic) :=
+  `(tactic| (and_intros <;>
+     (first | trivial | infer_instance | (simp [*] <;> done))))
+
 /--
   Attempts to solve the side condition `target`.
 
@@ -32,7 +36,7 @@ def mkSideConditionGoal (target : Q(Prop)) : MetaM Q($target) := do
 -/
 def iSolveSidecondition (target : Q(Prop)) (failOnUnsolved := true) : ProofModeM Q($target) := do
   let pf ← mkSideConditionGoal target
-  let tac ← `(tactic| (and_intros <;> (first | trivial | infer_instance | (simp [*] <;> done))))
+  let tac ← sideconditionTactic
   let gs ← (observing? <| evalTacticAt tac pf.mvarId!) <&> (·.getD [pf.mvarId!])
   if !gs.isEmpty then
     if failOnUnsolved then
@@ -62,7 +66,7 @@ def solveTCSideCondition : SynthTactic := fun e => do
     return .continue
   let s ← saveState
   let pf ← mkSideConditionGoal φ
-  let tac ← `(tactic| (and_intros <;> (first | trivial | infer_instance | (simp [*] <;> done))))
+  let tac ← sideconditionTactic
   let gs ← (observing? <| runTacticOn pf.mvarId! tac) <&> (·.getD [pf.mvarId!])
   -- Successful TC synthesis if and only if the side condition is completely solved
   if gs.isEmpty then

--- a/Iris/Iris/ProofMode/SolveSideCondition.lean
+++ b/Iris/Iris/ProofMode/SolveSideCondition.lean
@@ -56,23 +56,29 @@ class TCSideCondition (φ : Prop) : Prop where
   sidecondition : φ
 
 def runTacticOn (mvarId : MVarId) (tac : TSyntax `tactic) : MetaM (List MVarId) :=
-  TermElabM.run' (Lean.Elab.Tactic.run mvarId (evalTactic tac))
+  TermElabM.run' <| run mvarId (withoutRecover <| evalTactic tac)
 
 @[ipm_tactic_instance TCSideCondition _]
 def solveTCSideCondition : SynthTactic := fun e => do
   let_expr TCSideCondition φ := e | return .continue
   have φ : Q(Prop) := φ
-  if (← instantiateMVars φ).hasExprMVar then
+  -- The side condition may contain metavariables but not itself be one
+  if (← instantiateMVars φ).getAppFn.isMVar then
     return .continue
   let s ← saveState
-  let pf ← mkSideConditionGoal φ
-  let tac ← sideconditionTactic
-  let gs ← (observing? <| runTacticOn pf.mvarId! tac) <&> (·.getD [pf.mvarId!])
-  -- Successful TC synthesis if and only if the side condition is completely solved
-  if gs.isEmpty then
+  let res ← withNewMCtxDepth do
+    let pf ← mkSideConditionGoal φ
+    let tac ← sideconditionTactic
+    let gs ← (observing? <| runTacticOn pf.mvarId! tac) <&> (·.getD [pf.mvarId!])
+    if gs.isEmpty then
+      let pf ← instantiateMVars pf
+      if pf.hasSorry then return none else return some pf
+    else
+      return none
+  match res with
+  | some pf =>
+    have pf : Q($φ) := pf
     return .success q(⟨$pf⟩ : TCSideCondition $φ)
-  else
-    s.restore
-    return .continue
+  | none => s.restore; return .continue
 
 end

--- a/Iris/Iris/ProofMode/SolveSideCondition.lean
+++ b/Iris/Iris/ProofMode/SolveSideCondition.lean
@@ -66,13 +66,14 @@ def solveTCSideCondition : SynthTactic := fun e => do
   if (← instantiateMVars φ).getAppFn.isMVar then
     return .continue
   let s ← saveState
+  -- new context depth to prevent instantiation of mvars
   let res ← withNewMCtxDepth do
     let pf ← mkSideConditionGoal φ
     let tac ← sideconditionTactic
-    let gs ← (observing? <| runTacticOn pf.mvarId! tac) <&> (·.getD [pf.mvarId!])
+    let some gs ← observing? <| runTacticOn pf.mvarId! tac
+      | return none
     if gs.isEmpty then
-      let pf ← instantiateMVars pf
-      if pf.hasSorry then return none else return some pf
+      return some <| ← instantiateMVars pf
     else
       return none
   match res with

--- a/Iris/Iris/ProofMode/Tactics/Basic.lean
+++ b/Iris/Iris/ProofMode/Tactics/Basic.lean
@@ -29,31 +29,6 @@ macro_rules | `(tactic| itrivial) => `(tactic| mytac)
 syntax "itrivial" : tactic
 
 /--
-  Attempts to solve the side condition `target`.
-
-  When `failOnUnsolved` is set as `true`, this function throws an error when
-  the side condition cannot be solved automatically.
-
-  Otherwise, when `failOnUnsolved` is set as `false`, the unsolved subgoals
-  are added to the proof state for the user.
--/
-def iSolveSidecondition (target : Q(Prop)) (failOnUnsolved := true) : ProofModeM Q($target) := do
-  let mvar ← mkFreshExprSyntheticOpaqueMVar q($target)
-  match ← instantiateMVars target with
-  | .app (.const ``PMError _) (.lit (.strVal msg)) =>
-      throwError "{msg}"
-  | _ =>
-      let gs ← (observing? <|
-        evalTacticAt (← `(tactic | (and_intros <;> (first | trivial | infer_instance | (simp [*] <;> done))))) mvar.mvarId!) <&>
-        (·.getD [mvar.mvarId!])
-      if !gs.isEmpty then
-        if failOnUnsolved then
-          throwError "iSolveSidecondition: failed to solve side condition {target}"
-        else
-          for g in gs do addMVarGoal g
-      return mvar
-
-/--
   `istart` starts the Iris Proof Mode.
 -/
 elab "istart" : tactic => do

--- a/Iris/Iris/ProofMode/Tactics/Mod.lean
+++ b/Iris/Iris/ProofMode/Tactics/Mod.lean
@@ -7,6 +7,7 @@ module
 
 import Iris.BI
 public import Iris.ProofMode.Classes
+public import Iris.ProofMode.SolveSideCondition
 public import Iris.ProofMode.Tactics.Basic
 
 namespace Iris.ProofMode

--- a/Iris/Iris/ProofMode/Tactics/ModIntro.lean
+++ b/Iris/Iris/ProofMode/Tactics/ModIntro.lean
@@ -6,6 +6,7 @@ Authors: Michael Sammler
 module
 
 import Iris.ProofMode.Modalities
+public import Iris.ProofMode.SolveSideCondition
 public meta import Iris.ProofMode.Tactics.Basic
 
 namespace Iris.ProofMode

--- a/Iris/Iris/Std/TC.lean
+++ b/Iris/Iris/Std/TC.lean
@@ -40,6 +40,9 @@ class inductive TCEq {α : Sort _} (a : α) : α → Prop
 
 instance {α : Sort _} {a : α} : TCEq a a := TCEq.refl
 
+theorem TCEq.to_eq {α : Sort _} {a b : α} : TCEq a b → a = b
+  | .refl => rfl
+
 /-- Type class version of `Ite`, i.e. a type class for which an instance exists if the boolean
 condition is `true` and an instance of `T` is present or the condition is `false` and an instance
 of `U` is present.

--- a/Iris/IrisTest/Instances.lean
+++ b/Iris/IrisTest/Instances.lean
@@ -629,4 +629,14 @@ variable (E : CoPset) (Ψ : Nat → PROP) [∀ n, Plain (Ψ n)]
 #guard_msgs (whitespace := lax) in
 #ipm_synth @FromForall PROP _ iprop(|={E,∅}=> ∀ x, Ψ x) (_ : Type) _
 
+/- Tests `fromForall_fupd` with mvar, which should not be instantiated. -/
+/-- info: None -/
+#guard_msgs (whitespace := lax) in
+#ipm_synth @FromForall PROP _ iprop(|={E,_}=> ∀ x, Ψ x) (_ : Type) _
+
+/- Tests `fromForall_fupd` with mvar sidecondition that can be solved. -/
+/-- info: solution: FromForall iprop(|={?E}=> ∀ x, Ψ x) fun a => iprop(|={?E}=> Ψ a), new goals: [] -/
+#guard_msgs (whitespace := lax) in
+#ipm_synth @FromForall PROP _ iprop(|={?E,?E}=> ∀ x, Ψ x) (_ : Type) _
+
 end TCSideCondition

--- a/Iris/IrisTest/Instances.lean
+++ b/Iris/IrisTest/Instances.lean
@@ -605,6 +605,25 @@ section TCSideCondition
 variable [Sbi PROP] [BIFUpdate PROP] [BIFUpdateSbi PROP] [BIAffine PROP]
 variable (E : CoPset) (Ψ : Nat → PROP) [∀ n, Plain (Ψ n)]
 
+/- Tests `TCSideCondition` with sidecondition that can be solved. -/
+/-- info: solution: TCSideCondition (E ⊆ ⊤), new goals: [] -/
+#guard_msgs (whitespace := lax) in
+set_option pp.mvars false in
+#ipm_synth TCSideCondition (E ⊆ ⊤)
+
+/- Tests `TCSideCondition` with mvar, which should not be instantiated. -/
+/-- info: None -/
+#guard_msgs (whitespace := lax) in
+set_option pp.mvars false in
+#ipm_synth TCSideCondition (_ ⊆ E)
+
+/- Tests `TCSideCondition` with mvar sidecondition that can be solved. -/
+/-- info: solution: TCSideCondition (?_ ⊆ ?_), new goals: [?_: CoPset] -/
+#guard_msgs (whitespace := lax) in
+set_option pp.mvars false in
+#ipm_synth TCSideCondition ((?E : CoPset) ⊆ ?E)
+
+
 /- Tests `fromForall_fupd` with the side condition `E ⊆ E` discharged. -/
 /-- info:
   solution: FromForall iprop(|={E}=> ∀ x, Ψ x) fun a => iprop(|={E}=> Ψ a),
@@ -634,14 +653,5 @@ variable (E : CoPset) (Ψ : Nat → PROP) [∀ n, Plain (Ψ n)]
 #guard_msgs (whitespace := lax) in
 set_option pp.mvars false in
 #ipm_synth @FromForall PROP _ iprop(|={E,_}=> ∀ x, Ψ x) (_ : Type) _
-
-/- Tests `fromForall_fupd` with mvar sidecondition that can be solved. -/
-/-- info:
-  solution: FromForall iprop(|={?_}=> ∀ x, Ψ x) fun a => iprop(|={?_}=> Ψ a),
-  new goals: [?_: CoPset]
--/
-#guard_msgs (whitespace := lax) in
-set_option pp.mvars false in
-#ipm_synth @FromForall PROP _ iprop(|={?E,?E}=> ∀ x, Ψ x) (_ : Type) _
 
 end TCSideCondition

--- a/Iris/IrisTest/Instances.lean
+++ b/Iris/IrisTest/Instances.lean
@@ -10,6 +10,7 @@ public import Iris.Algebra.Frac
 public import Iris.ProofMode.SynthInstance
 public import Iris.ProofMode.Instances
 public import Iris.ProofMode.InstancesMake
+public import Iris.ProofMode.InstancesUpdates
 public import Iris.ProofMode.NatCancel
 
 @[expose] public section
@@ -598,3 +599,34 @@ variable (p : Bool) in
 #ipm_synth (IntoWand p true iprop(∀ _ : φ, P) (.matching .argument) iprop(⌜φ⌝) _)
 
 end ProofModeInstances
+
+section TCSideCondition
+
+variable [Sbi PROP] [BIFUpdate PROP] [BIFUpdateSbi PROP] [BIAffine PROP]
+variable (E : CoPset) (Ψ : Nat → PROP) [∀ n, Plain (Ψ n)]
+
+/- Tests `fromForall_fupd` with the side condition `E ⊆ E` discharged. -/
+/-- info:
+  solution: FromForall iprop(|={E}=> ∀ x, Ψ x) fun a => iprop(|={E}=> Ψ a),
+  new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+#ipm_synth @FromForall PROP _ iprop(|={E,E}=> ∀ x, Ψ x) (_ : Type) _
+
+/- Tests `fromForall_fupd` with the side condition `E ⊆ ⊤` discharged. -/
+/-- info:
+  solution: FromForall iprop(|={⊤, E}=> ∀ x, Ψ x) fun a => iprop(|={⊤, E}=> Ψ a),
+  new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+#ipm_synth @FromForall PROP _ iprop(|={⊤,E}=> ∀ x, Ψ x) (_ : Type) _
+
+/- Tests `fromForall_fupd` with the side condition `∅ ⊆ E` discharged. -/
+/-- info:
+  solution: FromForall iprop(|={E, ∅}=> ∀ x, Ψ x) fun a => iprop(|={E, ∅}=> Ψ a),
+  new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+#ipm_synth @FromForall PROP _ iprop(|={E,∅}=> ∀ x, Ψ x) (_ : Type) _
+
+end TCSideCondition

--- a/Iris/IrisTest/Instances.lean
+++ b/Iris/IrisTest/Instances.lean
@@ -632,11 +632,16 @@ variable (E : CoPset) (Ψ : Nat → PROP) [∀ n, Plain (Ψ n)]
 /- Tests `fromForall_fupd` with mvar, which should not be instantiated. -/
 /-- info: None -/
 #guard_msgs (whitespace := lax) in
+set_option pp.mvars false in
 #ipm_synth @FromForall PROP _ iprop(|={E,_}=> ∀ x, Ψ x) (_ : Type) _
 
 /- Tests `fromForall_fupd` with mvar sidecondition that can be solved. -/
-/-- info: solution: FromForall iprop(|={?E}=> ∀ x, Ψ x) fun a => iprop(|={?E}=> Ψ a), new goals: [] -/
+/-- info:
+  solution: FromForall iprop(|={?_}=> ∀ x, Ψ x) fun a => iprop(|={?_}=> Ψ a),
+  new goals: [?_: CoPset]
+-/
 #guard_msgs (whitespace := lax) in
+set_option pp.mvars false in
 #ipm_synth @FromForall PROP _ iprop(|={?E,?E}=> ∀ x, Ψ x) (_ : Type) _
 
 end TCSideCondition


### PR DESCRIPTION
## Description

Resolves #255 in full. Addresses #280 in part.

The type class instances `fromForall_fupd` and `fromForall_stepFupd` are ported using the type class `BIFUpdateSbi`, which is in turn defined in terms of `<si_pure>`.

### Other Changes

Bug fixes for the instances [`forall_plain`](https://github.com/ISTA-PLV/iris-lean/blob/f8ea7bd/Iris/Iris/BI/Plainly.lean#L582-L584) and [`exists_plain`](https://github.com/ISTA-PLV/iris-lean/blob/f8ea7bd/Iris/Iris/BI/Plainly.lean#L586-L588): it is possible for `A` to be of type `Sort 0`.

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files
