### PR TITLE
feat: update HeapLang semantics, finishing lang and locations

### DIFF
--- a/Iris/Iris/HeapLang/Instances.lean
+++ b/Iris/Iris/HeapLang/Instances.lean
@@ -19,6 +19,7 @@ namespace Iris.HeapLang
 
 open ProgramLogic ProgramLogic.Language FromMathlib EctxItemLanguage EctxLanguage
 
+@[rocq_alias heap_lang.heap_lang.heap_lang_mixin]
 instance instEctxItemLanguageExp : EctxItemLanguage Exp ECtxItem State Observation Val where
   baseStep := fun ⟨e, σ⟩ obs ⟨e', σ', eps⟩ => BaseStep e σ obs e' σ' eps
   fillItem := ECtxItem.fill
@@ -63,6 +64,32 @@ theorem fill_isSome_empty {K : List ECtxItem} {e : Exp}
     rw [fill_cons] at h
     have h2 := EctxLanguage.fill_val (K := K') (e := fillItem Ki e) h
     simp [fillItem_expToVal_none] at h2
+
+@[rocq_alias heap_lang.to_val_fill_some]
+theorem toVal_fill_some {K : List ECtxItem} {e : Exp} {v : Val}
+    (h : toVal (fill K e) = some v) : K = [] ∧ e = Exp.ofVal v := by
+  obtain rfl := fill_isSome_empty (K := K) (e := e) (by simp [h])
+  exact ⟨rfl, (coe_of_toVal_eq_some (by simpa using h)).symm⟩
+
+-- The `EctxItemLanguage` instance above bundles what Rocq states as separate HeapLang lemmas and
+-- then packages into `heap_lang_mixin`; the generic projections of the class carry the
+-- `ectxi_language.v` aliases of the same names.
+#rocq_ignore heap_lang.heap_lang.fill_item_inj
+  "The `fillItem_inj` field of `instEctxItemLanguageExp`."
+#rocq_ignore heap_lang.heap_lang.fill_item_val
+  "The `fillItem_val` field of `instEctxItemLanguageExp`."
+#rocq_ignore heap_lang.heap_lang.fill_item_no_val_inj
+  "The `fillItem_no_val_inj` field of `instEctxItemLanguageExp`."
+#rocq_ignore heap_lang.heap_lang.val_base_stuck
+  "The `val_stuck` field of `instEctxItemLanguageExp`."
+#rocq_ignore heap_lang.heap_lang.base_ctx_step_val
+  "The `base_ctx_step_val` field of `instEctxItemLanguageExp`."
+#rocq_ignore heap_lang.heap_ectxi_lang
+  "`instEctxItemLanguageExp` is at once the mixin and the canonical structure it builds."
+#rocq_ignore heap_lang.heap_ectx_lang
+  "The generic `EctxItemLanguage.instEctxLanguage` (`EctxLanguageOfEctxi`) at `Exp`."
+#rocq_ignore heap_lang.heap_lang
+  "The generic `EctxLanguage.instLanguage` (`LanguageOfEctx`) at `Exp`."
 
 local macro "solve_subredex_values" : tactic =>
   `(tactic|
@@ -263,6 +290,9 @@ theorem primStep_val_baseStep {e : Exp} {σ : State} {obs : List Observation}
   subst hg
   exact Hbase
 
+attribute [rocq_alias heap_lang.prim_step_to_val_is_base_step] primStep_val_baseStep
+
+@[rocq_alias heap_lang.base_step_to_val]
 theorem base_step_to_val_always_to_val
     {e₁ : Exp} {σ₁ₐ : State} {κsₐ : List Observation} {v₂ₐ : Val} {σ₂ₐ : State}
     {efsₐ : List Exp} {σ₁ᵦ : State} {κsᵦ : List Observation}
@@ -371,6 +401,32 @@ theorem prim_step_more_proph_ids {e : Exp} {σ : State} {κs : List Observation}
     σ.usedProphId ⊆ σ'.usedProphId := by
   obtain ⟨hbase⟩ := h
   exact base_step_more_proph_ids hbase
+
+/-- A `resolve` whose subexpression cannot step cannot step either: the only base step of a
+`resolve` runs its subexpression to a value, and a step inside an evaluation context is a step of
+the subexpression. -/
+@[rocq_alias heap_lang.irreducible_resolve]
+theorem irreducible_resolve {e : Exp} {v1 v2 : Val} {σ : State}
+    (H : PrimStep.Irreducible (e, σ)) :
+    PrimStep.Irreducible (Exp.resolve e (.val v1) (.val v2), σ) := by
+  intro obs e' σ' eₜ hstep
+  generalize hsrc : Exp.resolve e (.val v1) (.val v2) = src at hstep
+  obtain ⟨Hbase⟩ := hstep
+  rename_i e₁' e₂' K
+  cases K using List.reverseRec with
+  | nil =>
+    simp only [fill_nil] at hsrc; subst hsrc
+    cases Hbase with | resolveS _ _ _ _ _ _ _ _ hb _ => exact H _ _ _ _ (primStep_of_baseStep hb)
+  | append_singleton K' Ki =>
+    have hnv := EctxLanguage.fill_not_val K' e₁' (EctxLanguage.val_stuck Hbase)
+    cases Ki <;>
+      simp only [fill_append, fill_cons, fill_nil, fillItem, ECtxItem.fill,
+        Exp.resolve.injEq, reduceCtorEq] at hsrc <;>
+      first
+      | exact H obs _ σ' eₜ (BaseStep.ContextStep.ofBaseStep' (K' ++ [_])
+          (by simp only [fill_append, fill_cons, fill_nil]; exact hsrc.1.symm) rfl Hbase)
+      | (rw [← hsrc.2.1] at hnv; simp [toVal] at hnv)
+      | (rw [← hsrc.2.2] at hnv; simp [toVal] at hnv)
 
 /-- `resolve e &vp &vt` is atomic whenever its subexpression `e` is strongly
 atomic: any step of the whole expression is a `resolveS` base step, which runs

--- a/Iris/Iris/HeapLang/Instances.lean
+++ b/Iris/Iris/HeapLang/Instances.lean
@@ -418,15 +418,14 @@ theorem irreducible_resolve {e : Exp} {v1 v2 : Val} {σ : State}
     simp only [fill_nil] at hsrc; subst hsrc
     cases Hbase with | resolveS _ _ _ _ _ _ _ _ hb _ => exact H _ _ _ _ (primStep_of_baseStep hb)
   | append_singleton K' Ki =>
-    have hnv := EctxLanguage.fill_not_val K' e₁' (EctxLanguage.val_stuck Hbase)
     cases Ki <;>
       simp only [fill_append, fill_cons, fill_nil, fillItem, ECtxItem.fill,
-        Exp.resolve.injEq, reduceCtorEq] at hsrc <;>
-      first
-      | exact H obs _ σ' eₜ (BaseStep.ContextStep.ofBaseStep' (K' ++ [_])
-          (by simp only [fill_append, fill_cons, fill_nil]; exact hsrc.1.symm) rfl Hbase)
-      | (rw [← hsrc.2.1] at hnv; simp [toVal] at hnv)
-      | (rw [← hsrc.2.2] at hnv; simp [toVal] at hnv)
+        Exp.resolve.injEq, reduceCtorEq] at hsrc
+    case resolveL =>
+      exact H obs _ σ' eₜ (BaseStep.ContextStep.ofBaseStep' (K' ++ [_])
+        (by simp only [fill_append, fill_cons, fill_nil]; exact hsrc.1.symm) rfl Hbase)
+    case resolveM => exact baseStep_fill_eq_val_absurd Hbase hsrc.2.1
+    case resolveR => exact baseStep_fill_eq_val_absurd Hbase hsrc.2.2
 
 /-- `resolve e &vp &vt` is atomic whenever its subexpression `e` is strongly
 atomic: any step of the whole expression is a `resolveS` base step, which runs

--- a/Iris/Iris/HeapLang/Metatheory.lean
+++ b/Iris/Iris/HeapLang/Metatheory.lean
@@ -220,8 +220,20 @@ theorem UnOp.eval_isClosed {op : UnOp} {v v' : Val} (h : op.eval v = some v') : 
 @[rocq_alias heap_lang.bin_op_eval_closed]
 theorem BinOp.eval_isClosed {op : BinOp} {v₁ v₂ v : Val} (h : op.eval v₁ v₂ = some v) :
     v.isClosed := by
+  have map_isClosed {result : Option BaseLit} (h : Val.lit <$> result = some v) : v.isClosed := by
+    cases result with
+    | none => cases h
+    | some lit => cases h; rfl
   unfold eval at h
-  split at h <;> (try split at h) <;> cases h <;> rfl
+  split at h
+  · split at h
+    · cases h; rfl
+    · cases h
+  · split at h
+    · exact map_isClosed h
+    · exact map_isClosed h
+    · exact map_isClosed h
+    · cases h
 
 /-- All values stored in the heap of `σ` are closed. -/
 def State.isClosed (σ : State) : Prop := ∀ l v, σ.get? l = some (some v) → v.isClosed

--- a/Iris/Iris/HeapLang/Semantics.lean
+++ b/Iris/Iris/HeapLang/Semantics.lean
@@ -93,6 +93,15 @@ instance : Inhabited State := ⟨.empty, .empty⟩
 
 attribute [rocq_alias heap_lang.heap_lang.state_inhabited] instInhabitedState
 
+-- Rocq threads state updates through the two `state_upd_*` functions; in Lean that role is
+-- played by record-update syntax, as in `State.initHeap` below.
+#rocq_ignore heap_lang.heap_lang.state_upd_heap
+  "Lean updates the `State` record directly: `{ σ with heap := f σ.heap }`."
+#rocq_ignore heap_lang.heap_lang.state_upd_used_proph_id
+  "Lean updates the `State` record directly: `{ σ with usedProphId := f σ.usedProphId }`."
+#rocq_ignore heap_lang.heap_lang.stateO
+  "Canonical Leibniz OFE on `state`; Lean uses the generic `stateO State`, i.e. `DiscreteO State`."
+
 @[rocq_alias heap_lang.heap_lang.observation]
 abbrev Observation := ProphId × (Val × Val)
 
@@ -101,6 +110,44 @@ def UnOp.eval : UnOp → Val → Option Val
   | .neg,   .lit (.bool b) => some (.lit (.bool (!b)))
   | .minus, .lit (.int n)  => some (.lit (.int (-n)))
   | _,      _              => none
+
+/-- Binary operations on two integer literals. `BinOp.eval` agrees with this on integers
+(`BinOp.eval_lit_int`); `.eq` is listed here because Rocq's `bin_op_eval_int` does, even though
+`BinOp.eval` routes equality through `Val.compareSafe`. -/
+@[rocq_alias heap_lang.heap_lang.bin_op_eval_int]
+def BinOp.evalInt : BinOp → Int → Int → Option BaseLit
+  | .plus,   n1, n2 => some (.int (n1 + n2))
+  | .minus,  n1, n2 => some (.int (n1 - n2))
+  | .mult,   n1, n2 => some (.int (n1 * n2))
+  | .tdiv,   n1, n2 => some (.int (n1.tdiv n2))
+  | .tmod,   n1, n2 => some (.int (n1.tmod n2))
+  | .and,    n1, n2 => some (.int (n1 &&& n2))
+  | .or,     n1, n2 => some (.int (n1 ||| n2))
+  | .xor,    n1, n2 => some (.int (n1 ^^^ n2))
+  | .shiftl, n1, n2 => some (.int (n1 <<< n2))
+  | .shiftr, n1, n2 => some (.int (n1 >>> n2))
+  | .le,     n1, n2 => some (.bool (n1 ≤ n2))
+  | .lt,     n1, n2 => some (.bool (n1 < n2))
+  | .eq,     n1, n2 => some (.bool (n1 = n2))
+  | .offset, _,  _  => none -- Pointer arithmetic
+
+/-- Binary operations on two boolean literals; see `BinOp.eval_lit_bool`. -/
+@[rocq_alias heap_lang.heap_lang.bin_op_eval_bool]
+def BinOp.evalBool : BinOp → Bool → Bool → Option BaseLit
+  | .and, b1, b2 => some (.bool (b1 && b2))
+  | .or,  b1, b2 => some (.bool (b1 || b2))
+  | .xor, b1, b2 => some (.bool (b1 ^^ b2))
+  | .eq,  b1, b2 => some (.bool (b1 == b2))
+  | _,    _,  _  => none
+
+/-- Binary operations whose left argument is a location: pointer arithmetic and the comparison
+of two locations. See `BinOp.eval_lit_loc`. -/
+@[rocq_alias heap_lang.heap_lang.bin_op_eval_loc]
+def BinOp.evalLoc : BinOp → Loc → BaseLit → Option BaseLit
+  | .offset, l1, .int off => some (.loc (l1 + off))
+  | .le,     l1, .loc l2  => some (.bool (l1 ≤ l2))
+  | .lt,     l1, .loc l2  => some (.bool (l1 < l2))
+  | _,       _,  _        => none
 
 @[rocq_alias heap_lang.heap_lang.bin_op_eval]
 def BinOp.eval : BinOp → Val → Val → Option Val
@@ -122,7 +169,25 @@ def BinOp.eval : BinOp → Val → Val → Option Val
   | .eq,     v1,              v2              =>
       if v1.compareSafe v2 then some (.lit (.bool (v1 == v2))) else none
   | .offset, .lit (.loc l),   .lit (.int n)   => some (.lit (.loc (l + n)))
+  | .le,     .lit (.loc l1),  .lit (.loc l2)  => some (.lit (.bool (l1 ≤ l2)))
+  | .lt,     .lit (.loc l1),  .lit (.loc l2)  => some (.lit (.bool (l1 < l2)))
   | _,       _,               _               => none
+
+theorem BinOp.eval_lit_int (op : BinOp) (n1 n2 : Int) :
+    BinOp.eval op (.lit (.int n1)) (.lit (.int n2)) = (Val.lit <$> op.evalInt n1 n2) := by
+  cases op <;> simp [BinOp.eval, BinOp.evalInt, Val.compareSafe, BaseLit.isUnboxed, Val.isUnboxed]
+    <;> by_cases h : n1 = n2 <;> simp [h]
+
+theorem BinOp.eval_lit_bool (op : BinOp) (b1 b2 : Bool) :
+    BinOp.eval op (.lit (.bool b1)) (.lit (.bool b2)) = (Val.lit <$> op.evalBool b1 b2) := by
+  cases b1 <;> cases b2 <;> cases op <;> rfl
+
+/-- Unlike the integer and boolean cases, this one needs `op ≠ .eq`: Rocq's `bin_op_eval`
+dispatches `EqOp` before it ever reaches `bin_op_eval_loc`, and `BinOp.eval` likewise routes
+equality of two locations through `Val.compareSafe`. -/
+theorem BinOp.eval_lit_loc (op : BinOp) (l : Loc) (lit : BaseLit) (hop : op ≠ .eq) :
+    BinOp.eval op (.lit (.loc l)) (.lit lit) = (Val.lit <$> op.evalLoc l lit) := by
+  cases op <;> cases lit <;> simp_all [BinOp.eval, BinOp.evalLoc]
 
 abbrev HeapF := fun V => Std.ExtTreeMap Loc V compare
 
@@ -287,5 +352,26 @@ inductive BaseStep : Exp → State → List Observation → Exp → State → Li
       σ.usedProphId.contains p →
       BaseStep (.resolve e (.ofVal (.lit (.prophecy p))) (.ofVal w)) σ
                (κs ++ [(p, (v, w))]) (.ofVal v) σ' ts
+
+/-- Allocation always has a step available: `Loc.fresh` picks a block that the heap does not
+use. -/
+@[rocq_alias heap_lang.heap_lang.alloc_fresh]
+theorem alloc_fresh (v : Val) (n : Int) (σ : State) (hn : 0 < n) :
+    BaseStep (.allocN (.ofVal (.lit (.int n))) (.ofVal v)) σ []
+      (.ofVal (.lit (.loc (Loc.fresh σ.heap.keys))))
+      (σ.initHeap (Loc.fresh σ.heap.keys) n v) [] :=
+  .allocNS n v σ _ hn fun i hi0 _ => by
+    simpa [State.get?, PartialMap.get?, getElem?_eq_none_iff, ← Std.ExtTreeMap.mem_keys]
+      using Loc.fresh_fresh _ hi0
+
+/-- Creating a prophecy variable always has a step available. Rocq names the fresh identifier
+with stdpp's `fresh`; `ProphId` has no computable fresh element here, so the identifier is
+existentially quantified. -/
+@[rocq_alias heap_lang.heap_lang.new_proph_id_fresh]
+theorem new_proph_id_fresh (σ : State) :
+    ∃ p : ProphId, BaseStep .newProph σ []
+      (.ofVal (.lit (.prophecy p))) { σ with usedProphId := σ.usedProphId.insert p } [] :=
+  let ⟨p, hp⟩ := _root_.Iris.Std.List.fresh σ.usedProphId.toList
+  ⟨p, .newProphS σ p (hp <| Std.ExtTreeSet.mem_toList.mpr <| Std.ExtTreeSet.mem_iff_contains.mpr ·)⟩
 
 end Iris.HeapLang

--- a/Iris/Iris/HeapLang/Semantics.lean
+++ b/Iris/Iris/HeapLang/Semantics.lean
@@ -108,6 +108,7 @@ abbrev Observation := ProphId × (Val × Val)
 @[rocq_alias heap_lang.heap_lang.un_op_eval]
 def UnOp.eval : UnOp → Val → Option Val
   | .neg,   .lit (.bool b) => some (.lit (.bool (!b)))
+  | .neg,   .lit (.int n)  => some (.lit (.int (~~~n)))
   | .minus, .lit (.int n)  => some (.lit (.int (-n)))
   | _,      _              => none
 
@@ -150,28 +151,15 @@ def BinOp.evalLoc : BinOp → Loc → BaseLit → Option BaseLit
   | _,       _,  _        => none
 
 @[rocq_alias heap_lang.heap_lang.bin_op_eval]
-def BinOp.eval : BinOp → Val → Val → Option Val
-  | .plus,   .lit (.int n1),  .lit (.int n2)  => some (.lit (.int (n1 + n2)))
-  | .minus,  .lit (.int n1),  .lit (.int n2)  => some (.lit (.int (n1 - n2)))
-  | .mult,   .lit (.int n1),  .lit (.int n2)  => some (.lit (.int (n1 * n2)))
-  | .tdiv,   .lit (.int n1),  .lit (.int n2)  => some (.lit (.int (n1.tdiv n2)))
-  | .tmod,   .lit (.int n1),  .lit (.int n2)  => some (.lit (.int (n1.tmod n2)))
-  | .and,    .lit (.int n1),  .lit (.int n2)  => some (.lit (.int (n1 &&& n2)))
-  | .or,     .lit (.int n1),  .lit (.int n2)  => some (.lit (.int (n1 ||| n2)))
-  | .xor,    .lit (.int n1),  .lit (.int n2)  => some (.lit (.int (n1 ^^^ n2)))
-  | .and,    .lit (.bool b1), .lit (.bool b2) => some (.lit (.bool (b1 && b2)))
-  | .or,     .lit (.bool b1), .lit (.bool b2) => some (.lit (.bool (b1 || b2)))
-  | .xor,    .lit (.bool b1), .lit (.bool b2) => some (.lit (.bool (b1 ^^ b2)))
-  | .shiftl, .lit (.int n1),  .lit (.int n2)  => some (.lit (.int (n1 <<< n2)))
-  | .shiftr, .lit (.int n1),  .lit (.int n2)  => some (.lit (.int (n1 >>> n2)))
-  | .le,     .lit (.int n1),  .lit (.int n2)  => some (.lit (.bool (n1 ≤ n2)))
-  | .lt,     .lit (.int n1),  .lit (.int n2)  => some (.lit (.bool (n1 < n2)))
-  | .eq,     v1,              v2              =>
-      if v1.compareSafe v2 then some (.lit (.bool (v1 == v2))) else none
-  | .offset, .lit (.loc l),   .lit (.int n)   => some (.lit (.loc (l + n)))
-  | .le,     .lit (.loc l1),  .lit (.loc l2)  => some (.lit (.bool (l1 ≤ l2)))
-  | .lt,     .lit (.loc l1),  .lit (.loc l2)  => some (.lit (.bool (l1 < l2)))
-  | _,       _,               _               => none
+def BinOp.eval (op : BinOp) (v1 v2 : Val) : Option Val :=
+  if op = .eq then
+    if v1.compareSafe v2 then some (.lit (.bool (v1 == v2))) else none
+  else
+    match v1, v2 with
+    | .lit (.int n1), .lit (.int n2) => Val.lit <$> op.evalInt n1 n2
+    | .lit (.bool b1), .lit (.bool b2) => Val.lit <$> op.evalBool b1 b2
+    | .lit (.loc l1), .lit lit2 => Val.lit <$> op.evalLoc l1 lit2
+    | _, _ => none
 
 theorem BinOp.eval_lit_int (op : BinOp) (n1 n2 : Int) :
     BinOp.eval op (.lit (.int n1)) (.lit (.int n2)) = (Val.lit <$> op.evalInt n1 n2) := by
@@ -469,9 +457,6 @@ theorem alloc_fresh (v : Val) (n : Int) (σ : State) (hn : 0 < n) :
     simpa [State.get?, PartialMap.get?, getElem?_eq_none_iff, ← Std.ExtTreeMap.mem_keys]
       using Loc.fresh_fresh _ hi0
 
-/-- Creating a prophecy variable always has a step available. Rocq names the fresh identifier
-with stdpp's `fresh`; `ProphId` has no computable fresh element here, so the identifier is
-existentially quantified. -/
 @[rocq_alias heap_lang.heap_lang.new_proph_id_fresh]
 theorem new_proph_id_fresh (σ : State) :
     ∃ p : ProphId, BaseStep .newProph σ []

--- a/Iris/Iris/HeapLang/Syntax.lean
+++ b/Iris/Iris/HeapLang/Syntax.lean
@@ -47,18 +47,46 @@ attribute [rocq_alias heap_lang.Loc.eq_spec] Loc.ext_iff
 instance : HAdd Loc Int Loc where
   hAdd l i := ⟨l.n + i⟩
 
--- Rocq's `Loc` carries a `Prop`-valued order `Loc.le`/`Loc.lt` together with its
--- decidability and order-theoretic properties. `Loc` has no `LE`/`LT` instance here:
--- comparison goes through `Ord Loc` above, and the order itself is the `Int` order
--- on the `Loc.n` field, so all of these are `Int` facts.
-#rocq_ignore heap_lang.Loc.le "Use the `Int` order on `Loc.n`; comparison is the `Ord Loc` instance."
-#rocq_ignore heap_lang.Loc.lt "Use the `Int` order on `Loc.n`; comparison is the `Ord Loc` instance."
-#rocq_ignore heap_lang.Loc.le_dec "Decidable via the `Int` order on `Loc.n`."
-#rocq_ignore heap_lang.Loc.lt_dec "Decidable via the `Int` order on `Loc.n`."
-#rocq_ignore heap_lang.Loc.le_po "Follows from the `Int` order on `Loc.n`, with `Loc.ext_iff` for antisymmetry."
-#rocq_ignore heap_lang.Loc.le_total "Follows from the `Int` order on `Loc.n`."
-#rocq_ignore heap_lang.Loc.le_ngt "Follows from the `Int` order on `Loc.n`."
-#rocq_ignore heap_lang.Loc.le_lteq "Follows from the `Int` order on `Loc.n`, with `Loc.ext_iff`."
+-- The order on locations is the `Int` order on the `Loc.n` field. It is a `Prop`-valued order,
+-- as in Rocq, and is what `BinOp.eval` compares locations with; the `Ord Loc` instance above is
+-- the separate, `Ordering`-valued comparison that the heap's `ExtTreeMap` is keyed by.
+
+@[rocq_alias heap_lang.Loc.le]
+instance : LE Loc where
+  le l₁ l₂ := l₁.n ≤ l₂.n
+
+@[rocq_alias heap_lang.Loc.lt]
+instance : LT Loc where
+  lt l₁ l₂ := l₁.n < l₂.n
+
+@[simp]
+theorem Loc.le_iff {l₁ l₂ : Loc} : l₁ ≤ l₂ ↔ l₁.n ≤ l₂.n := .rfl
+
+@[simp]
+theorem Loc.lt_iff {l₁ l₂ : Loc} : l₁ < l₂ ↔ l₁.n < l₂.n := .rfl
+
+@[rocq_alias heap_lang.Loc.le_dec]
+instance (l₁ l₂ : Loc) : Decidable (l₁ ≤ l₂) := inferInstanceAs (Decidable (l₁.n ≤ l₂.n))
+
+@[rocq_alias heap_lang.Loc.lt_dec]
+instance (l₁ l₂ : Loc) : Decidable (l₁ < l₂) := inferInstanceAs (Decidable (l₁.n < l₂.n))
+
+@[rocq_alias heap_lang.Loc.le_po]
+instance : Std.IsPartialOrder Loc where
+  le_refl _ := Int.le_refl _
+  le_trans _ _ _ h₁ h₂ := Int.le_trans h₁ h₂
+  le_antisymm _ _ h₁ h₂ := Loc.ext (Int.le_antisymm h₁ h₂)
+
+@[rocq_alias heap_lang.Loc.le_total]
+instance : Std.Total ((· ≤ ·) : Loc → Loc → Prop) where
+  total l₁ l₂ := Int.le_total l₁.n l₂.n
+
+@[rocq_alias heap_lang.Loc.le_ngt]
+theorem Loc.le_ngt {l₁ l₂ : Loc} : l₁ ≤ l₂ ↔ ¬ l₂ < l₁ := by simp
+
+@[rocq_alias heap_lang.Loc.le_lteq]
+theorem Loc.le_lteq {l₁ l₂ : Loc} : l₁ ≤ l₂ ↔ l₁ < l₂ ∨ l₁ = l₂ := by
+  simp only [Loc.le_iff, Loc.lt_iff, Loc.ext_iff]; omega
 
 instance : Zero Loc where
   zero := ⟨0⟩
@@ -66,6 +94,32 @@ instance : Zero Loc where
 @[simp]
 theorem loc_add_n (l : Loc) n :
   (l + n).n = l.n + n := by simp [HAdd.hAdd]
+
+@[rocq_alias heap_lang.Loc.add_le_mono]
+theorem Loc.add_le_mono {l₁ l₂ : Loc} {i₁ i₂ : Int} (hl : l₁ ≤ l₂) (hi : i₁ ≤ i₂) :
+    l₁ + i₁ ≤ l₂ + i₂ := Int.add_le_add hl hi
+
+/-- A location that is fresh for `ls`, and stays fresh at every non-negative offset
+(`Loc.fresh_fresh`). Rocq folds over a `gset loc`; here the argument is the key list of
+a heap, as produced by `Std.ExtTreeMap.keys`. -/
+@[rocq_alias heap_lang.Loc.fresh]
+def Loc.fresh (ls : List Loc) : Loc := ⟨(ls.map Loc.n).foldr max 0 + 1⟩
+
+@[rocq_alias heap_lang.Loc.fresh_fresh]
+theorem Loc.fresh_fresh (ls : List Loc) {i : Int} (hi : 0 ≤ i) : Loc.fresh ls + i ∉ ls :=
+  fun hmem => by
+    have := List.mem_le_foldr_max _ _ (List.mem_map_of_mem (f := Loc.n) hmem)
+    simp only [loc_add_n, Loc.fresh] at this; omega
+
+@[rocq_alias heap_lang.Loc.countable]
+instance : Pos.Countable Loc where
+  encode l := Pos.Countable.encode l.n
+  decode p := ((Pos.Countable.decode p : Option Int)).map Loc.mk
+  decode_encode _ := by simp [Pos.Countable.decode_encode]
+
+-- Rocq registers a canonical Leibniz OFE on `loc`. In Lean the discrete OFE is the generic
+-- `DiscreteO` from `Iris.Algebra.OFE`, applied to `Loc` at its use sites.
+#rocq_ignore heap_lang.heap_lang.locO "Canonical Leibniz OFE on `loc`; Lean uses `DiscreteO Loc`."
 
 @[ext, rocq_alias heap_lang.heap_lang.proph_id]
 structure ProphId where
@@ -93,10 +147,27 @@ instance : InfiniteType ProphId where
   enum n := .mk n
   enum_inj n m := by grind
 
+-- Rocq takes `proph_id := positive`, which is countable outright.
+instance : Pos.Countable ProphId where
+  encode p := Pos.Countable.encode p.n
+  decode p := ((Pos.Countable.decode p : Option Nat)).map ProphId.mk
+  decode_encode _ := by simp [Pos.Countable.decode_encode]
+
 inductive Binder where
   | anon
   | named (name : String)
 deriving Inhabited, Repr, DecidableEq
+
+instance : Pos.Countable Binder where
+  encode
+    | .anon    => Pos.Countable.encode ([] : List Pos)
+    | .named s => Pos.Countable.encode [Pos.Countable.encode s]
+  decode p :=
+    match (Pos.Countable.decode p : Option (List Pos)) with
+    | some []  => some .anon
+    | some [s] => ((Pos.Countable.decode s : Option String)).map .named
+    | _ => none
+  decode_encode b := by cases b <;> simp [Pos.Countable.decode_encode]
 
 @[rocq_alias heap_lang.heap_lang.base_lit]
 inductive BaseLit where
@@ -110,6 +181,34 @@ deriving Inhabited, Repr, DecidableEq
 
 attribute [rocq_alias heap_lang.heap_lang.base_lit_eq_dec] instDecidableEqBaseLit
 
+/-- A literal is encoded as the list `[tag]`, or `[tag, payload]` for the literals that carry
+one. -/
+@[rocq_alias heap_lang.heap_lang.base_lit_countable]
+instance : Pos.Countable BaseLit where
+  encode
+    | .int n      => Pos.Countable.encode [Pos.Countable.encode (0 : Nat), Pos.Countable.encode n]
+    | .bool b     => Pos.Countable.encode [Pos.Countable.encode (1 : Nat), Pos.Countable.encode b]
+    | .unit       => Pos.Countable.encode [Pos.Countable.encode (2 : Nat)]
+    | .poison     => Pos.Countable.encode [Pos.Countable.encode (3 : Nat)]
+    | .loc l      => Pos.Countable.encode [Pos.Countable.encode (4 : Nat), Pos.Countable.encode l]
+    | .prophecy p => Pos.Countable.encode [Pos.Countable.encode (5 : Nat), Pos.Countable.encode p]
+  decode p :=
+    match (Pos.Countable.decode p : Option (List Pos)) with
+    | some [t] =>
+      match (Pos.Countable.decode t : Option Nat) with
+      | some 2 => some .unit
+      | some 3 => some .poison
+      | _ => none
+    | some [t, x] =>
+      match (Pos.Countable.decode t : Option Nat) with
+      | some 0 => ((Pos.Countable.decode x : Option Int)).map .int
+      | some 1 => ((Pos.Countable.decode x : Option Bool)).map .bool
+      | some 4 => ((Pos.Countable.decode x : Option Loc)).map .loc
+      | some 5 => ((Pos.Countable.decode x : Option ProphId)).map .prophecy
+      | _ => none
+    | _ => none
+  decode_encode l := by cases l <;> simp [Pos.Countable.decode_encode]
+
 @[rocq_alias heap_lang.heap_lang.un_op]
 inductive UnOp where
   | neg
@@ -117,6 +216,19 @@ inductive UnOp where
 deriving Inhabited, Repr, DecidableEq
 
 attribute [rocq_alias heap_lang.heap_lang.un_op_eq_dec] instDecidableEqUnOp
+
+-- Rocq calls this instance `un_op_finite`, but states it as countability.
+@[rocq_alias heap_lang.heap_lang.un_op_finite]
+instance : Pos.Countable UnOp where
+  encode
+    | .neg   => Pos.Countable.encode (0 : Nat)
+    | .minus => Pos.Countable.encode (1 : Nat)
+  decode p :=
+    match (Pos.Countable.decode p : Option Nat) with
+    | some 0 => some .neg
+    | some 1 => some .minus
+    | _ => none
+  decode_encode op := by cases op <;> simp [Pos.Countable.decode_encode]
 
 @[rocq_alias heap_lang.heap_lang.bin_op]
 inductive BinOp where
@@ -131,6 +243,42 @@ inductive BinOp where
 deriving Inhabited, Repr, DecidableEq
 
 attribute [rocq_alias heap_lang.heap_lang.bin_op_eq_dec] instDecidableEqBinOp
+
+@[rocq_alias heap_lang.heap_lang.bin_op_countable]
+instance : Pos.Countable BinOp where
+  encode
+    | .plus   => Pos.Countable.encode (0 : Nat)
+    | .minus  => Pos.Countable.encode (1 : Nat)
+    | .mult   => Pos.Countable.encode (2 : Nat)
+    | .tdiv   => Pos.Countable.encode (3 : Nat)
+    | .tmod   => Pos.Countable.encode (4 : Nat)
+    | .and    => Pos.Countable.encode (5 : Nat)
+    | .or     => Pos.Countable.encode (6 : Nat)
+    | .xor    => Pos.Countable.encode (7 : Nat)
+    | .shiftl => Pos.Countable.encode (8 : Nat)
+    | .shiftr => Pos.Countable.encode (9 : Nat)
+    | .le     => Pos.Countable.encode (10 : Nat)
+    | .lt     => Pos.Countable.encode (11 : Nat)
+    | .eq     => Pos.Countable.encode (12 : Nat)
+    | .offset => Pos.Countable.encode (13 : Nat)
+  decode p :=
+    match (Pos.Countable.decode p : Option Nat) with
+    | some 0  => some .plus
+    | some 1  => some .minus
+    | some 2  => some .mult
+    | some 3  => some .tdiv
+    | some 4  => some .tmod
+    | some 5  => some .and
+    | some 6  => some .or
+    | some 7  => some .xor
+    | some 8  => some .shiftl
+    | some 9  => some .shiftr
+    | some 10 => some .le
+    | some 11 => some .lt
+    | some 12 => some .eq
+    | some 13 => some .offset
+    | _ => none
+  decode_encode op := by cases op <;> simp [Pos.Countable.decode_encode]
 
 mutual
   @[rocq_alias heap_lang.heap_lang.expr]
@@ -183,6 +331,76 @@ attribute [rocq_alias heap_lang.heap_lang.val_eq_dec] instDecidableEqVal
 attribute [rocq_alias heap_lang.heap_lang.expr_inhabited] instInhabitedExp
 attribute [rocq_alias heap_lang.heap_lang.val_inhabited] instInhabitedVal
 
+/-! ### Countability of expressions and values
+
+Rocq encodes expressions and values into `gen_tree` and inherits countability from there. The
+encoding below plays the same role: every node becomes the `Pos` code of the list holding its
+constructor tag and the codes of its arguments. -/
+
+/-- One node of the `Exp`/`Val` encoding: a constructor tag followed by the codes of that
+constructor's arguments. -/
+def encNode (tag : Nat) (args : List Pos) : Pos :=
+  Pos.Countable.encode (Pos.Countable.encode tag :: args)
+
+@[simp]
+theorem encNode_eq_iff {t₁ t₂ : Nat} {a₁ a₂ : List Pos} :
+    encNode t₁ a₁ = encNode t₂ a₂ ↔ t₁ = t₂ ∧ a₁ = a₂ := by
+  simp [encNode]
+
+mutual
+
+/-- Injective encoding of expressions into `Pos`; see `Exp.enc_inj`. -/
+def Exp.enc : Exp → Pos
+  | .val v            => encNode 0 [v.enc]
+  | .var x            => encNode 1 [Pos.Countable.encode x]
+  | .rec_ f x e       => encNode 2 [Pos.Countable.encode f, Pos.Countable.encode x, e.enc]
+  | .app e₁ e₂        => encNode 3 [e₁.enc, e₂.enc]
+  | .unop op e        => encNode 4 [Pos.Countable.encode op, e.enc]
+  | .binop op e₁ e₂   => encNode 5 [Pos.Countable.encode op, e₁.enc, e₂.enc]
+  | .if e₀ e₁ e₂      => encNode 6 [e₀.enc, e₁.enc, e₂.enc]
+  | .pair e₁ e₂       => encNode 7 [e₁.enc, e₂.enc]
+  | .fst e            => encNode 8 [e.enc]
+  | .snd e            => encNode 9 [e.enc]
+  | .injL e           => encNode 10 [e.enc]
+  | .injR e           => encNode 11 [e.enc]
+  | .case e₀ e₁ e₂    => encNode 12 [e₀.enc, e₁.enc, e₂.enc]
+  | .allocN e₁ e₂     => encNode 13 [e₁.enc, e₂.enc]
+  | .free e           => encNode 14 [e.enc]
+  | .load e           => encNode 15 [e.enc]
+  | .store e₁ e₂      => encNode 16 [e₁.enc, e₂.enc]
+  | .cmpXchg e₀ e₁ e₂ => encNode 17 [e₀.enc, e₁.enc, e₂.enc]
+  | .xchg e₁ e₂       => encNode 18 [e₁.enc, e₂.enc]
+  | .faa e₁ e₂        => encNode 19 [e₁.enc, e₂.enc]
+  | .fork e           => encNode 20 [e.enc]
+  | .newProph         => encNode 21 []
+  | .resolve e₀ e₁ e₂ => encNode 22 [e₀.enc, e₁.enc, e₂.enc]
+
+/-- Injective encoding of values into `Pos`; see `Val.enc_inj`. -/
+def Val.enc : Val → Pos
+  | .lit l      => encNode 0 [Pos.Countable.encode l]
+  | .rec_ f x e => encNode 1 [Pos.Countable.encode f, Pos.Countable.encode x, e.enc]
+  | .pair v₁ v₂ => encNode 2 [v₁.enc, v₂.enc]
+  | .injL v     => encNode 3 [v.enc]
+  | .injR v     => encNode 4 [v.enc]
+
+end
+
+theorem Exp.enc_inj : Exp.enc.Injective := by
+  intro e₁
+  induction e₁ using Exp.enc.induct (motive_2 := fun v => ∀ v', Val.enc v = Val.enc v' → v = v') <;>
+    (try intro _ _) <;> rename_i e₂ _ <;> cases e₂ <;> simp_all [Exp.enc, Val.enc] <;> grind
+
+theorem Val.enc_inj : Val.enc.Injective := by
+  intro v₁
+  induction v₁ using Val.enc.induct (motive_1 := fun e => ∀ e', Exp.enc e = Exp.enc e' → e = e') <;>
+    (try intro _ _) <;> rename_i v₂ _ <;> cases v₂ <;> simp_all [Exp.enc, Val.enc] <;> grind
+
+@[rocq_alias heap_lang.heap_lang.expr_countable]
+noncomputable instance : Pos.Countable Exp := .ofInjective Exp.enc Exp.enc_inj
+
+@[rocq_alias heap_lang.heap_lang.val_countable]
+noncomputable instance : Pos.Countable Val := .ofInjective Val.enc Val.enc_inj
+
 def Exp.isVal : Exp → Bool
   | .val _ => true
   | _ => false
@@ -195,6 +413,26 @@ instance instToVal : ProgramLogic.ToVal Exp Val where
   coe_of_toVal_eq_some {e v} h := by
     cases e <;> simp_all
   toVal_coe _ := rfl
+
+-- Rocq's `to_val`/`of_val` and their round-trip lemmas are stand-alone declarations. Here they
+-- are the fields of `instToVal` above, and the round-trip lemmas are already available
+-- generically for any `ProgramLogic.ToVal` instance (they carry the `language.v` aliases
+-- `of_to_val`, `to_of_val` and `of_val_inj`).
+#rocq_ignore heap_lang.heap_lang.to_val
+  "The `toVal` field of `instToVal`; `of_val` is its `ofVal` field."
+#rocq_ignore heap_lang.heap_lang.of_to_val
+  "The `coe_of_toVal_eq_some` field of `instToVal`, aliased generically as `of_to_val`."
+#rocq_ignore heap_lang.heap_lang.to_of_val
+  "The `toVal_coe` field of `instToVal`, aliased generically as `to_of_val`."
+#rocq_ignore heap_lang.heap_lang.of_val_inj
+  "Generic `ProgramLogic.ToVal.ofVal_inj`, aliased as `of_val_inj`, applied to `instToVal`."
+
+-- Rocq registers canonical Leibniz OFEs on `expr` and `val`. In Lean the generic `exprO`/`valO`
+-- of `Iris.ProgramLogic.Language` are `DiscreteO` abbreviations, applied at their use sites.
+#rocq_ignore heap_lang.heap_lang.exprO
+  "Canonical Leibniz OFE on `expr`; Lean uses the generic `exprO Exp`, i.e. `DiscreteO Exp`."
+#rocq_ignore heap_lang.heap_lang.valO
+  "Canonical Leibniz OFE on `val`; Lean uses the generic `valO Val`, i.e. `DiscreteO Val`."
 
 namespace Exp
 export ProgramLogic.ToVal (ofVal)

--- a/Iris/Iris/ProgramLogic/EctxiLanguage.lean
+++ b/Iris/Iris/ProgramLogic/EctxiLanguage.lean
@@ -37,7 +37,7 @@ export EctxItemLanguage (fillItem)
 
 -- attribute [rocq_alias fill_item] EctxItemLanguage.fillItem
 attribute [rocq_alias fill_item_inj] EctxItemLanguage.fillItem_inj
-attribute [rocq_alias fill_item_val] EctxItemLanguage.fillItem
+attribute [rocq_alias fill_item_val] EctxItemLanguage.fillItem_val
 attribute [rocq_alias fill_item_no_val_inj] EctxItemLanguage.fillItem_no_val_inj
 
 attribute [simp] EctxItemLanguage.fillItem_inj

--- a/Iris/Iris/Std/Positives.lean
+++ b/Iris/Iris/Std/Positives.lean
@@ -418,6 +418,22 @@ theorem encode_inj [c : Countable A] : c.encode.Injective :=
     rewrite [<- c.decode_encode x, Hxy, c.decode_encode]
     rfl
 
+@[simp]
+theorem encode_eq_iff [Countable A] {x y : A} : Countable.encode x = Countable.encode y ↔ x = y :=
+  ⟨fun H => encode_inj H, fun H => H ▸ rfl⟩
+
+open Classical in
+/-- Countability from an injection into `Pos`. Rocq's `inj_countable` asks for a computable
+partial inverse of the injection; the inverse here is obtained classically, so the `decode` of
+the resulting instance is noncomputable. -/
+@[reducible]
+noncomputable def Countable.ofInjective {A} (f : A → Pos) (Hf : f.Injective) : Countable A where
+  encode := f
+  decode p := if H : ∃ a, f a = p then some H.choose else none
+  decode_encode a := by
+    have H : ∃ b, f b = f a := ⟨a, rfl⟩
+    rw [dif_pos H]; exact congrArg some (Hf H.choose_spec)
+
 instance [Countable A] : Countable (List A) where
   encode xs := Pos.flatten (List.map Countable.encode xs)
   decode p := (Pos.unflatten p).bind (List.mapM Countable.decode ·)
@@ -449,6 +465,19 @@ instance : Pos.Countable String where
   encode s := (Pos.Countable.encode : List Char → Pos) s.toList
   decode p := ((Pos.Countable.decode p : Option (List Char))).map String.ofList
   decode_encode s := by simp [Pos.Countable.decode_encode, String.ofList_toList]
+
+instance : Pos.Countable Bool where
+  encode b := Pos.Countable.encode (if b then 1 else 0 : Nat)
+  decode p := ((Pos.Countable.decode p : Option Nat)).map (· != 0)
+  decode_encode b := by cases b <;> simp [Pos.Countable.decode_encode]
+
+/-- `Int` is countable by interleaving the non-negative and the negative integers. -/
+instance : Pos.Countable Int where
+  encode i := Pos.Countable.encode (if 0 ≤ i then 2 * i.toNat else 2 * (-i).toNat - 1)
+  decode p := ((Pos.Countable.decode p : Option Nat)).map
+    fun n => if n % 2 = 0 then (n / 2 : Int) else -((n + 1) / 2 : Int)
+  decode_encode i := by
+    by_cases h : 0 ≤ i <;> simp [Pos.Countable.decode_encode, h] <;> omega
 
 instance : Ord Pos where
   compare x y := Pos.compare x y

--- a/Iris/IrisTest/HeapLang.lean
+++ b/Iris/IrisTest/HeapLang.lean
@@ -6,4 +6,5 @@ public import IrisTest.HeapLang.WeakestPre
 public import IrisTest.HeapLang.HeapTactics
 public import IrisTest.HeapLang.Linter
 public import IrisTest.HeapLang.Par
+public import IrisTest.HeapLang.Semantics
 public import IrisTest.HeapLang.Tactics

--- a/Iris/IrisTest/HeapLang/Semantics.lean
+++ b/Iris/IrisTest/HeapLang/Semantics.lean
@@ -1,0 +1,27 @@
+module
+
+public import Iris.HeapLang.Instances
+
+@[expose] public section
+namespace IrisTest.HeapLang.Semantics
+
+open Iris.HeapLang
+
+example (b : Bool) : UnOp.eval .neg (.lit (.bool b)) = some (.lit (.bool (!b))) := by rfl
+example (n : Int) : UnOp.eval .neg (.lit (.int n)) = some (.lit (.int (~~~n))) := by rfl
+
+example : BinOp.eval .plus (.lit (.int 2)) (.lit (.int 3)) = some (.lit (.int 5)) := by decide
+example : BinOp.eval .xor (.lit (.bool true)) (.lit (.bool false)) =
+    some (.lit (.bool true)) := by decide
+example : BinOp.eval .le (.lit (.loc ⟨2⟩)) (.lit (.loc ⟨3⟩)) =
+    some (.lit (.bool true)) := by decide
+example : BinOp.eval .lt (.lit (.loc ⟨3⟩)) (.lit (.loc ⟨3⟩)) =
+    some (.lit (.bool false)) := by decide
+example : BinOp.eval .offset (.lit (.loc ⟨2⟩)) (.lit (.int 3)) =
+    some (.lit (.loc ⟨5⟩)) := by decide
+example : BinOp.eval .eq (.lit (.int 2)) (.lit (.int 2)) =
+    some (.lit (.bool true)) := by decide
+example : BinOp.eval .eq (.pair (.lit .unit) (.lit .unit))
+    (.pair (.lit .unit) (.lit .unit)) = none := by decide
+
+end IrisTest.HeapLang.Semantics


### PR DESCRIPTION
## Description
Finish two more files in HeapLang and fix some missing cases in the HeapLang semantics. It also adds in some countable instances, I think that for now it is probably easiest that we just add these to the library. I made an issue to look out for upstreamed Countable classes, we can pivot to those at a later point if they meet our needs.

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
