### PR TITLE
fix: `wp_rec` keeps the evaluation context flat

### DIFF
--- a/Iris/Iris/HeapLang/ProofMode.lean
+++ b/Iris/Iris/HeapLang/ProofMode.lean
@@ -408,14 +408,15 @@ macro "wp_unop" : tactic => `(tactic | wp_pure (&(Exp.unop _ _)))
 macro "wp_binop" : tactic => `(tactic | wp_pure (&(Exp.binop _ _ _)))
 macro "wp_op" : tactic => `(tactic | first | wp_unop | wp_binop)
 macro "wp_lam" : tactic => `(tactic | wp_rec)
-macro "wp_let" : tactic => `(tactic | (wp_pure (rec _ &(.named _) := _); wp_lam))
-macro "wp_seq" : tactic => `(tactic | (wp_pure (rec _ _ := _); wp_lam))
+-- use `wp_pure (_ _)` in `wp_let`, `wp_seq` and `wp_match` because no unfolding is needed
+macro "wp_let" : tactic => `(tactic | (wp_pure (rec _ &(.named _) := _); wp_pure (_ _)))
+macro "wp_seq" : tactic => `(tactic | (wp_pure (rec _ _ := _); wp_pure (_ _)))
 macro "wp_proj" : tactic => `(tactic | first | wp_pure (fst(_)) | wp_pure (snd(_)))
 macro "wp_case" : tactic => `(tactic | wp_pure (&(Exp.case _ _ _)))
 macro "wp_inj" : tactic => `(tactic | first | wp_pure (injl(_)) | wp_pure (injr(_)))
 macro "wp_pair" : tactic => `(tactic | wp_pure ((_, _)))
 macro "wp_closure" : tactic => `(tactic | wp_pure (rec &_ &_ := _))
-macro "wp_match" : tactic => `(tactic | (wp_case; wp_closure; wp_lam))
+macro "wp_match" : tactic => `(tactic | (wp_case; wp_closure; wp_pure (_ _)))
 
 /-! ## Tactic lemmas for the heap tactics -/
 

--- a/Iris/Iris/HeapLang/ProofMode.lean
+++ b/Iris/Iris/HeapLang/ProofMode.lean
@@ -349,7 +349,6 @@ public theorem tac_wp_pure [ι : IrisGS_gen hlc Exp GF] {Δ Δ'} {s : Stuckness}
   refine .trans (BI.laterN_mono _ H) ?_
   iintro $ !> -; itrivial
 
-/-- Shared core of `wp_pure` and `wp_rec`; `unfoldHead` retries a stuck head at whnf. -/
 public meta def iWpPure {u}
   {GF : Q(BundledGFunctors.{0, 0, 0})}
   {hlc : Q(HasLC)}
@@ -362,8 +361,8 @@ public meta def iWpPure {u}
   (E : Q(CoPset))
   (e : Q(Exp))
   (Φ : Q(Val → $prop))
-  (focus : Q(Exp))
-  (unfoldHead : Bool := false)
+  (findPureExec : (e₁ : Q(Exp)) →
+    ProofModeM ((φ : Q(Prop)) × (n : Q(Nat)) × (e₂ : Q(Exp)) × Q(ProgramLogic.Language.PureExec $φ $n $e₁ $e₂)))
 
   (_hu : QuotedLevelDefEq u 0 := ⟨⟩)
   (_hprop : $prop =Q IProp $GF := ⟨⟩)
@@ -371,50 +370,28 @@ public meta def iWpPure {u}
   (κ : Q(Wp $prop Exp Val Stuckness) := q(wp.def))
   (_hwp : $κ =Q wp.def := ⟨⟩) :
     ProofModeM (Q($ehyps ⊢ Wp.wp $s $E $e $Φ)) := do
-  trace[wp_pure] m!"Focusing with {focus}"
-  -- `findECtx` swallows predicate errors, so the unfold branch stashes its message here
-  let errMsg ← IO.mkRef m!"Cannot find expression to evaluate"
-
-  let synthPureExec (e₁ : Q(Exp)) : ProofModeM (Q(Prop) × Q(Nat) × Q(Exp) × Lean.Expr) := do
-    let φ ← mkFreshExprMVarQ q(Prop)
-    let n ← mkFreshExprMVarQ q(Nat)
-    let e₂ ← mkFreshExprMVarQ q(Exp)
-    let some inst ← ProofModeM.trySynthInstanceQ q(ProgramLogic.Language.PureExec $φ $n $e₁ $e₂)
-      | failure
-    return (φ, n, e₂, inst)
-
-  let some {result := (φ, n, e₂, inst), K, e' := e₁, ..} ← findECtx e fun e₁ => do
-    guard <| ← isDefEq e₁ focus
-    synthPureExec e₁ <|> do
-      guard unfoldHead
-      let ~q(Exp.app (Exp.ofVal $f) (Exp.ofVal $a)) := e₁ | failure
-      let f' : Q(Val) ← whnf f
-      let ~q(Val.rec_ $fb $xb $body) := f' | do
-        errMsg.set m!"head of application does not reduce to a rec-value: {f}"
-        failure
-      -- the unfolded application is definitionally `e₁`, so its instance applies to `e₁`
-      let (φ, n, e₂, inst) ← synthPureExec q(Exp.app (Exp.ofVal $f') (Exp.ofVal $a))
-      -- substitute the folded head, as Rocq's `pure_beta` does with `v1`, not a rewrite
-      let e₂' := q(Exp.subst $xb $a (Exp.subst $fb $f $body))
-      guard <| ← isDefEq e₂ e₂'
-      return (φ, n, e₂', inst)
-    | throwIPMError (← errMsg.get)
+  let some {result := ⟨φ, n, e₂, inst⟩, K, e' := e₁, ..} ←
+    findECtx (α:=((_ : Q(Prop)) × (_ : Q(Nat)) × (_ : Q(Exp)) × Lean.Expr)) e findPureExec
+    | throwIPMError "Cannot find expression to evaluate"
   have inst : Q(ProgramLogic.Language.PureExec $φ $n $e₁ $e₂) := inst
 
   let ⟨_, hyps', pf⟩ ← iModAction hyps q(modality_laterN $n)
-
   let ⟨inner, .up _⟩ ← HeapLang.fillQ K e₂
-
   let nextPf ← iWpFinish hyps' ι s E inner Φ
-
   let HΦ ← iSolveSidecondition φ (failOnUnsolved := false)
-
   return q(tac_wp_pure $inst $HΦ $pf $nextPf)
 
 elab "wp_pure " colGt ppSpace focus:hl_exp:10 : tactic =>
   ProofModeM.runTacticWp `wp_pure fun mvar {hyps, ι, s, E, e, Φ, ..} => do
     let focus ← elabTermEnsuringTypeQ (← `(hl($focus))) q(HeapLang.Exp)
-    mvar.assign <| ← iWpPure hyps ι s E e Φ focus
+    mvar.assign <| ← iWpPure hyps ι s E e Φ fun e₁ => do
+      guard <| ← isDefEq e₁ focus
+      let φ ← mkFreshExprMVarQ q(Prop)
+      let n ← mkFreshExprMVarQ q(Nat)
+      let e₂ ← mkFreshExprMVarQ q(Exp)
+      let some inst ← ProofModeM.trySynthInstanceQ q(ProgramLogic.Language.PureExec $φ $n $e₁ $e₂)
+        | failure
+      return ⟨φ, n, e₂, inst⟩
 
 macro "wp_pure" : tactic => `(tactic| wp_pure _)
 
@@ -442,8 +419,16 @@ macro "wp_pures" : tactic =>
 /-- Beta-reduce the innermost application, unfolding a head hidden behind a definition. -/
 elab "wp_rec" : tactic =>
   ProofModeM.runTacticWp `wp_rec fun mvar {hyps, ι, s, E, e, Φ, ..} => do
-    let focus ← elabTermEnsuringTypeQ (← `(hl(_ _))) q(HeapLang.Exp)
-    mvar.assign <| ← iWpPure hyps ι s E e Φ focus (unfoldHead := true)
+    mvar.assign <| ← iWpPure hyps ι s E e Φ fun e₁ => do
+      let ~q(Exp.app (Exp.ofVal $f) (Exp.ofVal $a)) := e₁ | failure
+      -- reduce `f` to find a recursive function
+      let f' : Q(Val) ← whnf f
+      let ~q(Val.rec_ $fb $xb $body) := f' | failure
+      have : $f' =Q $f := ⟨⟩
+      -- substitute the folded head `f`, not the unfolded `Val.rec_`
+      let e₂ := q(Exp.subst $xb $a (Exp.subst $fb $f $body))
+      return ⟨_, _, e₂, q(instPureExecBeta)⟩
+
 
 macro "wp_if" : tactic => `(tactic | wp_pure (if _ then _ else _))
 macro "wp_if_true" : tactic => `(tactic | wp_pure (if #true then _ else _))

--- a/Iris/Iris/HeapLang/ProofMode.lean
+++ b/Iris/Iris/HeapLang/ProofMode.lean
@@ -306,7 +306,7 @@ public theorem tac_wp_bind [ι : IrisGS_gen hlc Exp GF] {Δ} {s : Stuckness} {E 
     (Δ ⊢ WP (ProgramLogic.fill K e') @ s ; E {{ Φ }}) :=
   H.trans (wp_bind (ProgramLogic.fill K))
 
--- level of hl_exp should be above the level of ; in the heaplang notation to make `wp_bind _ _; wp_rec` work
+-- `hl_exp` must bind tighter than `;` in the heaplang notation so `wp_bind _ _; tac` parses
 elab "wp_bind" colGt ppSpace focus:hl_exp:10 : tactic =>
   ProofModeM.runTacticWp `wp_bind fun mvar {GF, hyps, s, E, e, Φ, ..} => do
     let focus ← elabTermEnsuringTypeQ (←`(hl($focus))) q(HeapLang.Exp)
@@ -349,32 +349,72 @@ public theorem tac_wp_pure [ι : IrisGS_gen hlc Exp GF] {Δ Δ'} {s : Stuckness}
   refine .trans (BI.laterN_mono _ H) ?_
   iintro $ !> -; itrivial
 
+/-- Shared core of `wp_pure` and `wp_rec`; `unfoldHead` retries a stuck head at whnf. -/
+public meta def iWpPure {u}
+  {GF : Q(BundledGFunctors.{0, 0, 0})}
+  {hlc : Q(HasLC)}
+  {prop : Q(Type u)}
+  {bi : Q(BI $prop)}
+  {ehyps : Q($prop)}
+  (hyps : Hyps bi ehyps)
+  (ι : Q(IrisGS_gen $hlc Exp $GF))
+  (s : Q(Stuckness))
+  (E : Q(CoPset))
+  (e : Q(Exp))
+  (Φ : Q(Val → $prop))
+  (focus : Q(Exp))
+  (unfoldHead : Bool := false)
+
+  (_hu : QuotedLevelDefEq u 0 := ⟨⟩)
+  (_hprop : $prop =Q IProp $GF := ⟨⟩)
+  (_hbi : $bi =Q UPred.instBIUPred := ⟨⟩)
+  (κ : Q(Wp $prop Exp Val Stuckness) := q(wp.def))
+  (_hwp : $κ =Q wp.def := ⟨⟩) :
+    ProofModeM (Q($ehyps ⊢ Wp.wp $s $E $e $Φ)) := do
+  trace[wp_pure] m!"Focusing with {focus}"
+  -- `findECtx` swallows predicate errors, so the unfold branch stashes its message here
+  let errMsg ← IO.mkRef m!"Cannot find expression to evaluate"
+
+  let synthPureExec (e₁ : Q(Exp)) : ProofModeM (Q(Prop) × Q(Nat) × Q(Exp) × Lean.Expr) := do
+    let φ ← mkFreshExprMVarQ q(Prop)
+    let n ← mkFreshExprMVarQ q(Nat)
+    let e₂ ← mkFreshExprMVarQ q(Exp)
+    let some inst ← ProofModeM.trySynthInstanceQ q(ProgramLogic.Language.PureExec $φ $n $e₁ $e₂)
+      | failure
+    return (φ, n, e₂, inst)
+
+  let some {result := (φ, n, e₂, inst), K, e' := e₁, ..} ← findECtx e fun e₁ => do
+    guard <| ← isDefEq e₁ focus
+    synthPureExec e₁ <|> do
+      guard unfoldHead
+      let ~q(Exp.app (Exp.ofVal $f) (Exp.ofVal $a)) := e₁ | failure
+      let f' : Q(Val) ← whnf f
+      let ~q(Val.rec_ $fb $xb $body) := f' | do
+        errMsg.set m!"head of application does not reduce to a rec-value: {f}"
+        failure
+      -- the unfolded application is definitionally `e₁`, so its instance applies to `e₁`
+      let (φ, n, e₂, inst) ← synthPureExec q(Exp.app (Exp.ofVal $f') (Exp.ofVal $a))
+      -- substitute the folded head, as Rocq's `pure_beta` does with `v1`, not a rewrite
+      let e₂' := q(Exp.subst $xb $a (Exp.subst $fb $f $body))
+      guard <| ← isDefEq e₂ e₂'
+      return (φ, n, e₂', inst)
+    | throwIPMError (← errMsg.get)
+  have inst : Q(ProgramLogic.Language.PureExec $φ $n $e₁ $e₂) := inst
+
+  let ⟨_, hyps', pf⟩ ← iModAction hyps q(modality_laterN $n)
+
+  let ⟨inner, .up _⟩ ← HeapLang.fillQ K e₂
+
+  let nextPf ← iWpFinish hyps' ι s E inner Φ
+
+  let HΦ ← iSolveSidecondition φ (failOnUnsolved := false)
+
+  return q(tac_wp_pure $inst $HΦ $pf $nextPf)
+
 elab "wp_pure " colGt ppSpace focus:hl_exp:10 : tactic =>
   ProofModeM.runTacticWp `wp_pure fun mvar {hyps, ι, s, E, e, Φ, ..} => do
     let focus ← elabTermEnsuringTypeQ (← `(hl($focus))) q(HeapLang.Exp)
-    trace[wp_pure] m!"Focusing with {focus}"
-
-    let some {result := (φ, n, e₂, inst), K, e' := e₁, heq := _} ← findECtx e fun e₁ => do
-      guard <| ← isDefEq e₁ focus
-      let φ ← mkFreshExprMVarQ q(Prop)
-      let n ← mkFreshExprMVarQ q(Nat)
-      let e₂ ← mkFreshExprMVarQ q(Exp)
-      let some inst ← ProofModeM.trySynthInstanceQ q(ProgramLogic.Language.PureExec $φ $n $e₁ $e₂) | failure
-      return (φ, n, e₂, inst)
-      | throwIPMError "Cannot find expression to evaluate"
-    have inst : Q(ProgramLogic.Language.PureExec $φ $n $e₁ $e₂) := inst
-
-    let ⟨_, hyps', pf⟩ ← iModAction hyps q(modality_laterN $n)
-
-    let ⟨inner, .up _⟩ ← HeapLang.fillQ K e₂
-
-    let nextPf ← iWpFinish hyps' ι s E inner Φ
-
-    let HΦ ← iSolveSidecondition q($φ) (failOnUnsolved := false)
-
-    let pf := q(tac_wp_pure $inst $HΦ $pf $nextPf)
-
-    mvar.assign pf
+    mvar.assign <| ← iWpPure hyps ι s E e Φ focus
 
 macro "wp_pure" : tactic => `(tactic| wp_pure _)
 
@@ -399,7 +439,11 @@ macro "wp_pures" : tactic =>
     | (wp_pure_step; repeat wp_pure_step)
     | wp_finish)
 
-macro "wp_rec" : tactic => `(tactic | (wp_bind _ _; iapply $(mkIdent `wp_rec):ident; rfl; imodintro; wp_finish))
+/-- Beta-reduce the innermost application, unfolding a head hidden behind a definition. -/
+elab "wp_rec" : tactic =>
+  ProofModeM.runTacticWp `wp_rec fun mvar {hyps, ι, s, E, e, Φ, ..} => do
+    let focus ← elabTermEnsuringTypeQ (← `(hl(_ _))) q(HeapLang.Exp)
+    mvar.assign <| ← iWpPure hyps ι s E e Φ focus (unfoldHead := true)
 
 macro "wp_if" : tactic => `(tactic | wp_pure (if _ then _ else _))
 macro "wp_if_true" : tactic => `(tactic | wp_pure (if #true then _ else _))

--- a/Iris/IrisTest/HeapLang/WeakestPre.lean
+++ b/Iris/IrisTest/HeapLang/WeakestPre.lean
@@ -449,7 +449,7 @@ example (v : Val) : ⊢@{IProp GF} WP hl(&loopIt &v) {{ v, True }} := by
   trace_state
 
 -- a head that unfolds to something other than a closure is reported as such
-/-- error: wp_rec: head of application does not reduce to a rec-value: notARec -/
+/-- error: wp_rec: Cannot find expression to evaluate -/
 #guard_msgs in
 example (v : Val) : ⊢@{IProp GF} WP hl(&notARec &v) {{ v, True }} := by
   wp_rec

--- a/Iris/IrisTest/HeapLang/WeakestPre.lean
+++ b/Iris/IrisTest/HeapLang/WeakestPre.lean
@@ -398,6 +398,22 @@ example : ⊢@{IProp GF} WP hl(let x := #1; x + #1) {{ v, ⌜v = hl_val(#2)⌝ }
   wp_let
   trace_state
 
+-- the evaluation context stays in the goal instead of moving into the postcondition
+/-- trace:
+hlc : HasLC
+GF✝ : BundledGFunctors
+ι : IrisGS_gen hlc Exp GF✝
+GF : BundledGFunctors
+inst✝ : HeapLangGS hlc GF
+l : Loc
+⊢ ⏎
+  ⊢ WP hl((!#l + #1)) {{ v, True }}
+-/
+#guard_msgs (trace, drop error) in
+example (l : Loc) : ⊢@{IProp GF} WP hl((let x := #l; !x) + #1) {{ v, True }} := by
+  wp_let
+  trace_state
+
 end wp_let
 
 section wp_seq
@@ -420,6 +436,22 @@ example : ⊢@{IProp GF} WP hl(#1; #2) {{ v, ⌜v = hl_val(#2)⌝ }} := by
 #guard_msgs in
 example : ⊢@{IProp GF} WP hl(let x := #1; x) {{ v, ⌜v = hl_val(#1)⌝ }} := by
   wp_seq
+
+-- the evaluation context stays in the goal instead of moving into the postcondition
+/-- trace:
+hlc : HasLC
+GF✝ : BundledGFunctors
+ι : IrisGS_gen hlc Exp GF✝
+GF : BundledGFunctors
+inst✝ : HeapLangGS hlc GF
+l : Loc
+⊢ ⏎
+  ⊢ WP hl((!#l + #1)) {{ v, True }}
+-/
+#guard_msgs (trace, drop error) in
+example (l : Loc) : ⊢@{IProp GF} WP hl((#(); !#l) + #1) {{ v, True }} := by
+  wp_seq
+  trace_state
 
 end wp_seq
 
@@ -737,6 +769,23 @@ inst✝ : HeapLangGS hlc GF
 example : ⊢@{IProp GF}
     WP hl(match v(injl(#1)) with | injl(x) => x + #1 | injr(y) => y)
       {{ v, ⌜v = hl_val(#2)⌝ }} := by
+  wp_match
+  trace_state
+
+-- the evaluation context stays in the goal instead of moving into the postcondition
+/-- trace:
+hlc : HasLC
+GF✝ : BundledGFunctors
+ι : IrisGS_gen hlc Exp GF✝
+GF : BundledGFunctors
+inst✝ : HeapLangGS hlc GF
+l : Loc
+⊢ ⏎
+  ⊢ WP hl((!#l + #1)) {{ v, True }}
+-/
+#guard_msgs (trace, drop error) in
+example (l : Loc) : ⊢@{IProp GF}
+    WP hl((match v(injl(#l)) with | injl(x) => !x | injr(y) => y) + #1) {{ v, True }} := by
   wp_match
   trace_state
 

--- a/Iris/IrisTest/HeapLang/WeakestPre.lean
+++ b/Iris/IrisTest/HeapLang/WeakestPre.lean
@@ -347,9 +347,8 @@ example : ⊢@{IProp GF} WP hl(v(λ x, x + #1) #1) {{ v, ⌜v = hl_val(#2)⌝ }}
   wp_lam
   trace_state
 
-/--
-error: iapply: cannot apply WP hl(v(&?_) v(&?_)) @ ?_ ; ?_ {{ ?_ }} to WP hl(let x := #1; (x + #1)) {{ v, ⌜v = hl_val(#2)⌝ }}
--/
+-- the head is still a closure expression, so there is no beta redex yet
+/-- error: wp_rec: Cannot find expression to evaluate -/
 #guard_msgs in
 example : ⊢@{IProp GF} WP hl((λ x, x + #1) #1) {{ v, ⌜v = hl_val(#2)⌝ }} := by
   wp_lam
@@ -368,14 +367,94 @@ example : ⊢@{IProp GF} WP hl(&addOne #1) {{ v, ⌜v = hl_val(#2)⌝ }} := by
   wp_lam
   trace_state
 
-/--
-error: iapply: cannot apply WP hl(v(&?_) v(&?_)) @ ?_ ; ?_ {{ ?_ }} to WP hl(v(&addOne) (#1 + #1)) {{ v, ⌜v = hl_val(#3)⌝ }}
--/
+-- the argument is not a value yet, so the application is not a redex
+/-- error: wp_rec: Cannot find expression to evaluate -/
 #guard_msgs in
 example : ⊢@{IProp GF} WP hl(&addOne (#1 + #1)) {{ v, ⌜v = hl_val(#3)⌝ }} := by
   wp_lam
 
 end wp_lam
+
+section wp_rec
+
+def readIt : Val := hl_val% λ l, !l
+
+def loopIt : Val := hl_val% rec f x := f x
+
+def callIt : Val := hl_val% rec f x := x #()
+
+def notARec : Val := hl_val% #3
+
+-- unfolding the head to find the redex does not lose the surrounding evaluation context
+/-- trace:
+hlc : HasLC
+GF✝ : BundledGFunctors
+ι : IrisGS_gen hlc Exp GF✝
+GF : BundledGFunctors
+inst✝ : HeapLangGS hlc GF
+l : Loc
+⊢ ⏎
+  ⊢ WP hl((!#l + #1)) {{ v, True }}
+-/
+#guard_msgs (trace, drop error) in
+example (l : Loc) : ⊢@{IProp GF} WP hl(&readIt #l + #1) {{ v, True }} := by
+  wp_rec
+  trace_state
+
+-- the recursive call reads as the definition rather than as its expansion
+/-- trace:
+hlc : HasLC
+GF✝ : BundledGFunctors
+ι : IrisGS_gen hlc Exp GF✝
+GF : BundledGFunctors
+inst✝ : HeapLangGS hlc GF
+v : Val
+⊢ ⏎
+  ⊢ WP hl(v(&loopIt) v(&v)) {{ v, True }}
+-/
+#guard_msgs (trace, drop error) in
+example (v : Val) : ⊢@{IProp GF} WP hl(&loopIt &v) {{ v, True }} := by
+  wp_rec
+  trace_state
+
+-- an argument that happens to be the same closure is left as written, not folded too
+/-- trace:
+hlc : HasLC
+GF✝ : BundledGFunctors
+ι : IrisGS_gen hlc Exp GF✝
+GF : BundledGFunctors
+inst✝ : HeapLangGS hlc GF
+⊢ ⏎
+  ⊢ WP hl((v(rec f x := x #())) #()) {{ v, True }}
+-/
+#guard_msgs (trace, drop error) in
+example : ⊢@{IProp GF} WP hl(&callIt v(rec f x := x #())) {{ v, True }} := by
+  wp_rec
+  trace_state
+
+-- `wp_pures` never unfolds a head, so it terminates on a recursive definition
+/-- trace:
+hlc : HasLC
+GF✝ : BundledGFunctors
+ι : IrisGS_gen hlc Exp GF✝
+GF : BundledGFunctors
+inst✝ : HeapLangGS hlc GF
+v : Val
+⊢ ⏎
+  ⊢ WP hl(v(&loopIt) v(&v)) {{ v, True }}
+-/
+#guard_msgs (trace, drop error) in
+example (v : Val) : ⊢@{IProp GF} WP hl(&loopIt &v) {{ v, True }} := by
+  wp_pures
+  trace_state
+
+-- a head that unfolds to something other than a closure is reported as such
+/-- error: wp_rec: head of application does not reduce to a rec-value: notARec -/
+#guard_msgs in
+example (v : Val) : ⊢@{IProp GF} WP hl(&notARec &v) {{ v, True }} := by
+  wp_rec
+
+end wp_rec
 
 section wp_let
 


### PR DESCRIPTION
## Description

This PR fully addresses #603 and is comprised of two commits:

- [commit 1](https://github.com/leanprover-community/iris-lean/commit/c2b571b179d3a45fe1bc83422598e58f6e0b67ac) changes the definitions of `wp_match`, `wp_seq`, and `wp_let` to use `wp_pure (_ _)` instead of `wp_rec` because they do not require unfolding. This fixes the first part of #603 even without redefinition of `wp_rec` but is still an arguably cleaner path since the unfolding route does not need to be invoked.
- [commit 2](https://github.com/leanprover-community/iris-lean/commit/b7601126e00ca476559c3e709386850849b4e83b) extracts the body of `wp_pure` into a shared core with `wp_rec` that takes an `unfoldHead` parameter and redefines `wp_rec` on top of it. `wp_rec` thus no longer calls `wp_bind` and leaves a flat goal like the Rocq counterpart. This fixes the [second part of #603](https://github.com/leanprover-community/iris-lean/issues/603#issuecomment-5293234856)

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
