### PR TITLE
feat: proof mode instances for big operators

### DIFF
--- a/Iris/Iris/BI/BigOp/BigOp.lean
+++ b/Iris/Iris/BI/BigOp/BigOp.lean
@@ -504,6 +504,42 @@ def delabBigOpS : Delab := do
   else
     failure
 
+private def delabBigOpMSBody (fn : Expr) (xArg phiArg : Nat)
+    (mk : Ident → TSyntax `term → TSyntax `term → DelabM (TSyntax `term)) : Delab := do
+  let X ← withNaryArg xArg delab
+  match fn with
+  | .lam xn _ _ _ =>
+    let P ← withNaryArg phiArg <| withBindingBody xn delab
+    let x := mkIdent xn
+    mk x X P
+  | _ => failure
+
+/-- Delaborator for `bigSepMS` -/
+@[delab app.Iris.BI.bigSepMS]
+def delabBigSepMS : Delab := do
+  let e ← getExpr
+  unless e.isApp do failure
+  unless e.getAppFn.isConstOf ``bigSepMS do failure
+  let args := e.getAppArgs
+  unless args.size == 7 do failure
+  delabBigOpMSBody args[5]! 6 5
+    (fun x X P => `([∗mset] $x ∈ $X, $P))
+
+@[delab app.Iris.Algebra.bigOpMS]
+def delabBigOpMS : Delab := do
+  let e ← getExpr
+  unless e.isApp do failure
+  unless e.getAppFn.isConstOf ``Iris.Algebra.bigOpMS do failure
+  let args := e.getAppArgs
+  -- need at least `Φ` and `X`, plus an `op` somewhere before them
+  unless args.size ≥ 3 do failure
+  let phiArg := args.size - 2
+  let xArg := args.size - 1
+  -- the monoid operation is the (unique) earlier argument headed by a BI connective
+  unless args[:phiArg].any (·.getAppFn.isConstOf ``BIBase.sep) do failure
+  delabBigOpMSBody args[phiArg]! xArg phiArg
+    (fun x X P => `([∗mset] $x ∈ $X, $P))
+
 /-- Delaborator for `bigOpL` applied to `sep`/`and`/`or` — catches cases where
     `bigSepL`/`bigAndL`/`bigOrL` abbrevs are unfolded. -/
 @[delab app.Iris.Algebra.bigOpL]

--- a/Iris/Iris/ProgramLogic/Adequacy.lean
+++ b/Iris/Iris/ProgramLogic/Adequacy.lean
@@ -319,8 +319,8 @@ theorem wp_adequacy_gen [InvGpreS GF] (s : Stuckness) (e : Expr) (σ : State) (�
   dsimp only
   imodintro
   iframe
-  isplitl [Hwp]
-  · iapply BigSepL2.bigSepL2_singleton; iframe
+  isplitl
+  · iapply BigSepL2.bigSepL2_nil; itrivial
   iintro %_ %_ %Heq %_ %HNS Hst Hwptp _
   iapply fupd_mask_intro_discard empty_subset
   icases BigSepL2.bigSepL2_cons_inv_right $$ Hwptp with ⟨%e', %_, %Heq', Hpost, H⟩

--- a/Iris/Iris/ProofMode/Classes.lean
+++ b/Iris/Iris/ProofMode/Classes.lean
@@ -11,7 +11,7 @@ public import Iris.ProofMode.Modalities
 @[expose] public section
 
 namespace Iris.ProofMode
-open Iris.BI
+open Iris.BI Std
 
 /--
 [PMError] is used as precondition on "failing" instances of typeclasses that
@@ -274,6 +274,35 @@ export AddModal (add_modal)
 @[rocq_alias add_modal_id]
 theorem addModal_id {PROP} [BI PROP] (P Q : PROP) : AddModal P P Q where
   add_modal := wand_elim_right
+
+@[ipm_class, rocq_alias IsCons]
+class IsCons {α} (l : List α) (x : outParam α) (xs : outParam <| List α) where
+  is_cons : l = x :: xs
+export IsCons (is_cons)
+
+@[ipm_class, rocq_alias IsApp]
+class IsApp {α} (l : List α) (l1 l2 : outParam (List α)) where
+  is_app : l = l1 ++ l2
+export IsApp (is_app)
+
+@[rocq_alias is_cons_cons]
+instance isCons_cons {α} (x : α) (xs : List α) : IsCons (x :: xs) x xs where
+  is_cons := rfl
+
+@[rocq_alias is_app_app]
+instance isApp_app {α} (l1 l2 : List α) : IsApp (l1 ++ l2) l1 l2 where
+  is_app := rfl
+
+@[ipm_class, rocq_alias IsDisjUnion]
+class IsDisjUnion {MS A : Type _} [FiniteMultiSet MS A]
+    (X : MS) (X₁ X₂ : outParam MS) : Prop where
+  is_disj_union : X = X₁ ⊎ X₂
+export IsDisjUnion (is_disj_union)
+
+@[rocq_alias is_disj_union_disj_union]
+instance isDisjUnion_disjUnion {MS A : Type _} [FiniteMultiSet MS A] (X₁ X₂ : MS) :
+    IsDisjUnion (A := A) (X₁ ⊎ X₂) X₁ X₂ where
+  is_disj_union := rfl
 
 @[ipm_class, rocq_alias Frame]
 class Frame {PROP} [BI PROP] (p : Bool) (R P : PROP) (Q : outParam PROP) where

--- a/Iris/Iris/ProofMode/Instances.lean
+++ b/Iris/Iris/ProofMode/Instances.lean
@@ -604,6 +604,47 @@ instance (priority := default + 10) fromSep_persistently [BI PROP] (P Q1 Q2 : PR
     [h : FromSep P Q1 Q2] : FromSep iprop(<pers> P) iprop(<pers> Q1) iprop(<pers> Q2) where
   from_sep := persistently_sep_mpr.trans (persistently_mono h.1)
 
+@[ipm_backtrack, rocq_alias from_sep_big_sepL_cons]
+instance (priority := default + 10) fromSep_bigSepL_cons [BI PROP] {A}
+    (Φ : Nat → A → PROP) (l : List A) (x : A) (l' : List A) [hl : IsCons l x l'] :
+    FromSep ([∗list] k ↦ y ∈ l, Φ k y) (Φ 0 x) ([∗list] k ↦ y ∈ l', Φ (k + 1) y) where
+  from_sep := hl.is_cons ▸ BigSepL.bigSepL_cons.mpr
+
+@[ipm_backtrack, rocq_alias from_sep_big_sepL_app]
+instance (priority := default + 10) fromSep_bigSepL_app [BI PROP] {A}
+    (Φ : Nat → A → PROP) (l l1 l2 : List A) [hl : IsApp l l1 l2] :
+    FromSep ([∗list] k ↦ y ∈ l, Φ k y)
+      ([∗list] k ↦ y ∈ l1, Φ k y) ([∗list] k ↦ y ∈ l2, Φ (k + l1.length) y) where
+  from_sep := hl.is_app ▸ BigSepL.bigSepL_append.mpr
+
+@[ipm_backtrack, rocq_alias from_sep_big_sepL2_cons]
+instance (priority := default + 5) fromSep_bigSepL2_cons [BI PROP] {A B}
+    (Φ : Nat → A → B → PROP) (l₁ : List A) (x₁ : A) (l₁' : List A)
+    (l₂ : List B) (x₂ : B) (l₂' : List B)
+    [h₁ : IsCons l₁ x₁ l₁'] [h₂ : IsCons l₂ x₂ l₂'] :
+    FromSep ([∗list] k ↦ y₁;y₂ ∈ l₁;l₂, Φ k y₁ y₂)
+      (Φ 0 x₁ x₂) ([∗list] k ↦ y₁;y₂ ∈ l₁';l₂', Φ (k + 1) y₁ y₂) where
+  from_sep := by
+    rw [h₁.is_cons, h₂.is_cons]
+    exact BigSepL2.bigSepL2_cons.mpr
+
+@[ipm_backtrack, rocq_alias from_sep_big_sepL2_app]
+instance (priority := default + 5) fromSep_bigSepL2_app [BI PROP] {A B}
+    (Φ : Nat → A → B → PROP) (l₁ l₁' l₁'' : List A) (l₂ l₂' l₂'' : List B)
+    [h₁ : IsApp l₁ l₁' l₁''] [h₂ : IsApp l₂ l₂' l₂''] :
+    FromSep ([∗list] k ↦ y₁;y₂ ∈ l₁;l₂, Φ k y₁ y₂)
+      ([∗list] k ↦ y₁;y₂ ∈ l₁';l₂', Φ k y₁ y₂)
+      ([∗list] k ↦ y₁;y₂ ∈ l₁'';l₂'', Φ (k + l₁'.length) y₁ y₂) where
+  from_sep := by
+    rw [h₁.is_app, h₂.is_app]
+    exact wand_elim BigSepL2.bigSepL2_app_wand
+
+@[rocq_alias from_sep_big_sepMS_disj_union]
+instance (priority := default + 20) fromSep_bigSepMS_disjUnion [BI PROP] {MS A : Type _}
+    [LawfulFiniteMultiSet MS A] (Φ : A → PROP) (X₁ X₂ : MS) :
+    FromSep ([∗mset] y ∈ X₁ ⊎ X₂, Φ y) ([∗mset] y ∈ X₁, Φ y) ([∗mset] y ∈ X₂, Φ y) where
+  from_sep := BigSepMS.bigSepMS_disjUnion.2
+
 /-! ### AndIntoSep -/
 
 @[ipm_class, rocq_alias AndIntoSep]

--- a/Iris/Iris/ProofMode/Instances.lean
+++ b/Iris/Iris/ProofMode/Instances.lean
@@ -990,6 +990,31 @@ instance intoPure_pure_wand [BI PROP] (a : Bool) (φ1 φ2 : Prop) (P1 P2 : PROP)
           sep_mono_left <| affinely_intro <| pure_intro hφ1
       _ ⊢ ⌜φ2⌝                                    := wand_elim_right
 
+@[rocq_alias into_pure_big_sepL]
+instance intoPure_bigSepL [BI PROP] {A} (Φ : Nat → A → PROP)
+    (φ : Nat → A → Prop) (l : List A) [h : ∀ k x, IntoPure (Φ k x) (φ k x)] :
+    IntoPure ([∗list] k ↦ x ∈ l, Φ k x) (∀ k x, l[k]? = some x → φ k x) where
+  into_pure := (BigSepL.bigSepL_mono fun _ => (h ..).into_pure).trans BigSepL.bigSepL_pure_intro
+
+@[rocq_alias into_pure_big_sepM]
+instance intoPure_bigSepM [BI PROP] {K V : Type _} {M : Type _ → Type _}
+    [LawfulFiniteMap M K] (Φ : K → V → PROP) (φ : K → V → Prop) (m : M V)
+    [h : ∀ k x, IntoPure (Φ k x) (φ k x)] :
+    IntoPure ([∗map] k ↦ x ∈ m, Φ k x) (PartialMap.all φ m) where
+  into_pure := (BigSepM.bigSepM_mono fun _ => (h ..).into_pure).trans BigSepM.bigSepM_pure_intro
+
+@[rocq_alias into_pure_big_sepS]
+instance intoPure_bigSepS [BI PROP] {S A} [LawfulFiniteSet S A]
+    (Φ : A → PROP) (φ : A → Prop) (X : S) [h : ∀ x, IntoPure (Φ x) (φ x)] :
+    IntoPure ([∗set] y ∈ X, Φ y) (∀ y, y ∈ X → φ y) where
+  into_pure := (BigSepS.bigSepS_mono fun _ => (h _).into_pure).trans BigSepS.bigSepS_pure_intro
+
+@[rocq_alias into_pure_big_sepMS]
+instance intoPure_bigSepMS [BI PROP] {MS A} [LawfulFiniteMultiSet MS A]
+    (Φ : A → PROP) (φ : A → Prop) (X : MS) [h : ∀ x, IntoPure (Φ x) (φ x)] :
+    IntoPure ([∗mset] y ∈ X, Φ y) (∀ y, y ∈ X → φ y) where
+  into_pure := (BigSepMS.bigSepMS_mono fun _ => (h _).into_pure).trans BigSepMS.bigSepMS_pure_intro
+
 /-! ### FromPure -/
 
 @[rocq_alias from_pure_emp]

--- a/Iris/Iris/ProofMode/Instances.lean
+++ b/Iris/Iris/ProofMode/Instances.lean
@@ -481,6 +481,50 @@ instance (priority := default + 10) fromAnd_persistently_sep [BI PROP] (P Q1 Q2 
     [h : FromSep P Q1 Q2] : FromAnd iprop(<pers> P) iprop(<pers> Q1) iprop(<pers> Q2) where
   from_and := persistently_and.2.trans <| persistently_and_sep.trans <| persistently_mono h.1
 
+@[ipm_backtrack, rocq_alias from_and_big_sepL_cons_persistent]
+instance (priority := default + 38) fromAnd_bigSepL_cons_persistent [BI PROP] {A}
+    (Φ : Nat → A → PROP) (l : List A) (x : A) (l' : List A)
+    [hl : IsCons l x l'] [Persistent (Φ 0 x)] :
+    FromAnd ([∗list] k ↦ y ∈ l, Φ k y) (Φ 0 x) ([∗list] k ↦ y ∈ l', Φ (k + 1) y) where
+  from_and := hl.is_cons ▸ persistent_and_sep_mp.trans BigSepL.bigSepL_cons.mpr
+
+@[ipm_backtrack, rocq_alias from_and_big_sepL_app_persistent]
+instance (priority := default + 38) fromAnd_bigSepL_app_persistent [BI PROP] {A}
+    (Φ : Nat → A → PROP) (l l₁ l₂ : List A)
+    [hl : IsApp l l₁ l₂] [∀ k y, Persistent (Φ k y)] :
+    FromAnd ([∗list] k ↦ y ∈ l, Φ k y)
+      ([∗list] k ↦ y ∈ l₁, Φ k y) ([∗list] k ↦ y ∈ l₂, Φ (k + l₁.length) y) where
+  from_and := hl.is_app ▸ persistent_and_sep_mp.trans BigSepL.bigSepL_append.mpr
+
+@[ipm_backtrack, rocq_alias from_and_big_sepL2_cons_persistent]
+instance (priority := default + 36) fromAnd_bigSepL2_cons_persistent [BI PROP] {A B}
+    (Φ : Nat → A → B → PROP) (l₁ : List A) (x₁ : A) (l₁' : List A)
+    (l₂ : List B) (x₂ : B) (l₂' : List B)
+    [h₁ : IsCons l₁ x₁ l₁'] [h₂ : IsCons l₂ x₂ l₂'] [Persistent (Φ 0 x₁ x₂)] :
+    FromAnd ([∗list] k ↦ y₁;y₂ ∈ l₁;l₂, Φ k y₁ y₂)
+      (Φ 0 x₁ x₂) ([∗list] k ↦ y₁;y₂ ∈ l₁';l₂', Φ (k + 1) y₁ y₂) where
+  from_and := by
+    rw [h₁.is_cons, h₂.is_cons]
+    exact persistent_and_sep_mp.trans BigSepL2.bigSepL2_cons.2
+
+@[ipm_backtrack, rocq_alias from_and_big_sepL2_app_persistent]
+instance (priority := default + 36) fromAnd_bigSepL2_app_persistent [BI PROP] {A B}
+    (Φ : Nat → A → B → PROP) (l₁ l₁' l₁'' : List A) (l₂ l₂' l₂'' : List B)
+    [h₁ : IsApp l₁ l₁' l₁''] [h₂ : IsApp l₂ l₂' l₂'']
+    [∀ k y₁ y₂, Persistent (Φ k y₁ y₂)] :
+    FromAnd ([∗list] k ↦ y₁;y₂ ∈ l₁;l₂, Φ k y₁ y₂)
+      ([∗list] k ↦ y₁;y₂ ∈ l₁';l₂', Φ k y₁ y₂)
+      ([∗list] k ↦ y₁;y₂ ∈ l₁'';l₂'', Φ (k + l₁'.length) y₁ y₂) where
+  from_and := by
+    rw [h₁.is_app, h₂.is_app]
+    exact persistent_and_sep_mp.trans <| wand_elim BigSepL2.bigSepL2_app_wand
+
+@[rocq_alias from_and_big_sepMS_disj_union_persistent]
+instance (priority := default + 40) fromAnd_bigSepMS_disjUnion_persistent [BI PROP]
+    {MS A} [LawfulFiniteMultiSet MS A] (Φ : A → PROP) (X₁ X₂ : MS) [∀ y, Persistent (Φ y)] :
+    FromAnd ([∗mset] y ∈ X₁ ⊎ X₂, Φ y) ([∗mset] y ∈ X₁, Φ y) ([∗mset] y ∈ X₂, Φ y) where
+  from_and := persistent_and_sep_mp.trans BigSepMS.bigSepMS_disjUnion.mpr
+
 /-! ### IntoAnd -/
 
 @[rocq_alias into_and_and]

--- a/Iris/Iris/ProofMode/Instances.lean
+++ b/Iris/Iris/ProofMode/Instances.lean
@@ -732,6 +732,36 @@ instance intoSep_intuitionistically_affine [BI PROP] (P Q1 Q2 : PROP) [h : IntoS
     _ ⊢ □ Q1 ∧ □ Q2 := intuitionistically_and.mp
     _ ⊢ □ Q1 ∗ □ Q2 := and_sep_intuitionistically.mp
 
+@[ipm_backtrack, rocq_alias into_sep_big_sepL_cons]
+instance intoSep_bigSepL_cons [BI PROP] {A}
+    (Φ : Nat → A → PROP) (l : List A) (x : A) (l' : List A) [hl : IsCons l x l'] :
+    IntoSep ([∗list] k ↦ y ∈ l, Φ k y) (Φ 0 x) ([∗list] k ↦ y ∈ l', Φ (k + 1) y) where
+  into_sep := hl.is_cons ▸ BigSepL.bigSepL_cons.mp
+
+@[ipm_backtrack, rocq_alias into_sep_big_sepL_app]
+instance intoSep_bigSepL_app [BI PROP] {A}
+    (Φ : Nat → A → PROP) (l l₁ l₂ : List A) [hl : IsApp l l₁ l₂] :
+    IntoSep ([∗list] k ↦ y ∈ l, Φ k y)
+      ([∗list] k ↦ y ∈ l₁, Φ k y) ([∗list] k ↦ y ∈ l₂, Φ (k + l₁.length) y) where
+  into_sep := hl.is_app ▸ BigSepL.bigSepL_append.mp
+
+@[rocq_alias into_sep_big_sepL2_cons]
+instance intoSep_bigSepL2_cons [BI PROP] {A B}
+    (Φ : Nat → A → B → PROP) (l₁ : List A) (x₁ : A) (l₁' : List A)
+    (l₂ : List B) (x₂ : B) (l₂' : List B)
+    [h₁ : IsCons l₁ x₁ l₁'] [h₂ : IsCons l₂ x₂ l₂'] :
+    IntoSep ([∗list] k ↦ y₁;y₂ ∈ l₁;l₂, Φ k y₁ y₂)
+      (Φ 0 x₁ x₂) ([∗list] k ↦ y₁;y₂ ∈ l₁';l₂', Φ (k + 1) y₁ y₂) where
+  into_sep := by
+    rw [h₁.is_cons, h₂.is_cons]
+    exact BigSepL2.bigSepL2_cons.mp
+
+@[rocq_alias into_sep_big_sepMS_disj_union]
+instance intoSep_bigSepMS_disjUnion [BI PROP] {MS A}
+    [LawfulFiniteMultiSet MS A] (Φ : A → PROP) (X₁ X₂ : MS) :
+    IntoSep ([∗mset] y ∈ X₁ ⊎ X₂, Φ y) ([∗mset] y ∈ X₁, Φ y) ([∗mset] y ∈ X₂, Φ y) where
+  into_sep := BigSepMS.bigSepMS_disjUnion.mp
+
 /-! ### FromOr -/
 
 @[rocq_alias from_or_or]

--- a/Iris/Iris/ProofMode/Instances.lean
+++ b/Iris/Iris/ProofMode/Instances.lean
@@ -1134,6 +1134,54 @@ instance fromPure_absorbingly (a : Bool) [BI PROP] (P : PROP) (φ : Prop)
   from_pure := absorbingly_affinely_intro_of_persistent.trans <|
     absorbingly_mono <| affinely_affinelyIf.trans h.1
 
+@[rocq_alias from_pure_big_sepL]
+instance fromPure_bigSepL (a : Bool) [BI PROP] {A} (Φ : Nat → A → PROP) io
+    (φ : Nat → A → Prop) (l : List A)
+    [h : ∀ k x, FromPure a (Φ k x) io (φ k x)] [or : TCOr (TCEq a true) (BIAffine PROP)] :
+    FromPure a ([∗list] k ↦ x ∈ l, Φ k x) io (∀ k x, l[k]? = some x → φ k x) where
+  from_pure := match a, or, h with
+    | true, _, h =>
+      BigSepL.bigSepL_affinely_pure_elim.trans <| BigSepL.bigSepL_mono fun _ => (h ..).from_pure
+    | false, TCOr.r, h =>
+      BigSepL.bigSepL_pure.mpr.trans <| BigSepL.bigSepL_mono fun _ => (h ..).from_pure
+    | false, TCOr.l (t := heq), _ => nomatch heq
+
+@[rocq_alias from_pure_big_sepM]
+instance fromPure_bigSepM (a : Bool) [BI PROP] {K V : Type _} {M : Type _ → Type _}
+    [LawfulFiniteMap M K] (Φ : K → V → PROP) (φ : K → V → Prop) (m : M V) io
+    [h : ∀ k x, FromPure a (Φ k x) io (φ k x)] [or : TCOr (TCEq a true) (BIAffine PROP)] :
+    FromPure a ([∗map] k ↦ x ∈ m, Φ k x) io (PartialMap.all φ m) where
+  from_pure := match a, or, h with
+    | true, _, h =>
+      BigSepM.bigSepM_affinely_pure_elim.trans <| BigSepM.bigSepM_mono fun _ => (h ..).from_pure
+    | false, TCOr.r, h =>
+      BigSepM.bigSepM_pure.mpr.trans <| BigSepM.bigSepM_mono fun _ => (h ..).from_pure
+    | false, TCOr.l (t := heq), _ => nomatch heq
+
+@[rocq_alias from_pure_big_sepS]
+instance fromPure_bigSepS (a : Bool) [BI PROP] {S A : Type _} [LawfulFiniteSet S A]
+    (Φ : A → PROP) (φ : A → Prop) (X : S) io
+    [h : ∀ x, FromPure a (Φ x) io (φ x)] [or : TCOr (TCEq a true) (BIAffine PROP)] :
+    FromPure a ([∗set] y ∈ X, Φ y) io (∀ y, y ∈ X → φ y) where
+  from_pure := match a, or, h with
+    | true, _, h =>
+      BigSepS.bigSepS_affinely_pure_elim.trans <| BigSepS.bigSepS_mono fun _ => (h _).from_pure
+    | false, TCOr.r, h =>
+      BigSepS.bigSepS_pure.mpr.trans <| BigSepS.bigSepS_mono fun _ => (h _).from_pure
+    | false, TCOr.l (t := heq), _ => nomatch heq
+
+@[rocq_alias from_pure_big_sepMS]
+instance fromPure_bigSepMS (a : Bool) [BI PROP] {MS A : Type _}
+    [LawfulFiniteMultiSet MS A] (Φ : A → PROP) (φ : A → Prop) (X : MS) io
+    [h : ∀ x, FromPure a (Φ x) io (φ x)] [or : TCOr (TCEq a true) (BIAffine PROP)] :
+    FromPure a ([∗mset] y ∈ X, Φ y) io (∀ y, y ∈ X → φ y) where
+  from_pure := match a, or, h with
+    | true, _, h =>
+      BigSepMS.bigSepMS_affinely_pure_elim.trans <| BigSepMS.bigSepMS_mono fun _ => (h _).from_pure
+    | false, TCOr.r, h =>
+      BigSepMS.bigSepMS_pure.mpr.trans <| BigSepMS.bigSepMS_mono fun _ => (h _).from_pure
+    | false, TCOr.l (t := heq), _ => nomatch heq
+
 /-! ### FromModal -/
 
 @[rocq_alias from_modal_affinely]

--- a/Iris/Iris/ProofMode/InstancesFrame.lean
+++ b/Iris/Iris/ProofMode/InstancesFrame.lean
@@ -271,6 +271,59 @@ instance (priority := default - 1) frame_eq_embed
   frame := (sep_mono_left <| intuitionisticallyIf_mono (embed_internal_eq a b).mpr).trans
     (frame_embed_core h1 h2)
 
+@[ipm_backtrack, rocq_alias frame_big_sepL_cons]
+instance frame_bigSepL_cons [BI PROP] {A} p (Φ : Nat → A → PROP)
+    (R Q : PROP) (l : List A) (x : A) (l' : List A)
+    [hc : IsCons l x l']
+    [hf : Frame p R iprop(Φ 0 x ∗ [∗list] k ↦ y ∈ l', Φ (k + 1) y) Q] :
+    Frame p R iprop([∗list] k ↦ y ∈ l, Φ k y) Q where
+  frame := hc.is_cons ▸ hf.frame.trans BigSepL.bigSepL_cons.mpr
+
+@[ipm_backtrack, rocq_alias frame_big_sepL_app]
+instance frame_bigSepL_app [BI PROP] {A} p (Φ : Nat → A → PROP)
+    (R Q : PROP) (l l1 l2 : List A)
+    [ha : IsApp l l1 l2]
+    [hf : Frame p R iprop(([∗list] k ↦ y ∈ l1, Φ k y) ∗
+                           [∗list] k ↦ y ∈ l2, Φ (k + l1.length) y) Q] :
+    Frame p R iprop([∗list] k ↦ y ∈ l, Φ k y) Q where
+  frame := ha.is_app ▸ hf.frame.trans BigSepL.bigSepL_append.mpr
+
+@[ipm_backtrack, rocq_alias frame_big_sepL2_cons]
+instance frame_bigSepL2_cons [BI PROP] {A B} p (Φ : Nat → A → B → PROP)
+    (R Q : PROP) (l1 : List A) (x1 : A) (l1' : List A)
+    (l2 : List B) (x2 : B) (l2' : List B)
+    [hc1 : IsCons l1 x1 l1'] [hc2 : IsCons l2 x2 l2']
+    [hf : Frame p R iprop(Φ 0 x1 x2 ∗
+                          [∗list] k ↦ y1;y2 ∈ l1';l2', Φ (k + 1) y1 y2) Q] :
+    Frame p R iprop([∗list] k ↦ y1;y2 ∈ l1;l2, Φ k y1 y2) Q where
+  frame := hc1.is_cons ▸ hc2.is_cons ▸ hf.frame.trans BigSepL2.bigSepL2_cons.mpr
+
+@[ipm_backtrack, rocq_alias frame_big_sepL2_app]
+instance frame_bigSepL2_app [BI PROP] {A B} p (Φ : Nat → A → B → PROP)
+    (R Q : PROP) (l1 l1' l1'' : List A) (l2 l2' l2'' : List B)
+    [ha1 : IsApp l1 l1' l1''] [ha2 : IsApp l2 l2' l2'']
+    [hf : Frame p R iprop(([∗list] k ↦ y1;y2 ∈ l1';l2', Φ k y1 y2) ∗
+                           [∗list] k ↦ y1;y2 ∈ l1'';l2'',
+                             Φ (k + l1'.length) y1 y2) Q] :
+    Frame p R iprop([∗list] k ↦ y1;y2 ∈ l1;l2, Φ k y1 y2) Q where
+  frame := by
+    rw [ha1.is_app, ha2.is_app]
+    calc
+      _ ⊢ ([∗list] k ↦ y1;y2 ∈ l1';l2', Φ k y1 y2) ∗
+          [∗list] k ↦ y1;y2 ∈ l1'';l2'', Φ (k + l1'.length) y1 y2 := hf.frame
+      _ ⊢ (([∗list] k ↦ y1;y2 ∈ l1'';l2'', Φ (k + l1'.length) y1 y2) ∗
+          [∗list] k ↦ y1;y2 ∈ l1';l2', Φ k y1 y2) := sep_symm
+      _ ⊢ [∗list] k ↦ x1;x2 ∈ l1' ++ l1'';l2' ++ l2'', Φ k x1 x2 :=
+          wand_elim_swap BigSepL2.bigSepL2_app_wand
+
+@[ipm_backtrack, rocq_alias frame_big_sepMS_disj_union]
+instance frame_bigSepMS_disjUnion [BI PROP] {MS A}
+    [LawfulFiniteMultiSet MS A] p (Φ : A → PROP) (R Q : PROP) (X X1 X2 : MS)
+    [hd : IsDisjUnion X X1 X2]
+    [hf : Frame p R iprop(([∗mset] y ∈ X1, Φ y) ∗ [∗mset] y ∈ X2, Φ y) Q] :
+    Frame p R iprop([∗mset] y ∈ X, Φ y) Q where
+  frame := hd.is_disj_union ▸ hf.frame.trans BigSepMS.bigSepMS_disjUnion.mpr
+
 section tactic_theorems
 
 @[rocq_alias maybe_frame_default_persistent]

--- a/Iris/Iris/ProofMode/InstancesLater.lean
+++ b/Iris/Iris/ProofMode/InstancesLater.lean
@@ -547,6 +547,73 @@ instance (priority := default - 11) intoLaterN_sep_right [BI PROP]
     IntoLaterN progress (only_head := false) n iprop(P ∗ P2) iprop(P ∗ Q2) where
   into_laterN := (sep_mono (laterN_intro n) h.into_laterN).trans (laterN_sep n).mpr
 
+/-- IntoLaterN, big operators -/
+
+@[ipm_backtrack, rocq_alias into_laterN_big_sepL]
+instance intoLaterN_bigSepL [BI PROP] {A} progress n
+    (Φ Ψ : Nat → A → PROP) (l : List A)
+    [h : ∀ k x, IntoLaterN (progress := true) (only_head := false) n (Φ k x) (Ψ k x)] :
+    IntoLaterN progress (only_head := false) n
+      iprop([∗list] k ↦ x ∈ l, Φ k x) iprop([∗list] k ↦ x ∈ l, Ψ k x) where
+  into_laterN :=
+    (BigSepL.bigSepL_mono_of_forall fun {k x} => (h k x).into_laterN).trans
+    BigSepL.bigSepL_laterN_2
+
+@[ipm_backtrack, rocq_alias into_laterN_big_sepL2]
+instance intoLaterN_bigSepL2 [BI PROP] {A B} progress n
+    (Φ Ψ : Nat → A → B → PROP) (l1 : List A) (l2 : List B)
+    [h : ∀ k x1 x2,
+      IntoLaterN (progress := true) (only_head := false) n (Φ k x1 x2) (Ψ k x1 x2)] :
+    IntoLaterN progress (only_head := false) n
+      iprop([∗list] k ↦ y1;y2 ∈ l1;l2, Φ k y1 y2)
+      iprop([∗list] k ↦ y1;y2 ∈ l1;l2, Ψ k y1 y2) where
+  into_laterN :=
+    (BigSepL2.bigSepL2_mono_of_forall fun {k x1 x2} => (h k x1 x2).into_laterN).trans
+    BigSepL2.bigSepL2_laterN_2
+
+@[ipm_backtrack, rocq_alias into_laterN_big_sepM]
+instance intoLaterN_bigSepM [BI PROP] {K V M}
+    [LawfulFiniteMap M K] progress n (Φ Ψ : K → V → PROP) (m : M V)
+    [h : ∀ k x, IntoLaterN (progress := true) (only_head := false) n (Φ k x) (Ψ k x)] :
+    IntoLaterN progress (only_head := false) n
+      iprop([∗map] k ↦ x ∈ m, Φ k x) iprop([∗map] k ↦ x ∈ m, Ψ k x) where
+  into_laterN :=
+    (BigSepM.bigSepM_mono_of_forall fun {k x} => (h k x).into_laterN).trans
+    BigSepM.bigSepM_laterN_2
+
+@[ipm_backtrack, rocq_alias into_laterN_big_sepS]
+instance intoLaterN_bigSepS [BI PROP] {S A} [LawfulFiniteSet S A]
+    progress n (Φ Ψ : A → PROP) (X : S)
+    [h : ∀ x, IntoLaterN (progress := true) (only_head := false) n (Φ x) (Ψ x)] :
+    IntoLaterN progress (only_head := false) n
+      iprop([∗set] x ∈ X, Φ x) iprop([∗set] x ∈ X, Ψ x) where
+  into_laterN :=
+    (BigSepS.bigSepS_mono_of_forall fun x => (h x).into_laterN).trans
+    BigSepS.bigSepS_laterN_2
+
+@[ipm_backtrack, rocq_alias into_laterN_big_sepMS]
+instance intoLaterN_bigSepMS [BI PROP] {MS A} [LawfulFiniteMultiSet MS A]
+    progress n (Φ Ψ : A → PROP) (X : MS)
+    [h : ∀ x, IntoLaterN (progress := true) (only_head := false) n (Φ x) (Ψ x)] :
+    IntoLaterN progress (only_head := false) n
+      iprop([∗mset] x ∈ X, Φ x) iprop([∗mset] x ∈ X, Ψ x) where
+  into_laterN :=
+    (BigSepMS.bigSepMS_mono_of_forall fun x => (h x).into_laterN).trans
+    BigSepMS.bigSepMS_laterN_2
+
+@[ipm_backtrack, rocq_alias into_laterN_big_sepM2]
+instance intoLaterN_bigSepM2 [BI PROP] {K A B M} [LawfulFiniteMap M K]
+    progress n (Φ Ψ : K → A → B → PROP) (m1 : M A) (m2 : M B)
+    [h : ∀ k x1 x2, IntoLaterN (progress := true) (only_head := false) n (Φ k x1 x2) (Ψ k x1 x2)] :
+    IntoLaterN progress (only_head := false) n
+      iprop([∗map] k ↦ x1;x2 ∈ m1;m2, Φ k x1 x2)
+      iprop([∗map] k ↦ x1;x2 ∈ m1;m2, Ψ k x1 x2) where
+  into_laterN := calc
+    _ ⊢ [∗map] k ↦ x1;x2 ∈ m1;m2, ▷^[n] Ψ k x1 x2 :=
+      BigSepM2.bigSepM2_mono_of_forall Φ (fun k x1 x2 => iprop(▷^[n] Ψ k x1 x2)) m1 m2
+        (fun {k x1 x2} => (h k x1 x2).into_laterN)
+    _ ⊢ ▷^[n] [∗map] k ↦ x1;x2 ∈ m1;m2, Ψ k x1 x2 := BigSepM2.bigSepM2_laterN_2 n
+
 /-! ### CombineSepAs -/
 
 @[rocq_alias maybe_combine_sep_as_later]

--- a/Iris/IrisTest/BigOp.lean
+++ b/Iris/IrisTest/BigOp.lean
@@ -167,4 +167,29 @@ variable [∀ y, Persistent (Ξ y)] in
 #guard_msgs (whitespace := lax) in
 #ipm_synth IntoLaterN true false 2 iprop([∗list] k ↦ x ∈ l, ▷ (▷ Φ k x ∧ ▷ Φ k x)) _
 
+/- Tests `frame_bigSepL_cons` after backtracking from `frame_bigSepL_app`. -/
+example (Φ : Nat → A → PROP) (x : A) (l : List A) :
+    ([∗list] k ↦ y ∈ l, Φ (k + 1) y) ∗ Φ 0 x ⊢ [∗list] k ↦ y ∈ x :: l, Φ k y := by
+  iintro ⟨H1, H2⟩
+  iframe
+
+/- Tests `frame_bigSepL_app`. -/
+example (Φ : Nat → A → PROP) (l1 l2 : List A) :
+    ([∗list] k ↦ y ∈ l1, Φ k y) ∗ ([∗list] k ↦ y ∈ l2, Φ (k + l1.length) y) ⊢
+      [∗list] k ↦ y ∈ l1 ++ l2, Φ k y := by
+  iintro ⟨H1, H2⟩
+  iframe
+
+/- Tests `frame_bigSepMS_disj_union`. -/
+example (Φ : A → PROP) (X Y : MS) :
+    ([∗mset] z ∈ X, Φ z) ∗ ([∗mset] z ∈ Y, Φ z) ⊢ [∗mset] z ∈ X ⊎ Y, Φ z := by
+  iintro ⟨H1, H2⟩
+  iframe
+
+/- Tests that `frame_here` has a higher priority than `Frame` instances for big operators. -/
+example (Φ : Nat → A → PROP) (x : A) (l : List A) (P : PROP) :
+    ([∗list] k ↦ y ∈ x :: l, Φ k y) ∗ P ⊢ ([∗list] k ↦ y ∈ x :: l, Φ k y) ∗ P := by
+  iintro ⟨H1, H2⟩
+  iframe
+
 end ProofModeInstances

--- a/Iris/IrisTest/BigOp.lean
+++ b/Iris/IrisTest/BigOp.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2026 Alvin Tang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alvin Tang
+-/
+module
+
+public import Iris.BI.BigOp
+public import Iris.ProofMode.Classes
+public import Iris.ProofMode.Instances
+
+@[expose] public section
+
+namespace IrisTest
+open Iris BI ProofMode Std
+
+section ProofModeInstances
+
+variable {PROP : Type} [BI PROP] {A B : Type}
+variable (Φ : Nat → A → PROP) (Ψ : Nat → A → B → PROP) (Ξ : A → PROP)
+variable (x x' : A) (y : B) (l l1 l2 : List A) (k1 k2 : List B)
+variable {MS : Type} [LawfulFiniteMultiSet MS A] (X1 X2 : MS)
+
+/-
+  Tests `fromSep_bigSepL_cons` after `fromSep_bigSepL_app` fails to apply
+  and causes backtracking.
+-/
+/-- info:
+  solution: FromSep ([∗list] k ↦ y ∈ x :: l, Φ k y) (Φ 0 x) ([∗list] k ↦ y ∈ l, Φ (k + 1) y),
+  new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+#ipm_synth FromSep ([∗list] k ↦ y ∈ x :: l, Φ k y) _ _
+
+/- Tests `fromSep_bigSepL_app`. -/
+/-- info:
+  solution: FromSep ([∗list] k ↦ y ∈ l1 ++ l2, Φ k y) ([∗list] k ↦ y ∈ l1, Φ k y)
+    ([∗list] k ↦ y ∈ l2, Φ (k + l1.length) y),
+  new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+#ipm_synth FromSep ([∗list] k ↦ y ∈ l1 ++ l2, Φ k y) _ _
+
+/-
+  Tests `fromSep_bigSepL2_cons` after `fromSep_bigSepL2_app` fails to apply
+  and causes backtracking.
+-/
+/-- info:
+  solution: FromSep ([∗list] k ↦ y₁;y₂ ∈ x :: l;y :: k1, Ψ k y₁ y₂) (Ψ 0 x y)
+    ([∗list] k ↦ y₁;y₂ ∈ l;k1, Ψ (k + 1) y₁ y₂),
+  new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+#ipm_synth FromSep ([∗list] k ↦ y1;y2 ∈ x :: l; y :: k1, Ψ k y1 y2) _ _
+
+/- Tests `fromSep_bigSepL2_app`. -/
+/-- info:
+  solution: FromSep ([∗list] k ↦ y₁;y₂ ∈ l1 ++ l2;k1 ++ k2, Ψ k y₁ y₂)
+    ([∗list] k ↦ y₁;y₂ ∈ l1;k1, Ψ k y₁ y₂) ([∗list] k ↦ y₁;y₂ ∈ l2;k2, Ψ (k + l1.length) y₁ y₂),
+  new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+#ipm_synth FromSep ([∗list] k ↦ y₁;y₂ ∈ l1 ++ l2; k1 ++ k2, Ψ k y₁ y₂) _ _
+
+/- Tests `fromSep_bigSepMS_disjUnion`, matching `X₁ ⊎ X₂` syntactically. -/
+/-- info:
+  solution: FromSep ([∗mset] y ∈ X1 ⊎ X2, Ξ y) ([∗mset] y ∈ X1, Ξ y) ([∗mset] y ∈ X2, Ξ y),
+  new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+#ipm_synth FromSep ([∗mset] z ∈ X1 ⊎ X2, Ξ z) _ _
+
+/-
+  Synthesis fails as the metavariable `?l` is involved and the guards
+  `IsApp` and `IsCons` apply.
+-/
+/-- info: None -/
+#guard_msgs in
+#ipm_synth FromSep ([∗list] k ↦ y ∈ ?l, Φ k y) _ _
+
+end ProofModeInstances

--- a/Iris/IrisTest/BigOp.lean
+++ b/Iris/IrisTest/BigOp.lean
@@ -78,4 +78,24 @@ variable {MS : Type} [LawfulFiniteMultiSet MS A] (X1 X2 : MS)
 #guard_msgs in
 #ipm_synth FromSep ([∗list] k ↦ y ∈ ?l, Φ k y) _ _
 
+/- Tests `intoSep_bigSepL_app`. -/
+/-- info:
+  solution: IntoSep ([∗list] k ↦ y ∈ l1 ++ l2, Φ k y) ([∗list] k ↦ y ∈ l1, Φ k y)
+    ([∗list] k ↦ y ∈ l2, Φ (k + l1.length) y),
+  new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+#ipm_synth IntoSep ([∗list] k ↦ y ∈ l1 ++ l2, Φ k y) _ _
+
+/-
+  Tests `intoSep_bigSepL_cons` after `intoSep_bigSepL_app` fails to apply
+  and causes backtracking.
+-/
+/-- info:
+  solution: IntoSep ([∗list] k ↦ y ∈ x :: l1, Φ k y) (Φ 0 x) ([∗list] k ↦ y ∈ l1, Φ (k + 1) y),
+  new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+#ipm_synth IntoSep ([∗list] k ↦ y ∈ x :: l1, Φ k y) _ _
+
 end ProofModeInstances

--- a/Iris/IrisTest/BigOp.lean
+++ b/Iris/IrisTest/BigOp.lean
@@ -98,4 +98,49 @@ variable {MS : Type} [LawfulFiniteMultiSet MS A] (X1 X2 : MS)
 #guard_msgs (whitespace := lax) in
 #ipm_synth IntoSep ([∗list] k ↦ y ∈ x :: l1, Φ k y) _ _
 
+/-
+  Tests `fromAnd_bigSepL_cons_persistent` after `fromAnd_bigSepL_app_persistent`
+  fails to apply and leads to backtracking.
+-/
+/-- info:
+  solution: FromAnd ([∗list] k ↦ y ∈ x :: l, Φ k y) (Φ 0 x) ([∗list] k ↦ y ∈ l, Φ (k + 1) y),
+  new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+variable [∀ k y, Persistent (Φ k y)] in
+#ipm_synth FromAnd ([∗list] k ↦ y ∈ x :: l, Φ k y) _ _
+
+/- Tests `fromAnd_bigSepL_app_persistent`. -/
+/-- info:
+  solution: FromAnd ([∗list] k ↦ y ∈ l1 ++ l2, Φ k y) ([∗list] k ↦ y ∈ l1, Φ k y)
+    ([∗list] k ↦ y ∈ l2, Φ (k + l1.length) y),
+  new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+variable [∀ k y, Persistent (Φ k y)] in
+#ipm_synth FromAnd ([∗list] k ↦ y ∈ l1 ++ l2, Φ k y) _ _
+
+/-
+  Tests `fromAnd_bigSepL2_cons_persistent` after `fromAnd_bigSepL2_app_persistent`
+  fails to apply and leads to backtracking.
+-/
+/-- info:
+  solution: FromAnd ([∗list] k ↦ y₁;y₂ ∈ x :: l;y :: k1, Ψ k y₁ y₂) (Ψ 0 x y)
+    ([∗list] k ↦ y₁;y₂ ∈ l;k1, Ψ (k + 1) y₁ y₂),
+  new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+variable [∀ k x1 x2, Persistent (Ψ k x1 x2)] in
+#ipm_synth FromAnd ([∗list] k ↦ x1;x2 ∈ x :: l; y :: k1, Ψ k x1 x2) _ _
+
+
+/- Tests `fromAnd_bigSepMS_disjUnion_persistent`. -/
+/-- info:
+  solution: FromAnd ([∗mset] y ∈ X1 ⊎ X2, Ξ y) ([∗mset] y ∈ X1, Ξ y) ([∗mset] y ∈ X2, Ξ y),
+  new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+variable [∀ y, Persistent (Ξ y)] in
+#ipm_synth FromAnd ([∗mset] z ∈ X1 ⊎ X2, Ξ z) _ _
+
 end ProofModeInstances

--- a/Iris/IrisTest/BigOp.lean
+++ b/Iris/IrisTest/BigOp.lean
@@ -6,8 +6,7 @@ Authors: Alvin Tang
 module
 
 public import Iris.BI.BigOp
-public import Iris.ProofMode.Classes
-public import Iris.ProofMode.Instances
+public import Iris.ProofMode
 
 @[expose] public section
 
@@ -16,7 +15,7 @@ open Iris BI ProofMode Std
 
 section ProofModeInstances
 
-variable {PROP : Type} [BI PROP] {A B : Type}
+variable {PROP : Type} [BI PROP] {A B : Type} (p : Bool)
 variable (Φ : Nat → A → PROP) (Ψ : Nat → A → B → PROP) (Ξ : A → PROP)
 variable (x x' : A) (y : B) (l l1 l2 : List A) (k1 k2 : List B)
 variable {MS : Type} [LawfulFiniteMultiSet MS A] (X1 X2 : MS)
@@ -142,5 +141,30 @@ variable [∀ k x1 x2, Persistent (Ψ k x1 x2)] in
 #guard_msgs (whitespace := lax) in
 variable [∀ y, Persistent (Ξ y)] in
 #ipm_synth FromAnd ([∗mset] z ∈ X1 ⊎ X2, Ξ z) _ _
+
+/- Tests `intoLaterN_bigSepL`: the later modality is stripped. -/
+/-- info:
+  solution: IntoLaterN true false 1
+    ([∗list] k ↦ x ∈ l, iprop(▷ Φ k x)) ([∗list] k ↦ x ∈ l, Φ k x),
+  new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+#ipm_synth IntoLaterN (progress := true) (only_head := false) 1
+  iprop([∗list] k ↦ x ∈ l, ▷ Φ k x) _
+
+/- Tests `intoLaterN_bigSepL` with `only_head = true`: the later modality is not stripped. -/
+/-- info: None -/
+#guard_msgs in
+#ipm_synth IntoLaterN (progress := true) (only_head := true) 1
+  iprop([∗list] k ↦ x ∈ l, ▷ Φ k x) _
+
+/- Tests `intoLaterN_bigSepL` along with `intoLaterN_later` and `intoLaterN_and_left`. -/
+/-- info:
+  solution: IntoLaterN true false 2 ([∗list] k ↦ x ∈ l, iprop(▷ (▷ Φ k x ∧ ▷ Φ k x)))
+  ([∗list] k ↦ x ∈ l, iprop(Φ k x ∧ Φ k x)),
+  new goals: []
+-/
+#guard_msgs (whitespace := lax) in
+#ipm_synth IntoLaterN true false 2 iprop([∗list] k ↦ x ∈ l, ▷ (▷ Φ k x ∧ ▷ Φ k x)) _
 
 end ProofModeInstances


### PR DESCRIPTION
## Description

Ports the remaining instances for big operators under the `ProofMode` directory and hence 100% progress for all but one module.

- Resolves #219.
- Resolves #251.
- Resolves #224.

<details>

<summary><b>Checklist for <tt>classes.v</tt></b></summary>

- [x] `IsApp`
- [x] `IsCons`
- [x] `IsDisjUnion`
- [x] `is_app_app`
- [x] `is_cons_cons`
- [x] `is_disj_union_disj_union`

</details>

<details>

<summary><b>Checklist for <tt>class_instances.v</tt></b></summary>

- [x] `from_and_big_sepL2_app_persistent`
- [x] `from_and_big_sepL2_cons_persistent`
- [x] `from_and_big_sepL_app_persistent`
- [x] `from_and_big_sepL_cons_persistent`
- [x] `from_and_big_sepMS_disj_union_persistent`
- [x] `from_pure_big_sepL`
- [x] `from_pure_big_sepM`
- [x] `from_pure_big_sepMS`
- [x] `from_pure_big_sepS`
- [x] `from_sep_big_sepL2_app`
- [x] `from_sep_big_sepL2_cons`
- [x] `from_sep_big_sepL_app`
- [x] `from_sep_big_sepL_cons`
- [x] `from_sep_big_sepMS_disj_union`
- [x] `into_pure_big_sepL`
- [x] `into_pure_big_sepM`
- [x] `into_pure_big_sepMS`
- [x] `into_pure_big_sepS`
- [x] `into_sep_big_sepL2_cons`
- [x] `into_sep_big_sepL_app`
- [x] `into_sep_big_sepL_cons`
- [x] `into_sep_big_sepMS_disj_union`

</details>

<details>

<summary><b>Checklist for <tt>class_instances_frame.v</tt></b></summary>

- [x] `frame_big_sepL2_app`
- [x] `frame_big_sepL2_cons`
- [x] `frame_big_sepL_app`
- [x] `frame_big_sepL_cons`
- [x] `frame_big_sepMS_disj_union`

</details>

<details>

<summary><b>Checklist for <tt>class_instances_later.v</tt></b></summary>

- [x] `into_laterN_big_sepL`
- [x] `into_laterN_big_sepL2`
- [x] `into_laterN_big_sepM`
- [x] `into_laterN_big_sepM2`: this depends on #582.
- [x] `into_laterN_big_sepMS`
- [x] `into_laterN_big_sepS`

</details>

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files
