### PR TITLE
feat: `wp_apply` and `wp_smart_apply`

### DIFF
--- a/Iris/Iris/HeapLang/Lib/Array.lean
+++ b/Iris/Iris/HeapLang/Lib/Array.lean
@@ -124,10 +124,8 @@ theorem wp_array_clone (s : Stuckness) (E : CoPset) (l : Loc) (dq : DFrac) (vl :
   wp_lam
   wp_alloc dst with Hdst
   wp_pures
-  wp_bind &arrayCopyTo _ _ _
-  iapply wp_array_copy_to s E dst l (List.replicate n.toNat hl_val(#())) vl dq n
-    (by simp only [List.length_replicate]; omega) hvl $$ [$Hdst $Hvl]
-  iintro !> ⟨Hdst, Hl⟩
+  wp_apply wp_array_copy_to s E dst l (List.replicate n.toNat hl_val(#())) vl dq n
+    (by simp only [List.length_replicate]; omega) hvl $$ [$Hdst $Hvl] with ⟨Hdst, Hl⟩
   wp_pures
   iapply HΦ $$ [$]
 
@@ -164,9 +162,7 @@ theorem wp_array_init_loop (s : Stuckness) (E : CoPset) (l : Loc) (i k : Nat) (n
     ieval (simp only [List.range'_succ]) at Hf
     icases array_cons.1 $$ Hl with ⟨Hl, HSl⟩
     icases BigSepL.bigSepL_cons.1 $$ Hf with ⟨Hf, HSf⟩
-    wp_bind &f _
-    iapply wp_wand $$ Hf
-    iintro %v Hv
+    wp_apply wp_wand $$ Hf with %v Hv
     wp_store
     wp_pures
     rw [show (i : Int) + 1 = ((i + 1 : Nat) : Int) by omega]
@@ -195,11 +191,10 @@ theorem wp_array_init (s : Stuckness) (E : CoPset) (n : Int) (f : Val) (hn : 0 <
   wp_lam
   wp_alloc src with Hl
   wp_pures
-  wp_bind &arrayInitLoop _ _ _ _
-  iapply wp_array_init_loop Q s E src 0 n.toNat n f (by simp; omega) $$ [Hl Hf]
+  wp_apply wp_array_init_loop Q s E src 0 n.toNat n f (by simp; omega) $$ [Hl Hf]
   · rw [loc_add_nat_zero, List.range_eq_range']
     iframe
-  · iintro !> %vs ⟨%hlen, Hl, Hvs⟩
+  · iintro %vs ⟨%hlen, Hl, Hvs⟩
     wp_pures
     imodintro
     iapply HΦ $$ %src %vs

--- a/Iris/Iris/HeapLang/Lib/Assert.lean
+++ b/Iris/Iris/HeapLang/Lib/Assert.lean
@@ -23,16 +23,14 @@ section Spec
 
 variable {GF : BundledGFunctors} [HeapLangGS hlc GF]
 
--- TODO: use wp_smart_apply
 @[rocq_alias heap_lang.wp_assert]
 theorem wp_assert (E : CoPset) (Φ : Val → IProp GF) (e : Exp) :
     WP e @ E {{ v, ⌜v = hl_val(#true)⌝ ∧ ▷ Φ hl_val(#()) }} -∗
     WP hl(assert(&e)) @ E {{ Φ }} := by
   iintro HΦ
   unfold Exp.assert
-  wp_bind &e
-  iapply wp_wand $$ HΦ
-  iintro %v ⟨%Heq, _⟩ ; subst Heq
+  wp_apply wp_wand $$ HΦ with %v ⟨%Heq, _⟩
+  subst Heq
   wp_if; itrivial
 
 end Spec

--- a/Iris/Iris/HeapLang/Lib/Assert.lean
+++ b/Iris/Iris/HeapLang/Lib/Assert.lean
@@ -29,8 +29,7 @@ theorem wp_assert (E : CoPset) (Φ : Val → IProp GF) (e : Exp) :
     WP hl(assert(&e)) @ E {{ Φ }} := by
   iintro HΦ
   unfold Exp.assert
-  wp_apply wp_wand $$ HΦ with %v ⟨%Heq, _⟩
-  subst Heq
+  wp_apply wp_wand $$ HΦ with %v ⟨%rfl, _⟩
   wp_if; itrivial
 
 end Spec

--- a/Iris/Iris/HeapLang/Lib/ClairvoyantCoin.lean
+++ b/Iris/Iris/HeapLang/Lib/ClairvoyantCoin.lean
@@ -53,12 +53,8 @@ theorem newCoin.spec :
   iunfold coin
   iintro %Φ - K
   wp_lam
-  wp_bind newProph()
-  iapply wp_new_proph $$ [//]
-  iintro %pvs %p !> proph
-  wp_bind &nondetBool _
-  iapply nondetBool.spec $$ [//]
-  iintro !> %b -
+  wp_apply wp_new_proph $$ [//] with %pvs %p proph
+  wp_apply nondetBool.spec $$ [//] with %b -
   wp_alloc c with Hc
   wp_pair
   iintro !>
@@ -94,13 +90,9 @@ theorem tossCoin.spec (cp : Val) (bs : List Bool) :
   isimp at Hb
   wp_lam
   wp_pures
-  wp_bind &nondetBool _
-  iapply nondetBool.spec $$ [//]
-  iintro !> %r -
+  wp_apply nondetBool.spec $$ [//] with %r -
   wp_store
-  wp_bind resolveProph(_, _)
-  iapply wp_resolve_proph $$ Hp
-  iintro !> %pvs' ⟨%rfl, Hp⟩
+  wp_apply wp_resolve_proph $$ Hp with %pvs' ⟨%rfl, Hp⟩
   simp only [List.tail_cons, prophecyToListBool_cons] at htl
   wp_seq
   iintro !>

--- a/Iris/Iris/HeapLang/Lib/LazyCoin.lean
+++ b/Iris/Iris/HeapLang/Lib/LazyCoin.lean
@@ -59,10 +59,9 @@ theorem newCoin.spec :
   iintro %Φ - K
   unfold newCoin
   wp_pures
-  wp_bind newProph()
-  iapply wp_new_proph
+  wp_apply wp_new_proph
   · itrivial
-  iintro !> %pvs %p Hp
+  iintro %pvs %p Hp
   wp_alloc l with Hl
   wp_pures
   iintro !>
@@ -94,10 +93,9 @@ theorem readCoin.spec (cp : Val) (b : Bool) :
     iframe; ipureintro; rfl
   · wp_load
     wp_pures
-    wp_bind &nondetBool _; iapply nondetBool.spec $$ [//]; iintro !> %b -
+    wp_apply nondetBool.spec $$ [//] with %b -
     wp_store
-    wp_bind resolveProph(_, _); iapply wp_resolve_proph $$ proph
-    iintro !> %pvs' ⟨%pvs_eq, proph⟩
+    wp_apply wp_resolve_proph $$ proph with %pvs' ⟨%pvs_eq, proph⟩
     subst pvs_eq
     wp_pures
     iintro !>

--- a/Iris/Iris/HeapLang/Lib/NondetBool.lean
+++ b/Iris/Iris/HeapLang/Lib/NondetBool.lean
@@ -28,13 +28,11 @@ theorem nondetBool.spec :
   wp_pures
   imod inv_alloc `rnd ⊤ iprop(∃ (b : Bool), l ↦ hl_val(#b)) $$ [$Hl] with #Hinv
   wp_apply wp_fork $$ [K] []
-  · inext
-    wp_pures
+  · wp_pures
     iinv Hinv with >⟨%b, Hl⟩
     wp_load
     iintro !> {$Hl}
     iapply K $$ [//]
-  · inext
-    iinv Hinv with >⟨%b, Hl⟩
+  · iinv Hinv with >⟨%b, Hl⟩
     wp_store
     iframe

--- a/Iris/Iris/HeapLang/Lib/NondetBool.lean
+++ b/Iris/Iris/HeapLang/Lib/NondetBool.lean
@@ -27,8 +27,7 @@ theorem nondetBool.spec :
   wp_alloc l with Hl
   wp_pures
   imod inv_alloc `rnd ⊤ iprop(∃ (b : Bool), l ↦ hl_val(#b)) $$ [$Hl] with #Hinv
-  wp_bind fork(_)
-  iapply wp_fork $$ [K] []
+  wp_apply wp_fork $$ [K] []
   · inext
     wp_pures
     iinv Hinv with >⟨%b, Hl⟩

--- a/Iris/Iris/HeapLang/Lib/Par.lean
+++ b/Iris/Iris/HeapLang/Lib/Par.lean
@@ -48,17 +48,11 @@ theorem par_spec (Ψ1 Ψ2 : Val → IProp GF) (f1 f2 : Val) (Φ : Val → IProp 
   iintro Hf1 Hf2 HΦ
   unfold par
   wp_pures
-  wp_bind &spawn _
-  iapply spawn_spec parN $$ Hf1
-  iintro %l Hl
+  wp_apply spawn_spec parN $$ Hf1 with %l Hl
   wp_pures
-  wp_bind &f2 _
-  iapply wp_wand $$ Hf2
-  iintro %v H2
+  wp_apply wp_wand $$ Hf2 with %v H2
   wp_pures
-  wp_bind &join _
-  iapply join_spec $$ Hl
-  iintro %w H1
+  wp_apply join_spec $$ Hl with %w H1
   ispecialize HΦ $$ [$H1 $H2]
   wp_pures
   iexact HΦ

--- a/Iris/Iris/HeapLang/Lib/Par.lean
+++ b/Iris/Iris/HeapLang/Lib/Par.lean
@@ -47,12 +47,10 @@ theorem par_spec (Ψ1 Ψ2 : Val → IProp GF) (f1 f2 : Val) (Φ : Val → IProp 
       WP hl(&par &f1 &f2) {{ Φ }} := by
   iintro Hf1 Hf2 HΦ
   unfold par
-  wp_pures
-  wp_apply spawn_spec parN $$ Hf1 with %l Hl
+  wp_smart_apply spawn_spec parN $$ Hf1 with %l Hl
   wp_pures
   wp_apply wp_wand $$ Hf2 with %v H2
-  wp_pures
-  wp_apply join_spec $$ Hl with %w H1
+  wp_smart_apply join_spec $$ Hl with %w H1
   ispecialize HΦ $$ [$H1 $H2]
   wp_pures
   iexact HΦ

--- a/Iris/Iris/HeapLang/Lib/Quicksort.lean
+++ b/Iris/Iris/HeapLang/Lib/Quicksort.lean
@@ -159,18 +159,14 @@ theorem partition_spec x l ls Φ :
       isList l2 (ls.filter (x < ·)) -∗
       Φ hl_val((&l1, &l2))) -∗
     WP hl(&partition #x &l) {{ Φ }} := by
-  iintro Hl HΦ
   iloeb as IH generalizing %l %ls %Φ
-  wp_rec; wp_pures
-  rw [isList.eq_def]
-  cases ls with
+  iintro Hl HΦ; wp_rec; rw [isList.eq_def]
+  cases ls with dsimp only
   | nil =>
-    simp only
-    icases Hl with %hl; subst hl
-    wp_pures; imodintro; simp
+    icases Hl with %rfl
+    wp_pures; imodintro
     iapply HΦ <;> simp [isList] <;> itrivial
   | cons hd ls =>
-    simp only
     icases Hl with ⟨%_, %tl, %rfl, Hpt, Hl⟩
     wp_load
     wp_smart_apply IH $$ Hl with %l1 %l2 Hl1 Hl2
@@ -188,40 +184,31 @@ theorem partition_spec x l ls Φ :
       simp [*]
       iframe
 
-theorem quicksort_spec l ls Φ :
-    isList (GF:=GF) l ls -∗
-    (∀ l' ls',
-      isList l' ls' -∗
-      ⌜List.Pairwise LE.le ls'⌝ -∗
-      ⌜List.Perm ls ls'⌝ -∗
-      Φ l') -∗
-    WP hl(&quicksort &l) {{ Φ }} := by
-  iintro Hl HΦ
-  iloeb as IH generalizing %l %ls %Φ
-  wp_rec
-  rw [isList.eq_def]
+theorem quicksort_spec l ls :
+    {{isList (GF:=GF) l ls}}
+      hl(&quicksort &l)
+    {{ l' ls', RET l'; isList l' ls' ∗
+      ⌜Pairwise LE.le ls'⌝ ∗
+      ⌜ls ~ ls'⌝}} := by
+  iloeb as IH generalizing %l %ls
+  iintro %Φ Hl HΦ; wp_rec; rw [isList.eq_def]
   cases ls with dsimp only
   | nil =>
-    iclear IH
     icases Hl with %rfl
-    wp_pures
-    imodintro
-    iapply HΦ $$ %_ %([]) [] [//] [//]
-    unfold isList; itrivial
+    wp_pures; imodintro
+    iapply HΦ $$ %_ %([]) <;> simp [isList] <;> itrivial
   | cons head tail =>
-    icases Hl with ⟨%l, %tl, %heq, Hpt, Hl⟩; subst heq
+    icases Hl with ⟨%l, %tl, %rfl, Hpt, Hl⟩
     wp_load
     wp_smart_apply partition_spec $$ [$] with %l1 %l2 Hl1 Hl2
-    wp_smart_apply IH $$ [$] with %l1' %ls1' Hl1 %_ %_
-    wp_smart_apply IH $$ [$] with %l2' %ls2' Hl2 %_ %_
+    wp_smart_apply IH $$ [$] with %l1' %ls1' ⟨Hl1, %_, %_⟩
+    wp_smart_apply IH $$ [$] with %l2' %ls2' ⟨Hl2, %_, %_⟩
     wp_smart_apply cons_spec $$ Hl2 with %_ _
     wp_smart_apply append_spec $$ [$] [$] with %_ _
-    iapply HΦ $$ [$]
-    · ipureintro
-      have : ls2'.all (head < ·) := by grind
+    iapply HΦ; iframe; isplit <;> ipureintro
+    · have : ls2'.all (head < ·) := by grind
       grind [pairwise_cons]
-    · ipureintro
-      grind [filter_append_perm]
+    · grind [filter_append_perm]
 
 -- example (l l1 l2 : List Int) x :
 --   Perm (l.filter (· ≤ x)) l1 →
@@ -242,7 +229,7 @@ theorem quicksort_spec l ls Φ :
 --     have : l2.all (x < ·) := by grind [Perm.mem_iff]
 --     grind [pairwise_cons]
 
-theorem wp_makeList (l : List Int) (Φ : Val → IProp GF) :
+theorem makeList_spec (l : List Int) (Φ : Val → IProp GF) :
     (∀ v, isList v l -∗ Φ v) -∗
     WP hl(&(makeList l)) {{ Φ }} := by
   iintro HΦ
@@ -260,7 +247,7 @@ theorem wp_makeList (l : List Int) (Φ : Val → IProp GF) :
 /- When a HeapLang list is sorted, checkSorted returns true -/
 theorem wp_checkSorted (v vacc : Val) (l : List Int) (Φ : Val → IProp GF) :
     isList (GF := GF) v l -∗
-    ⌜List.Pairwise (· ≤ ·) l⌝ -∗
+    ⌜Pairwise (· ≤ ·) l⌝ -∗
     ⌜vacc = hl_val(none()) ∨ ∃ va : Int, vacc = hl_val(some(#va)) ∧ ∀ lv ∈ l, va ≤ lv⌝ -∗
     (∀ bv, isList v l -∗ ⌜bv = hl_val(#true)⌝ -∗ Φ bv) -∗
     WP hl(&checkSorted &vacc &v) {{ Φ }} := by
@@ -312,22 +299,26 @@ def sortAndCheck (l : List Int) : Exp := hl%
   let v' := &quicksort v;
   &checkSorted (none()) v'
 
-theorem wp_sortAndCheck [HeapLangGS hlc GF] (l : List Int) :
-    ⊢@{IProp GF} WP (sortAndCheck l) {{ fun bv => iprop% ⌜bv = hl_val(#true)⌝}} := by
+theorem sortAndCheck_spec [HeapLangGS hlc GF] (l : List Int) :
+    {{ (True : IProp GF) }} (sortAndCheck l) {{ RET hl_val(#true); True}} := by
   unfold sortAndCheck
-  wp_apply wp_makeList with %v Hv
+  iintro %Φ - HΦ
+  wp_bind &(makeList _)
+  iapply makeList_spec
+  iintro %v Hv
   wp_pures
-  wp_apply quicksort_spec $$ Hv with %v %l' Hv %Hsorted %Heqv
+  wp_bind &quicksort _
+  iapply quicksort_spec $$ Hv
+  iintro !> %v %l' ⟨Hv, %Hsorted, %Heqv⟩
   wp_pures
   iapply wp_checkSorted $$ Hv %Hsorted %(Or.inl rfl)
-  iintro %bv Hv' %hbv
-  itrivial
+  iintro %bv Hv' %rfl
+  iapply HΦ $$ [//]
 
 /-- Full application of adequacy: sortAndCheck is safe in any state and only ever return true. -/
 theorem sortAndCheckAdequate (l : List Int) (σ : State) :
     adequate .NotStuck (sortAndCheck l) σ (fun v _ => v = hl_val(#true)) := by
-  apply heap_adequacy (GF := HeapLangS)
-  intro _
-  apply wp_sortAndCheck
+  apply heap_adequacy (GF := HeapLangS); intro _
+  iapply sortAndCheck_spec <;> itrivial
 
 end Closed

--- a/Iris/Iris/HeapLang/Lib/Quicksort.lean
+++ b/Iris/Iris/HeapLang/Lib/Quicksort.lean
@@ -146,11 +146,8 @@ theorem append_spec l1 ls1 l2 ls2 Φ :
     icases isList_cons $$ Hl1 with ⟨%l, %tl, %heq, Hpt, Hl⟩
     subst heq; wp_pures
     wp_load
-    wp_pures
-    wp_apply IH $$ Hl Hl2 with %_ Hl
-    wp_pures
-    iapply cons_spec $$ [$]
-    iintro %_ _
+    wp_smart_apply IH $$ Hl Hl2 with %_ Hl
+    wp_smart_apply cons_spec $$ [$] with %_ _
     iapply HΦ
     simp
     itrivial
@@ -174,20 +171,16 @@ theorem partition_spec x l ls Φ :
     iapply HΦ <;> simp [isList] <;> itrivial
   | cons hd ls =>
     simp only
-    icases Hl with ⟨%_, %tl, %hl, Hpt, Hl⟩; subst hl
-    wp_pures
+    icases Hl with ⟨%_, %tl, %rfl, Hpt, Hl⟩
     wp_load
-    wp_pures
-    wp_apply IH $$ Hl with %l1 %l2 Hl1 Hl2
+    wp_smart_apply IH $$ Hl with %l1 %l2 Hl1 Hl2
     wp_pures
     by_cases hd ≤ x <;> simp [*]
-    · wp_pures
-      wp_apply cons_spec $$ Hl1 with %_ _
+    · wp_smart_apply cons_spec $$ Hl1 with %_ _
       wp_pures
       imodintro
       iapply HΦ $$ [$] [$]
-    · wp_pures
-      wp_apply cons_spec $$ Hl2 with %_ _
+    · wp_smart_apply cons_spec $$ Hl2 with %_ _
       wp_pures
       imodintro
       iapply HΦ $$ Hl1
@@ -218,17 +211,11 @@ theorem quicksort_spec l ls Φ :
   | cons head tail =>
     icases Hl with ⟨%l, %tl, %heq, Hpt, Hl⟩; subst heq
     wp_load
-    wp_pures
-    wp_apply partition_spec $$ [$] with %l1 %l2 Hl1 Hl2
-    wp_pures
-    wp_apply IH $$ [$] with %l1' %ls1' Hl1 %_ %_
-    wp_pures
-    wp_apply IH $$ [$] with %l2' %ls2' Hl2 %_ %_
-    wp_pures
-    wp_apply cons_spec $$ Hl2 with %_ _
-    wp_pures
-    iapply append_spec $$ [$] [$]
-    iintro %_ _
+    wp_smart_apply partition_spec $$ [$] with %l1 %l2 Hl1 Hl2
+    wp_smart_apply IH $$ [$] with %l1' %ls1' Hl1 %_ %_
+    wp_smart_apply IH $$ [$] with %l2' %ls2' Hl2 %_ %_
+    wp_smart_apply cons_spec $$ Hl2 with %_ _
+    wp_smart_apply append_spec $$ [$] [$] with %_ _
     iapply HΦ $$ [$]
     · ipureintro
       have : ls2'.all (head < ·) := by grind
@@ -294,9 +281,8 @@ theorem wp_checkSorted (v vacc : Val) (l : List Int) (Φ : Val → IProp GF) :
     wp_load
     rcases hinv with rfl | ⟨va, rfl, hva⟩
     · wp_pures
-      iapply IH $$ %_ %tl %_ %((List.pairwise_cons.mp hsorted).2)
-        %(Or.inr ⟨hd, rfl, fun lv h => (List.pairwise_cons.mp hsorted).1 lv h⟩) Htl
-      iintro %bv Hl %hb
+      wp_apply IH $$ %_ %tl %_ %((List.pairwise_cons.mp hsorted).2)
+        %(Or.inr ⟨hd, rfl, fun lv h => (List.pairwise_cons.mp hsorted).1 lv h⟩) Htl with %bv Hl %hb
       iapply HΦ $$ [Hpt Hl]
       · rw [isList]
         iexists loc, tlv

--- a/Iris/Iris/HeapLang/Lib/Quicksort.lean
+++ b/Iris/Iris/HeapLang/Lib/Quicksort.lean
@@ -147,9 +147,7 @@ theorem append_spec l1 ls1 l2 ls2 Φ :
     subst heq; wp_pures
     wp_load
     wp_pures
-    wp_bind &append _ _
-    iapply IH $$ Hl Hl2
-    iintro %_ Hl
+    wp_apply IH $$ Hl Hl2 with %_ Hl
     wp_pures
     iapply cons_spec $$ [$]
     iintro %_ _
@@ -180,22 +178,16 @@ theorem partition_spec x l ls Φ :
     wp_pures
     wp_load
     wp_pures
-    wp_bind &partition _ _
-    iapply IH $$ Hl
-    iintro %l1 %l2 Hl1 Hl2
+    wp_apply IH $$ Hl with %l1 %l2 Hl1 Hl2
     wp_pures
     by_cases hd ≤ x <;> simp [*]
     · wp_pures
-      wp_bind &cons _ _
-      iapply cons_spec $$ Hl1
-      iintro %_ _
+      wp_apply cons_spec $$ Hl1 with %_ _
       wp_pures
       imodintro
       iapply HΦ $$ [$] [$]
     · wp_pures
-      wp_bind &cons _ _
-      iapply cons_spec $$ Hl2
-      iintro %_ _
+      wp_apply cons_spec $$ Hl2 with %_ _
       wp_pures
       imodintro
       iapply HΦ $$ Hl1
@@ -227,21 +219,13 @@ theorem quicksort_spec l ls Φ :
     icases Hl with ⟨%l, %tl, %heq, Hpt, Hl⟩; subst heq
     wp_load
     wp_pures
-    wp_bind &partition _ _
-    iapply partition_spec $$ [$]
-    iintro %l1 %l2 Hl1 Hl2
+    wp_apply partition_spec $$ [$] with %l1 %l2 Hl1 Hl2
     wp_pures
-    wp_bind &quicksort _
-    iapply IH $$ [$]
-    iintro %l1' %ls1' Hl1 %_ %_
+    wp_apply IH $$ [$] with %l1' %ls1' Hl1 %_ %_
     wp_pures
-    wp_bind &quicksort _
-    iapply IH $$ [$]
-    iintro %l2' %ls2' Hl2 %_ %_
+    wp_apply IH $$ [$] with %l2' %ls2' Hl2 %_ %_
     wp_pures
-    wp_bind &cons _ _
-    iapply cons_spec $$ Hl2
-    iintro %_ _
+    wp_apply cons_spec $$ Hl2 with %_ _
     wp_pures
     iapply append_spec $$ [$] [$]
     iintro %_ _
@@ -282,9 +266,7 @@ theorem wp_makeList (l : List Int) (Φ : Val → IProp GF) :
   | cons l ls ih =>
     rw [makeList]
     wp_pures
-    wp_bind &(makeList _)
-    iapply ih
-    iintro %v Hv
+    wp_apply ih with %v Hv
     wp_pures
     iapply cons_spec $$ Hv HΦ
 
@@ -347,13 +329,9 @@ def sortAndCheck (l : List Int) : Exp := hl%
 theorem wp_sortAndCheck [HeapLangGS hlc GF] (l : List Int) :
     ⊢@{IProp GF} WP (sortAndCheck l) {{ fun bv => iprop% ⌜bv = hl_val(#true)⌝}} := by
   unfold sortAndCheck
-  wp_bind &(makeList _)
-  iapply wp_makeList
-  iintro %v Hv
+  wp_apply wp_makeList with %v Hv
   wp_pures
-  wp_bind &quicksort _
-  iapply quicksort_spec $$ Hv
-  iintro %v %l' Hv %Hsorted %Heqv
+  wp_apply quicksort_spec $$ Hv with %v %l' Hv %Hsorted %Heqv
   wp_pures
   iapply wp_checkSorted $$ Hv %Hsorted %(Or.inl rfl)
   iintro %bv Hv' %hbv

--- a/Iris/Iris/HeapLang/Lib/RwSpinLock.lean
+++ b/Iris/Iris/HeapLang/Lib/RwSpinLock.lean
@@ -277,9 +277,7 @@ theorem acquireReader_spec (γ : GName) (lk : Val) (Φ : Qp → IProp GF) :
   iintro %φ #Hislock Hφ
   iloeb as IH
   wp_rec
-  wp_bind &tryAcquireReader _
-  iapply tryAcquireReader_spec $$ Hislock
-  iintro !> %b Hb
+  wp_apply tryAcquireReader_spec $$ Hislock with %b Hb
   cases b
   · wp_if_false
     iapply IH
@@ -371,9 +369,7 @@ theorem acquireWriter_spec (γ : GName) (lk : Val) (Φ : Qp → IProp GF) :
   iintro %φ #Hislock Hφ
   iloeb as IH
   wp_rec
-  wp_bind &tryAcquireWriter _
-  iapply tryAcquireWriter_spec $$ Hislock
-  iintro !> %b Hb
+  wp_apply tryAcquireWriter_spec $$ Hislock with %b Hb
   cases b
   · wp_if_false; iapply IH; itrivial
   · wp_if_true; iapply Hφ;

--- a/Iris/Iris/HeapLang/Lib/Spawn.lean
+++ b/Iris/Iris/HeapLang/Lib/Spawn.lean
@@ -95,8 +95,7 @@ theorem spawn_spec (Ψ : Val → IProp GF) (f : Val) :
     ileft; itrivial
   imodintro
   wp_pures
-  wp_bind fork(_)
-  iapply wp_fork $$ [- Hf] [Hf]
+  wp_apply wp_fork $$ [- Hf] [Hf]
   · inext
     wp_pures
     imodintro
@@ -105,9 +104,7 @@ theorem spawn_spec (Ψ : Val → IProp GF) (f : Val) :
     iexists γ
     iframe Hγ Hinv
   inext
-  wp_bind &f _
-  iapply wp_wand $$ Hf
-  iintro %v HΨ
+  wp_apply wp_wand $$ Hf with %v HΨ
   wp_pures
   iinv Hinv with Hpt
   unfold spawnInv

--- a/Iris/Iris/HeapLang/Lib/Spawn.lean
+++ b/Iris/Iris/HeapLang/Lib/Spawn.lean
@@ -96,14 +96,12 @@ theorem spawn_spec (Ψ : Val → IProp GF) (f : Val) :
   imodintro
   wp_pures
   wp_apply wp_fork $$ [- Hf] [Hf]
-  · inext
-    wp_pures
+  · wp_pures
     imodintro
     iapply HΦ $$ %l
     unfold joinHandle
     iexists γ
     iframe Hγ Hinv
-  inext
   wp_apply wp_wand $$ Hf with %v HΨ
   wp_pures
   iinv Hinv with Hpt

--- a/Iris/Iris/HeapLang/Lib/SpinLock.lean
+++ b/Iris/Iris/HeapLang/Lib/SpinLock.lean
@@ -156,9 +156,7 @@ theorem acquire_spec (γ : GName) (lk : Val) (R : IProp GF) :
   iintro %Φ #Hlock Hcont
   iloeb as IH
   wp_rec
-  wp_bind &tryAcquire _
-  iapply try_acquire_spec $$ Hlock
-  iintro !> %b Hpt
+  wp_apply try_acquire_spec $$ Hlock with %b Hpt
   cases b
   · wp_pure
     iapply IH

--- a/Iris/Iris/HeapLang/ProofMode.lean
+++ b/Iris/Iris/HeapLang/ProofMode.lean
@@ -469,57 +469,81 @@ meta def iWpApplyCore {u} {GF : Q(BundledGFunctors.{0, 0, 0})} {hlc : Q(HasLC)}
     {prop : Q(Type u)} {bi : Q(BI $prop)} {ehyps : Q($prop)}
     (hyps : Hyps bi ehyps) (ι : Q(IrisGS_gen $hlc Exp $GF)) (s : Q(Stuckness)) (E : Q(CoPset))
     (e : Q(Exp)) (Φ : Q(Val → $prop)) (pmt : PMTerm)
-    (premisesOut : IO.Ref (Array MVarId × Array MVarId))
     (_hu : QuotedLevelDefEq u 0 := ⟨⟩) (_hprop : $prop =Q IProp $GF := ⟨⟩)
     (_hbi : $bi =Q UPred.instBIUPred := ⟨⟩)
     (κ : Q(Wp $prop Exp Val Stuckness) := q(wp.def)) (_hwp : $κ =Q wp.def := ⟨⟩) :
     ProofModeM Q($ehyps ⊢ Wp.wp $s $E $e $Φ) := do
-  let beforePose := (← get).goals.size
   let ⟨eΔ, hyps', p, A, posePf⟩ ← iHave hyps q(Wp.wp $s $E $e $Φ) pmt true
-  let afterPose := (← get).goals.size
   let some {result := pf, ..} ←
     findECtx (α := Q($eΔ ∗ □?$p $A ⊢ Wp.wp $s $E $e $Φ)) e fun K e' => do
       trace[wp_apply] m!"trying to apply {A} to {e'}"
       iWpBindCore _ ι s E e Φ K e' (iApply hyps' p A ·)
   | throwIPMError "cannot apply {A}"
-  premisesOut.set ((← get).goals.extract afterPose, (← get).goals.extract beforePose afterPose)
   return q($posePf $pf)
 
-/-- Strip a leading `▷` and simplify WP expressions, in the application's goals only -/
-meta def wpApplyPostPass (premises : Array MVarId) : TacticM (Array MVarId) := do
-  let post ← `(tactic| (try inext; try wp_expr_simp))
-  let mut out : Array MVarId := #[]
-  let mut produced : Array MVarId := #[]
-  for g in (← getGoals) do
-    if premises.contains g && !(← g.isAssigned) then
-      let new := (← Tactic.run g (evalTactic post)).toArray
-      out := out ++ new
-      produced := produced ++ new
+-- /-- Strip a leading `▷` and simplify WP expressions, in the application's goals only -/
+-- meta def wpApplyPostPass (premises : Array MVarId) : TacticM (Array MVarId) := do
+--   let post ← `(tactic| (try inext; try wp_expr_simp))
+--   let mut out : Array MVarId := #[]
+--   let mut produced : Array MVarId := #[]
+--   for g in (← getGoals) do
+--     if premises.contains g && !(← g.isAssigned) then
+--       let new := (← Tactic.run g (evalTactic post)).toArray
+--       out := out ++ new
+--       produced := produced ++ new
+--     else
+--       out := out.push g
+--   setGoals out.toList
+--   return produced
+
+-- /-- Apply and post-pass, return the application's goals. Dependee mvars (a lemma's `?Φ`)
+-- are registered before the snapshot, so they stay out of `premises` despite sorting last. -/
+-- meta def runWpApply (tacName : Name) (pmt : PMTerm) :
+--     TacticM (Array MVarId × Array MVarId) := do
+--   let premises ← IO.mkRef ((#[], #[]) : Array MVarId × Array MVarId)
+--   ProofModeM.runTacticWp tacName fun mvar {hyps, ι, s, E, e, Φ, ..} => do
+--     mvar.assign (← iWpApplyCore hyps ι s E e Φ pmt premises)
+--   let (application, specialisation) ← premises.get
+--   return (← wpApplyPostPass application, specialisation)
+
+-- /-- Needed for `wp_apply ... with`. Introduce into the last goal the application produced,
+-- or a `$$` goal if it produced none. -/
+-- meta def wpApplyIntro (tacName : Name) (produced specialisation : Array MVarId)
+--     (pats : Array (TSyntax `introPat)) : TacticM Unit := do
+--   if pats.isEmpty then return
+--   let fallback ← specialisation.filterM fun g => return !(← g.isAssigned)
+--   let some last := produced.back? <|> fallback.back?
+--     | throwError "{tacName}: no goal left for the `with` patterns"
+--   let new ← Tactic.run last (evalTactic (← `(tactic| iintro $pats*)))
+--   setGoals <| (← getGoals).flatMap fun g => if g == last then new else [g]
+
+elab "wp_apply_raw" colGt pmt:pmTerm : tactic => do
+  let pmt ← liftMacroM <| PMTerm.parse pmt
+  ProofModeM.runTacticWp `wp_apply fun mvar {hyps, ι, s, E, e, Φ, ..} => do
+     mvar.assign (← iWpApplyCore hyps ι s E e Φ pmt)
+
+-- TODO: Is there a more efficient way to implement this?
+-- TODO: move this somewhere else
+elab "focusLastIrisGoal" colGt tac:tactic : tactic => do
+  let goals ← getUnsolvedGoals
+  let mut goals_before := []
+  let mut iris_goal := []
+  let mut goals_after := []
+  for g in goals do
+    if isIrisGoal (← g.getType) then
+      goals_before := goals_before ++ iris_goal ++ goals_after
+      iris_goal := [g]
+      goals_after := []
     else
-      out := out.push g
-  setGoals out.toList
-  return produced
+      goals_after := goals_after ++ [g]
+  let [g] := iris_goal
+    | throwError "no remaining Iris goal"
+  setGoals [g]
+  evalTactic tac
+  let goals' ← getUnsolvedGoals
+  setGoals (goals_before ++ goals' ++ goals_after)
 
-/-- Apply and post-pass, return the application's goals. Dependee mvars (a lemma's `?Φ`)
-are registered before the snapshot, so they stay out of `premises` despite sorting last. -/
-meta def runWpApply (tacName : Name) (pmt : PMTerm) :
-    TacticM (Array MVarId × Array MVarId) := do
-  let premises ← IO.mkRef ((#[], #[]) : Array MVarId × Array MVarId)
-  ProofModeM.runTacticWp tacName fun mvar {hyps, ι, s, E, e, Φ, ..} => do
-    mvar.assign (← iWpApplyCore hyps ι s E e Φ pmt premises)
-  let (application, specialisation) ← premises.get
-  return (← wpApplyPostPass application, specialisation)
 
-/-- Needed for `wp_apply ... with`. Introduce into the last goal the application produced,
-or a `$$` goal if it produced none. -/
-meta def wpApplyIntro (tacName : Name) (produced specialisation : Array MVarId)
-    (pats : Array (TSyntax `introPat)) : TacticM Unit := do
-  if pats.isEmpty then return
-  let fallback ← specialisation.filterM fun g => return !(← g.isAssigned)
-  let some last := produced.back? <|> fallback.back?
-    | throwError "{tacName}: no goal left for the `with` patterns"
-  let new ← Tactic.run last (evalTactic (← `(tactic| iintro $pats*)))
-  setGoals <| (← getGoals).flatMap fun g => if g == last then new else [g]
 
 /--
 `wp_apply lem` poses the lemma `lem`, whose conclusion must be a `WP e' ...`, and applies
@@ -532,30 +556,33 @@ specialises the premises of `lem` with the given specialisation patterns, and
 syntax (name := wpApply) "wp_apply " colGt pmTerm
   (" with" (colGt ppSpace introPat)+)? : tactic
 
-elab_rules : tactic
+macro_rules
   | `(tactic| wp_apply $pmt:pmTerm $[with $pats*]?) => do
-    let (produced, spec) ← runWpApply `wp_apply (← liftMacroM <| PMTerm.parse pmt)
-    wpApplyIntro `wp_apply produced spec (pats.getD #[])
+    let t : TSyntax `tactic ←
+      if let some pats := pats then
+        `(tactic|focusLastIrisGoal (iintro $pats*))
+      else
+        `(tactic|skip)
+    `(tactic| focus ((wp_apply_raw $pmt <;> (try inext) <;> (try wp_expr_simp)); $t:tactic))
 
 /-- bound on `wp_smart_apply`'s pure steps. -/
 meta def smartApplyFuel : Nat := 10000
 
 /-- Retry the application after single pure steps, bounded. `with` runs after the loop:
 retrying a failed introduction would roll back an application that already succeeded. -/
-meta def runWpSmartApply (pmt : PMTerm) (pats : Array (TSyntax `introPat)) :
+meta def runWpSmartApply (pmt : TSyntax `pmTerm) (_pats : Array (TSyntax `introPat)) :
     TacticM Unit := do
   let mut firstErr : Option Exception := none
   for _ in [0:smartApplyFuel] do
     let s ← Tactic.saveState
     let attempt ←
       try
-        pure <| Sum.inl (← runWpApply `wp_smart_apply pmt)
+        pure <| Sum.inl (← evalTactic (← `(tactic| wp_apply_raw $pmt)))
       catch e =>
-        -- an interrupt or heartbeat exhaustion is not a failed application: do not retry it
-        if e.isInterrupt || e.isMaxHeartbeat then throw e else pure (Sum.inr e)
+        pure (Sum.inr e)
     match attempt with
-    | .inl (produced, spec) =>
-      wpApplyIntro `wp_smart_apply produced spec pats
+    | .inl _ =>
+      -- wpApplyIntro `wp_smart_apply produced spec pats
       return
     | .inr applyErr =>
       s.restore
@@ -579,7 +606,7 @@ syntax (name := wpSmartApply) "wp_smart_apply " colGt pmTerm
 
 elab_rules : tactic
   | `(tactic| wp_smart_apply $pmt:pmTerm $[with $pats*]?) => do
-    runWpSmartApply (← liftMacroM <| PMTerm.parse pmt) (pats.getD #[])
+    runWpSmartApply pmt (pats.getD #[])
 
 
 /-! ## Tactic lemmas for the heap tactics -/

--- a/Iris/Iris/HeapLang/ProofMode.lean
+++ b/Iris/Iris/HeapLang/ProofMode.lean
@@ -373,27 +373,31 @@ public theorem tac_wp_pure [ι : IrisGS_gen hlc Exp GF] {Δ Δ'} {s : Stuckness}
   iintro $ !> -; itrivial
 
 public meta def iWpPure {u}
-  {GF : Q(BundledGFunctors.{0, 0, 0})}
-  {hlc : Q(HasLC)}
-  {prop : Q(Type u)}
-  {bi : Q(BI $prop)}
-  {ehyps : Q($prop)}
-  (hyps : Hyps bi ehyps)
-  (ι : Q(IrisGS_gen $hlc Exp $GF))
-  (s : Q(Stuckness))
-  (E : Q(CoPset))
-  (e : Q(Exp))
-  (Φ : Q(Val → $prop))
-  (failOnUnsolved : Bool)
-  (findPureExec : (e₁ : Q(Exp)) →
-    ProofModeM ((φ : Q(Prop)) × (n : Q(Nat)) × (e₂ : Q(Exp)) × Q(ProgramLogic.Language.PureExec $φ $n $e₁ $e₂)))
-
-  (_hu : QuotedLevelDefEq u 0 := ⟨⟩)
-  (_hprop : $prop =Q IProp $GF := ⟨⟩)
-  (_hbi : $bi =Q UPred.instBIUPred := ⟨⟩)
-  (κ : Q(Wp $prop Exp Val Stuckness) := q(wp.def))
-  (_hwp : $κ =Q wp.def := ⟨⟩) :
-    ProofModeM (Q($ehyps ⊢ Wp.wp $s $E $e $Φ)) := do
+    {GF : Q(BundledGFunctors.{0, 0, 0})}
+    {hlc : Q(HasLC)}
+    {prop : Q(Type u)}
+    {bi : Q(BI $prop)}
+    {ehyps : Q($prop)}
+    (hyps : Hyps bi ehyps)
+    (ι : Q(IrisGS_gen $hlc Exp $GF))
+    (s : Q(Stuckness))
+    (E : Q(CoPset))
+    (e : Q(Exp))
+    (Φ : Q(Val → $prop))
+    (failOnUnsolved : Bool)
+    (findPureExec : (e₁ : Q(Exp)) →
+      ProofModeM ((φ : Q(Prop)) × (n : Q(Nat)) × (e₂ : Q(Exp)) ×
+        Q(ProgramLogic.Language.PureExec $φ $n $e₁ $e₂)))
+    (_hu : QuotedLevelDefEq u 0 := ⟨⟩)
+    (_hprop : $prop =Q IProp $GF := ⟨⟩)
+    (_hbi : $bi =Q UPred.instBIUPred := ⟨⟩)
+    (κ : Q(Wp $prop Exp Val Stuckness) := q(wp.def))
+    (_hwp : $κ =Q wp.def := ⟨⟩)
+    -- The continuation function: using `iWpFinish` by default
+    (k : {eΔ : Q($prop)} → Hyps bi eΔ → (e' : Q(Exp)) →
+          ProofModeM Q($eΔ ⊢ Wp.wp $s $E $e' $Φ) :=
+      fun hyps' e' => iWpFinish hyps' ι s E e' Φ) :
+      ProofModeM (Q($ehyps ⊢ Wp.wp $s $E $e $Φ)) := do
   let some {result := ⟨φ, n, e₂, inst⟩, K, e' := e₁, ..} ←
     findECtx (α:=((_ : Q(Prop)) × (_ : Q(Nat)) × (_ : Q(Exp)) × Lean.Expr)) e fun _ => findPureExec
   | throwIPMError "Cannot find expression to evaluate"
@@ -401,7 +405,7 @@ public meta def iWpPure {u}
 
   let ⟨_, hyps', pf⟩ ← iModAction hyps q(modality_laterN $n)
   let ⟨inner, .up _⟩ ← HeapLang.fillQ K e₂
-  let nextPf ← iWpFinish hyps' ι s E inner Φ
+  let nextPf ← k hyps' inner
   let HΦ ← iSolveSidecondition φ (failOnUnsolved := failOnUnsolved)
   return q(tac_wp_pure $inst $HΦ $pf $nextPf)
 
@@ -469,31 +473,60 @@ macro "wp_match" : tactic => `(tactic | (wp_case; wp_closure; wp_pure (_ _)))
 
 /-! ## The `wp_apply` tactics -/
 
+/--
+  Indicates whether `wp_apply` or `wp_smart_apply` is used.
+  For `wp_smart_apply`, also include the fuel amount, that is, the number of retries.
+-/
+inductive WpApplyKind where
+  | apply
+  | smartApply (fuel : Nat)
+
+/-- bound on `wp_smart_apply`'s pure steps. -/
+meta def smartApplyFuel : Nat := 10000
+
 /-- Pose `pmt`, then apply it at a decomposition `e = K[e']` pushing `K` into the
 postcondition via `iWpBindCore`. `premisesOut` gets the application's goals on success -/
-meta def iWpApplyCore {u} {GF : Q(BundledGFunctors.{0, 0, 0})} {hlc : Q(HasLC)}
+meta partial def iWpApplyCore {u} {GF : Q(BundledGFunctors.{0, 0, 0})} {hlc : Q(HasLC)}
     {prop : Q(Type u)} {bi : Q(BI $prop)} {ehyps : Q($prop)}
     (hyps : Hyps bi ehyps) (ι : Q(IrisGS_gen $hlc Exp $GF)) (s : Q(Stuckness)) (E : Q(CoPset))
-    (e : Q(Exp)) (Φ : Q(Val → $prop)) (pmt : PMTerm)
+    (e : Q(Exp)) (Φ : Q(Val → $prop)) (pmt : PMTerm) (wpApplyKind : WpApplyKind)
     (_hu : QuotedLevelDefEq u 0 := ⟨⟩) (_hprop : $prop =Q IProp $GF := ⟨⟩)
     (_hbi : $bi =Q UPred.instBIUPred := ⟨⟩)
     (κ : Q(Wp $prop Exp Val Stuckness) := q(wp.def)) (_hwp : $κ =Q wp.def := ⟨⟩) :
     ProofModeM Q($ehyps ⊢ Wp.wp $s $E $e $Φ) := do
+  let st ← ProofModeM.saveState
   let ⟨eΔ, hyps', p, A, posePf⟩ ← iHave hyps q(Wp.wp $s $E $e $Φ) pmt true
-  let some {result := pf, ..} ←
+  let applied ←
     findECtx (α := Q($eΔ ∗ □?$p $A ⊢ Wp.wp $s $E $e $Φ)) e fun K e' => do
       trace[wp_apply] m!"trying to apply {A} to {e'}"
       iWpBindCore _ ι s E e Φ K e' (iApply hyps' p A ·)
-  | throwIPMError "cannot apply {A}"
-  return q($posePf $pf)
+  if let some {result := pf, ..} := applied then
+    return q($posePf $pf)
+  let failed ← addMessageContext m!"cannot apply {A}"
+  match wpApplyKind with
+  | .apply => throwIPMError failed
+  | .smartApply 0 =>
+    throwIPMError m!"fuel exhausted after {smartApplyFuel} pure steps; {failed}"
+  | .smartApply (fuel + 1) =>
+    st.restore (restoreInfo := true)
+    try
+      iWpPure hyps ι s E e Φ (failOnUnsolved := true) findAnyPureExec
+        (k := fun hyps'' e'' => iWpApplyCore hyps'' ι s E e'' Φ pmt (.smartApply fuel))
+    catch err =>
+      if err.isInterrupt || err.isMaxHeartbeat then throw err
+      st.restore (restoreInfo := true)
+      throwIPMError failed
 
-meta def wpApplyRaw (tacName : Name) (pmt : TSyntax `pmTerm) : TacticM Unit := do
+meta def wpApplyRaw (tacName : Name) (wpApplyKind : WpApplyKind) (pmt : TSyntax `pmTerm) :
+    TacticM Unit := do
   let pmt ← liftMacroM <| PMTerm.parse pmt
   ProofModeM.runTacticWp tacName fun mvar {hyps, ι, s, E, e, Φ, ..} => do
-    mvar.assign (← iWpApplyCore hyps ι s E e Φ pmt)
+    mvar.assign (← iWpApplyCore hyps ι s E e Φ pmt wpApplyKind)
 
-elab "wp_apply_raw"       colGt pmt:pmTerm : tactic => wpApplyRaw `wp_apply pmt
-elab "wp_smart_apply_raw" colGt pmt:pmTerm : tactic => wpApplyRaw `wp_smart_apply pmt
+elab "wp_apply_raw" colGt pmt:pmTerm : tactic =>
+  wpApplyRaw `wp_apply .apply pmt
+elab "wp_smart_apply_raw" colGt pmt:pmTerm : tactic =>
+  wpApplyRaw `wp_smart_apply (.smartApply smartApplyFuel) pmt
 /-- Strip a leading `▷` and simplify WP expressions in the goals an application produced. -/
 macro "wp_apply_post" : tactic => `(tactic| ((try inext) <;> (try wp_expr_simp)))
 
@@ -540,9 +573,6 @@ macro_rules
         `(tactic| skip)
     `(tactic| focus (((wp_apply_raw $pmt) <;> wp_apply_post); $t:tactic))
 
-/-- bound on `wp_smart_apply`'s pure steps. -/
-meta def smartApplyFuel : Nat := 10000
-
 /-- Retry the application after single pure steps, bounded. `with` runs after the loop:
 retrying a failed introduction would roll back an application that already succeeded. -/
 meta def runWpSmartApply (pmt : TSyntax `pmTerm) (_pats : Array (TSyntax `introPat)) :
@@ -579,39 +609,14 @@ bounded under `smartApplyFuel` so the tactic does not diverge.
 syntax (name := wpSmartApply) "wp_smart_apply " colGt pmTerm
   (" with" (colGt ppSpace introPat)+)? : tactic
 
-/-- Run `tac`; if it fails, take one pure step whose side condition is fully discharged and
-retry. Bounded by `smartApplyFuel`. The error reported is the one from the *first* attempt:
-later ones are about goals the user never wrote. -/
-elab "wp_retry_pure" colGt tac:tactic : tactic => do
-  let mut firstErr : Option Exception := none
-  for _ in [0:smartApplyFuel] do
-    let s ← Tactic.saveState
-    let err? ←
-      try
-        evalTactic tac
-        pure none
-      catch e =>
-        -- an interrupt or heartbeat exhaustion is not a failed application: do not retry it
-        if e.isInterrupt || e.isMaxHeartbeat then throw e else pure (some e)
-    match err? with
-    | none => return
-    | some attemptErr =>
-      s.restore
-      let deadEndErr := firstErr.getD attemptErr
-      firstErr := some deadEndErr
-      try evalTactic (← `(tactic| wp_pure +!failOnUnsolved))
-      catch _ =>
-        s.restore
-        throw deadEndErr
-  throwError "wp_retry_pure: fuel exhausted after {smartApplyFuel} pure steps"
-
 macro_rules
   | `(tactic| wp_smart_apply $pmt:pmTerm $[with $pats*]?) => do
     let t : TSyntax `tactic ←
       if let some pats := pats then
         `(tactic| focusLastIrisGoal (iintro $pats*))
-      else `(tactic| skip)
-    `(tactic| focus ((wp_retry_pure ((wp_smart_apply_raw $pmt) <;> wp_apply_post)); $t:tactic))
+      else
+        `(tactic| skip)
+    `(tactic| focus (((wp_smart_apply_raw $pmt) <;> wp_apply_post); $t:tactic))
 
 /-! ## Tactic lemmas for the heap tactics -/
 

--- a/Iris/Iris/HeapLang/ProofMode.lean
+++ b/Iris/Iris/HeapLang/ProofMode.lean
@@ -306,33 +306,56 @@ public theorem tac_wp_bind [ι : IrisGS_gen hlc Exp GF] {Δ} {s : Stuckness} {E 
     (Δ ⊢ WP (ProgramLogic.fill K e') @ s ; E {{ Φ }}) :=
   H.trans (wp_bind (ProgramLogic.fill K))
 
+public meta def iWpBindCore {u}
+  {GF : Q(BundledGFunctors.{0, 0, 0})}
+  {hlc : Q(HasLC)}
+  {prop : Q(Type u)}
+  {bi : Q(BI $prop)}
+  (ehyps : Q($prop))
+  (ι : Q(IrisGS_gen $hlc Exp $GF))
+  (s : Q(Stuckness))
+  (E : Q(CoPset))
+  (e : Q(Exp))
+  (Φ : Q(Val → $prop))
+  (K : Q(List ECtxItem))
+  (e' : Q(Exp))
+  (k : (A : Q($prop)) → ProofModeM Q($ehyps ⊢ $A))
+
+  (_hu : QuotedLevelDefEq u 0 := ⟨⟩)
+  (_hprop : $prop =Q IProp $GF := ⟨⟩)
+  (_hbi : $bi =Q UPred.instBIUPred := ⟨⟩)
+  (κ : Q(Wp $prop Exp Val Stuckness) := q(wp.def))
+  (_hwp : $κ =Q wp.def := ⟨⟩) :
+    ProofModeM (Q($ehyps ⊢ Wp.wp $s $E (ProgramLogic.fill $K $e') $Φ)) := do
+  match K with
+  | ~q([]) =>
+    -- don't do anything for empty evaluation context
+    k q(Wp.wp $s $E $e $Φ)
+  | _ =>
+    -- construct the new postcondition
+    let Φ' : Q(Val → IProp $GF) ←
+      Qq.withLocalDeclDQ `v q(Val) fun v => do
+        mkLambdaFVars #[v] <|
+          q(Wp.wp $s $E $(← HeapLang.fill K q(.ofVal $v)) $Φ)
+    have _ : $Φ' =Q (fun v : Val => Wp.wp (PROP := IProp $GF) $s $E (ProgramLogic.fill $K (v : Exp)) $Φ) := ⟨⟩
+
+    let pf ← k q(Wp.wp $s $E $e' $Φ')
+    return q(tac_wp_bind $pf)
+
+
 -- `hl_exp` must bind tighter than `;` in the heaplang notation so `wp_bind _ _; tac` parses
 elab "wp_bind" colGt ppSpace focus:hl_exp:10 : tactic =>
-  ProofModeM.runTacticWp `wp_bind fun mvar {GF, hyps, s, E, e, Φ, ..} => do
+  ProofModeM.runTacticWp `wp_bind fun mvar {ehyps, hyps, s, ι, E, e, Φ, ..} => do
     let focus ← elabTermEnsuringTypeQ (←`(hl($focus))) q(HeapLang.Exp)
     trace[wp_bind] s!"Context to bind over: {←ppExpr focus}"
 
-    let some {K, e', ..} ← findECtx e (fun e => do
+    let some {K, e', ..} ← findECtx e fun _ e => do
       trace[wp_bind] s!"trying to unify {←ppExpr e} with {←ppExpr focus}"
-      guard <| ← isDefEq e focus)
-    -- TODO: add a throwProofModeEx for throwing errors consistently across all tactics
-      | throwIPMError s!"Cannot unify {←ppExpr focus} with any possible evaluation context"
+      guard <| ← isDefEq e focus
+    | throwIPMError s!"Cannot unify {←ppExpr focus} with any possible evaluation context"
     trace[wp_bind] s!"Found context {←ppExpr K} with expression {←ppExpr e'} matching our focus"
 
-    match K with
-    | ~q([]) =>
-      -- don't do anything for empty evaluation context
-      addMVarGoal mvar
-    | _ =>
-      -- construct the new postcondition
-      let Φ' : Q(Val → IProp $GF) ←
-        Qq.withLocalDeclDQ `v q(Val) fun v => do
-          mkLambdaFVars #[v] <|
-            q(Wp.wp $s $E $(← HeapLang.fill K q(.ofVal $v)) $Φ)
-      have _ : $Φ' =Q (fun v : Val => Wp.wp (PROP := IProp $GF) $s $E (ProgramLogic.fill $K (v : Exp)) $Φ) := ⟨⟩
-
-      let pf ← addBIGoal hyps q(Wp.wp $s $E $e' $Φ')
-      mvar.assign q(tac_wp_bind $pf)
+    mvar.assign <| ← iWpBindCore ehyps ι s E e Φ K e' (addBIGoal hyps)
 
 @[rocq_alias heap_lang.tac_wp_pure]
 public theorem tac_wp_pure [ι : IrisGS_gen hlc Exp GF] {Δ Δ'} {s : Stuckness} {E : CoPset} {K : List ECtxItem} {e₁ e₂ : Exp} {φ : Prop} {n : Nat} {Φ : Val → IProp GF} :
@@ -361,6 +384,7 @@ public meta def iWpPure {u}
   (E : Q(CoPset))
   (e : Q(Exp))
   (Φ : Q(Val → $prop))
+  (failOnUnsolved : Bool)
   (findPureExec : (e₁ : Q(Exp)) →
     ProofModeM ((φ : Q(Prop)) × (n : Q(Nat)) × (e₂ : Q(Exp)) × Q(ProgramLogic.Language.PureExec $φ $n $e₁ $e₂)))
 
@@ -371,20 +395,20 @@ public meta def iWpPure {u}
   (_hwp : $κ =Q wp.def := ⟨⟩) :
     ProofModeM (Q($ehyps ⊢ Wp.wp $s $E $e $Φ)) := do
   let some {result := ⟨φ, n, e₂, inst⟩, K, e' := e₁, ..} ←
-    findECtx (α:=((_ : Q(Prop)) × (_ : Q(Nat)) × (_ : Q(Exp)) × Lean.Expr)) e findPureExec
-    | throwIPMError "Cannot find expression to evaluate"
+    findECtx (α:=((_ : Q(Prop)) × (_ : Q(Nat)) × (_ : Q(Exp)) × Lean.Expr)) e fun _ => findPureExec
+  | throwIPMError "Cannot find expression to evaluate"
   have inst : Q(ProgramLogic.Language.PureExec $φ $n $e₁ $e₂) := inst
 
   let ⟨_, hyps', pf⟩ ← iModAction hyps q(modality_laterN $n)
   let ⟨inner, .up _⟩ ← HeapLang.fillQ K e₂
   let nextPf ← iWpFinish hyps' ι s E inner Φ
-  let HΦ ← iSolveSidecondition φ (failOnUnsolved := false)
+  let HΦ ← iSolveSidecondition φ (failOnUnsolved := failOnUnsolved)
   return q(tac_wp_pure $inst $HΦ $pf $nextPf)
 
-elab "wp_pure " colGt ppSpace focus:hl_exp:10 : tactic =>
+elab "wp_pure" failOnUnsolved:("+!failOnUnsolved")? colGt ppSpace focus:hl_exp:10 : tactic =>
   ProofModeM.runTacticWp `wp_pure fun mvar {hyps, ι, s, E, e, Φ, ..} => do
     let focus ← elabTermEnsuringTypeQ (← `(hl($focus))) q(HeapLang.Exp)
-    mvar.assign <| ← iWpPure hyps ι s E e Φ fun e₁ => do
+    mvar.assign <| ← iWpPure hyps ι s E e Φ failOnUnsolved.isSome fun e₁ => do
       guard <| ← isDefEq e₁ focus
       let φ ← mkFreshExprMVarQ q(Prop)
       let n ← mkFreshExprMVarQ q(Nat)
@@ -394,17 +418,7 @@ elab "wp_pure " colGt ppSpace focus:hl_exp:10 : tactic =>
       return ⟨φ, n, e₂, inst⟩
 
 macro "wp_pure" : tactic => `(tactic| wp_pure _)
-
-/-- A single `wp_pure` step that must leave exactly one goal, Rocq's `wp_pure _; []`. Fails
-if the step spawns a goal besides the continuation, such as an undischarged side condition
-of the reduction. -/
-elab "wp_pure_step" : tactic => focus do
-  evalTactic (← `(tactic| wp_pure))
-  -- we run under `focus` so we only see the unsolved goals of `wp_pure`
-  let goals ← getUnsolvedGoals
-  unless goals.length == 1 do
-    throwError "the pure reduction step must leave exactly one goal, it left {
-      goals.length}:{indentD <| .joinSep (goals.map fun g => m!"{g}") Format.line}"
+macro "wp_pure" "+!failOnUnsolved" : tactic => `(tactic| wp_pure +!failOnUnsolved _)
 
 /-- Reduce all pure redexes at the head of the weakest precondition, then simplify the
 resulting expression and strip the weakest precondition if it has become a value.
@@ -413,13 +427,13 @@ A pure step whose side condition cannot be discharged is not taken. -/
 macro "wp_pures" : tactic =>
   -- Rocq: `first [progress repeat (wp_pure _; []) | wp_finish]`
   `(tactic| first
-    | (wp_pure_step; repeat wp_pure_step)
+    | (wp_pure +!failOnUnsolved; repeat wp_pure +!failOnUnsolved)
     | wp_finish)
 
 /-- Beta-reduce the innermost application, unfolding a head hidden behind a definition. -/
 elab "wp_rec" : tactic =>
   ProofModeM.runTacticWp `wp_rec fun mvar {hyps, ι, s, E, e, Φ, ..} => do
-    mvar.assign <| ← iWpPure hyps ι s E e Φ fun e₁ => do
+    mvar.assign <| ← iWpPure hyps ι s E e Φ (failOnUnsolved := false) fun e₁ => do
       let ~q(Exp.app (Exp.ofVal $f) (Exp.ofVal $a)) := e₁ | failure
       -- reduce `f` to find a recursive function
       let f' : Q(Val) ← whnf f
@@ -449,18 +463,8 @@ macro "wp_match" : tactic => `(tactic | (wp_case; wp_closure; wp_pure (_ _)))
 
 /-! ## The `wp_apply` tactics -/
 
-/-- use `A` directly if it matches `goal`, else eliminate its wands -/
-meta def iWpApplyHyp {u} {prop : Q(Type u)} {bi : Q(BI $prop)}
-    {e' : Q($prop)} (hyps : Hyps bi e') (p : Q(Bool)) (A : Q($prop)) (goal : Q($prop)) :
-    ProofModeM Q($e' ∗ □?$p $A ⊢ $goal) := do
-  if let some _ ← ProofModeM.trySynthInstanceQ q(FromAssumption $p .in $A $goal) then
-    let .some _ ← trySynthInstanceQ q(Std.TCOr (Affine $e') (Absorbing $goal))
-      | throwIPMError "the context {e'} is not affine and goal not absorbing"
-    return q(apply_assumption)
-  iApplyCore hyps p A goal
-
 /-- Pose `pmt`, then apply it at a decomposition `e = K[e']` pushing `K` into the
-postcondition via `tac_wp_bind`. `premisesOut` gets the application's goals on success -/
+postcondition via `iWpBindCore`. `premisesOut` gets the application's goals on success -/
 meta def iWpApplyCore {u} {GF : Q(BundledGFunctors.{0, 0, 0})} {hlc : Q(HasLC)}
     {prop : Q(Type u)} {bi : Q(BI $prop)} {ehyps : Q($prop)}
     (hyps : Hyps bi ehyps) (ι : Q(IrisGS_gen $hlc Exp $GF)) (s : Q(Stuckness)) (E : Q(CoPset))
@@ -474,22 +478,10 @@ meta def iWpApplyCore {u} {GF : Q(BundledGFunctors.{0, 0, 0})} {hlc : Q(HasLC)}
   let ⟨eΔ, hyps', p, A, posePf⟩ ← iHave hyps q(Wp.wp $s $E $e $Φ) pmt true
   let afterPose := (← get).goals.size
   let some {result := pf, ..} ←
-    findECtxOutermost (α := Q($eΔ ∗ □?$p $A ⊢ Wp.wp $s $E $e $Φ)) e fun K e' => do
+    findECtx (α := Q($eΔ ∗ □?$p $A ⊢ Wp.wp $s $E $e $Φ)) e fun K e' => do
       trace[wp_apply] m!"trying to apply {A} to {e'}"
-      match K with
-      | ~q([]) =>
-        let pf ← iWpApplyHyp hyps' p A q(Wp.wp $s $E $e' $Φ)
-        pure (pf : Lean.Expr)
-      | _ =>
-        let Φ' : Q(Val → IProp $GF) ←
-          Qq.withLocalDeclDQ `v q(Val) fun v => do
-            mkLambdaFVars #[v] <|
-              q(Wp.wp $s $E $(← HeapLang.fill K q(.ofVal $v)) $Φ)
-        have _ : $Φ' =Q (fun v : Val =>
-          Wp.wp (PROP := IProp $GF) $s $E (ProgramLogic.fill $K (v : Exp)) $Φ) := ⟨⟩
-        let pf ← iWpApplyHyp hyps' p A q(Wp.wp $s $E $e' $Φ')
-        pure (q(tac_wp_bind $pf) : Lean.Expr)
-    | throwIPMError "cannot apply {A}"
+      iWpBindCore _ ι s E e Φ K e' (iApply hyps' p A ·)
+  | throwIPMError "cannot apply {A}"
   premisesOut.set ((← get).goals.extract afterPose, (← get).goals.extract beforePose afterPose)
   return q($posePf $pf)
 
@@ -570,7 +562,7 @@ meta def runWpSmartApply (pmt : PMTerm) (pats : Array (TSyntax `introPat)) :
       -- report iteration 0's error: later ones concern goals the user never saw
       let deadEndErr := firstErr.getD applyErr
       firstErr := some deadEndErr
-      try evalTactic (← `(tactic| wp_pure_step))
+      try evalTactic (← `(tactic| wp_pure +!failOnUnsolved))
       catch _ =>
         s.restore
         throw deadEndErr
@@ -874,10 +866,10 @@ meta def runTacticHeapWp {α} (tacName : Name)
 
 elab "wp_load" : tactic =>
   runTacticHeapWp `wp_load fun mvar {s, E, e, Φ, hgs, eΔ', hyps', pfLater, ..} => do
-    let some {result := l, K, ..} ← findECtx e fun e' => do
-        let ~q(Exp.load (Exp.ofVal (Val.lit (BaseLit.loc $l)))) := e' | failure
-        return l
-      | throwIPMError "cannot find a `load` redex"
+    let some {result := l, K, ..} ← findECtx e fun _ e' => do
+      let ~q(Exp.load (Exp.ofVal (Val.lit (BaseLit.loc $l)))) := e' | failure
+      return l
+    | throwIPMError "cannot find a `load` redex"
     trace[wp_heap.redex] "load {l}; K = {K}"
 
     -- find `l ↦{dq} some v` in the spatial context and extract `dq`
@@ -893,10 +885,10 @@ elab "wp_load" : tactic =>
 
 elab "wp_store" : tactic => do
   runTacticHeapWp `wp_store fun mvar {bi, s, E, e, Φ, hgs, eΔ', hyps', pfLater, ..} => do
-    let some {result := (l, v'), K, ..} ← findECtx e fun e' => do
-        let ~q(Exp.store (Exp.ofVal (Val.lit (BaseLit.loc $l))) (Exp.ofVal $v')) := e' | failure
-        return (l, v')
-      | throwIPMError "cannot find a `store` redex"
+    let some {result := (l, v'), K, ..} ← findECtx e fun _ e' => do
+      let ~q(Exp.store (Exp.ofVal (Val.lit (BaseLit.loc $l))) (Exp.ofVal $v')) := e' | failure
+      return (l, v')
+    | throwIPMError "cannot find a `store` redex"
     trace[wp_heap.redex] "store {l} ← {v'}; K = {K}"
 
     -- find and remove `l ↦ some v` (stores need full ownership)
@@ -914,10 +906,10 @@ elab "wp_store" : tactic => do
 
 elab "wp_xchg" : tactic => do
   runTacticHeapWp `wp_xchg fun mvar {bi, s, E, e, Φ, hgs, eΔ', hyps', pfLater, ..} => do
-    let some {result := (l, v'), K, ..} ← findECtx e fun e' => do
-        let ~q(Exp.xchg (Exp.ofVal (Val.lit (BaseLit.loc $l))) (Exp.ofVal $v')) := e' | failure
-        return (l, v')
-      | throwIPMError "cannot find an `xchg` redex"
+    let some {result := (l, v'), K, ..} ← findECtx e fun _ e' => do
+      let ~q(Exp.xchg (Exp.ofVal (Val.lit (BaseLit.loc $l))) (Exp.ofVal $v')) := e' | failure
+      return (l, v')
+    | throwIPMError "cannot find an `xchg` redex"
     trace[wp_heap.redex] "xchg {l} ← {v'}; K = {K}"
 
     -- find and remove `l ↦ some v` (xchg writes, so it needs full ownership)
@@ -934,12 +926,12 @@ elab "wp_xchg" : tactic => do
 
 elab "wp_faa" : tactic =>
   runTacticHeapWp `wp_faa fun mvar {bi, s, E, e, Φ, hgs, eΔ', hyps', pfLater, ..} => do
-    let some {result := (l, z2), K, ..} ← findECtx e fun e' => do
-        -- faa is only defined on integers
-        let ~q(Exp.faa (Exp.ofVal (Val.lit (BaseLit.loc $l)))
-            (Exp.ofVal (Val.lit (BaseLit.int $z2)))) := e' | failure
-        return (l, z2)
-      | throwIPMError "cannot find a `faa` redex"
+    let some {result := (l, z2), K, ..} ← findECtx e fun _ e' => do
+      -- faa is only defined on integers
+      let ~q(Exp.faa (Exp.ofVal (Val.lit (BaseLit.loc $l)))
+          (Exp.ofVal (Val.lit (BaseLit.int $z2)))) := e' | failure
+      return (l, z2)
+    | throwIPMError "cannot find a `faa` redex"
     trace[wp_heap.redex] "faa {l} += {z2}; K = {K}"
 
     -- find and remove `l ↦ some v` (faa writes, so it needs full ownership)
@@ -962,11 +954,11 @@ elab "wp_faa" : tactic =>
 
 elab "wp_cmpxchg_suc" : tactic =>
   runTacticHeapWp `wp_cmpxchg_suc fun mvar {bi, s, E, e, Φ, hgs, eΔ', hyps', pfLater, ..} => do
-    let some {result := (l, v1, v2), K, ..} ← findECtx e fun e' => do
-        let ~q(Exp.cmpXchg (Exp.ofVal (Val.lit (BaseLit.loc $l)))
-            (Exp.ofVal $v1) (Exp.ofVal $v2)) := e' | failure
-        return (l, v1, v2)
-      | throwIPMError "cannot find a `cmpXchg` redex"
+    let some {result := (l, v1, v2), K, ..} ← findECtx e fun _ e' => do
+      let ~q(Exp.cmpXchg (Exp.ofVal (Val.lit (BaseLit.loc $l)))
+          (Exp.ofVal $v1) (Exp.ofVal $v2)) := e' | failure
+      return (l, v1, v2)
+    | throwIPMError "cannot find a `cmpXchg` redex"
     trace[wp_heap.redex] "cmpXchg {l}: {v1} → {v2}; K = {K}"
 
     -- find and remove `l ↦ some v` (a successful cmpXchg writes, so full ownership)
@@ -990,11 +982,11 @@ elab "wp_cmpxchg_suc" : tactic =>
 
 elab "wp_cmpxchg_fail" : tactic =>
   runTacticHeapWp `wp_cmpxchg_fail fun mvar {s, E, e, Φ, hgs, eΔ', hyps', pfLater, ..} => do
-    let some {result := (l, v1, v2), K, ..} ← findECtx e fun e' => do
-        let ~q(Exp.cmpXchg (Exp.ofVal (Val.lit (BaseLit.loc $l)))
-            (Exp.ofVal $v1) (Exp.ofVal $v2)) := e' | failure
-        return (l, v1, v2)
-      | throwIPMError "cannot find a `cmpXchg` redex"
+    let some {result := (l, v1, v2), K, ..} ← findECtx e fun _ e' => do
+      let ~q(Exp.cmpXchg (Exp.ofVal (Val.lit (BaseLit.loc $l)))
+          (Exp.ofVal $v1) (Exp.ofVal $v2)) := e' | failure
+      return (l, v1, v2)
+    | throwIPMError "cannot find a `cmpXchg` redex"
     trace[wp_heap.redex] "cmpXchg {l}: {v1} → {v2}; K = {K}"
 
     -- any fraction suffices for a failing compare (the points-to is only read)
@@ -1018,11 +1010,11 @@ elab "wp_cmpxchg_fail" : tactic =>
 -- `colGt` on the names keeps an omitted one from swallowing the next line's tactic
 elab "wp_cmpxchg" " with" colGt ppSpace h1:binderIdent colGt ppSpace h2:binderIdent : tactic =>
   runTacticHeapWp `wp_cmpxchg fun mvar {bi, GF, hlc, s, E, e, Φ, hgs, eΔ', hyps', pfLater, ..} => do
-    let some {result := (l, v1, v2), K, ..} ← findECtx e fun e' => do
-        let ~q(Exp.cmpXchg (Exp.ofVal (Val.lit (BaseLit.loc $l)))
-            (Exp.ofVal $v1) (Exp.ofVal $v2)) := e' | failure
-        return (l, v1, v2)
-      | throwIPMError "cannot find a `cmpXchg` redex"
+    let some {result := (l, v1, v2), K, ..} ← findECtx e fun _ e' => do
+      let ~q(Exp.cmpXchg (Exp.ofVal (Val.lit (BaseLit.loc $l)))
+          (Exp.ofVal $v1) (Exp.ofVal $v2)) := e' | failure
+      return (l, v1, v2)
+    | throwIPMError "cannot find a `cmpXchg` redex"
     trace[wp_heap.redex] "cmpXchg {l}: {v1} → {v2}; K = {K}"
 
     -- find and remove `l ↦ some v` (the success branch writes, so full ownership)
@@ -1061,10 +1053,10 @@ elab "wp_cmpxchg" " with" colGt ppSpace h1:binderIdent colGt ppSpace h2:binderId
 
 elab "wp_free" : tactic =>
   runTacticHeapWp `wp_free fun mvar {s, E, e, Φ, hgs, eΔ', hyps', pfLater, ..} => do
-    let some {result := l, K, ..} ← findECtx e fun e' => do
-        let ~q(Exp.free (Exp.ofVal (Val.lit (BaseLit.loc $l)))) := e' | failure
-        return l
-      | throwIPMError "cannot find a `free` redex"
+    let some {result := l, K, ..} ← findECtx e fun _ e' => do
+      let ~q(Exp.free (Exp.ofVal (Val.lit (BaseLit.loc $l)))) := e' | failure
+      return l
+    | throwIPMError "cannot find a `free` redex"
     trace[wp_heap.redex] "free {l}; K = {K}"
 
     -- find and remove `l ↦ some v` (freeing needs full ownership); the continuation
@@ -1080,11 +1072,11 @@ elab "wp_free" : tactic =>
 elab "wp_alloc" colGt ppSpace loc:binderIdent " with" colGt ppSpace hyp:binderIdent : tactic =>
   runTacticHeapWp `wp_alloc fun mvar
       {bi, GF, hlc, s, E, e, Φ, hgs, eΔ', hyps', pfLater, ..} => do
-    let some {result := (n, v), K, ..} ← findECtx e fun e' => do
-        let ~q(Exp.allocN (Exp.ofVal (Val.lit (BaseLit.int $n)))
-            (Exp.ofVal $v)) := e' | failure
-        return (n, v)
-      | throwIPMError "cannot find an allocation redex"
+    let some {result := (n, v), K, ..} ← findECtx e fun _ e' => do
+      let ~q(Exp.allocN (Exp.ofVal (Val.lit (BaseLit.int $n)))
+          (Exp.ofVal $v)) := e' | failure
+      return (n, v)
+    | throwIPMError "cannot find an allocation redex"
     let single ← isDefEq n q((1 : Int))
 
     trace[wp_heap.redex] "allocn {n} {v}; K = {K}"

--- a/Iris/Iris/HeapLang/ProofMode.lean
+++ b/Iris/Iris/HeapLang/ProofMode.lean
@@ -488,8 +488,6 @@ structure WpApplyState {u} {GF : Q(BundledGFunctors.{0, 0, 0})}
   prefixPf : Q(($ehypsC ⊢ @Wp.wp $prop Exp Val Stuckness $κ $s $E $eC $Φ) →
     $ehyps ⊢ @Wp.wp $prop Exp Val Stuckness $κ $s $E $e $Φ)
 
-/-- Pose `pmt`, then apply it at a decomposition `e = K[e']` pushing `K` into the
-postcondition via `iWpBindCore`. `premisesOut` gets the application's goals on success -/
 meta partial def iWpApplyCore {u} {GF : Q(BundledGFunctors.{0, 0, 0})} {hlc : Q(HasLC)}
     {prop : Q(Type u)} {bi : Q(BI $prop)} {ehyps : Q($prop)}
     (hyps : Hyps bi ehyps) (ι : Q(IrisGS_gen $hlc Exp $GF)) (s : Q(Stuckness)) (E : Q(CoPset))

--- a/Iris/Iris/HeapLang/ProofMode.lean
+++ b/Iris/Iris/HeapLang/ProofMode.lean
@@ -405,8 +405,8 @@ public meta def iWpPure {u}
 
   let ⟨_, hyps', pf⟩ ← iModAction hyps q(modality_laterN $n)
   let ⟨inner, .up _⟩ ← HeapLang.fillQ K e₂
-  let nextPf ← k hyps' inner
   let HΦ ← iSolveSidecondition φ (failOnUnsolved := failOnUnsolved)
+  let nextPf ← k hyps' inner
   return q(tac_wp_pure $inst $HΦ $pf $nextPf)
 
 /-- Find any pure step for `e₁`, as `wp_pure _` does. -/

--- a/Iris/Iris/HeapLang/ProofMode.lean
+++ b/Iris/Iris/HeapLang/ProofMode.lean
@@ -478,6 +478,16 @@ inductive WpApplyKind where
   | apply
   | smartApply
 
+structure WpApplyState {u} {GF : Q(BundledGFunctors.{0, 0, 0})}
+    {hlc : Q(HasLC)} {prop : Q(Type u)} {bi : Q(BI $prop)} {ehyps : Q($prop)}
+    {s : Q(Stuckness)} {E : Q(CoPset)} {e : Q(Exp)} {Φ : Q(Val → $prop)}
+    (κ : Q(Wp $prop Exp Val Stuckness)) where
+  {ehypsC : Q($prop)}
+  hypsC : Hyps bi ehypsC
+  eC : Q(Exp)
+  prefixPf : Q(($ehypsC ⊢ @Wp.wp $prop Exp Val Stuckness $κ $s $E $eC $Φ) →
+    $ehyps ⊢ @Wp.wp $prop Exp Val Stuckness $κ $s $E $e $Φ)
+
 /-- Pose `pmt`, then apply it at a decomposition `e = K[e']` pushing `K` into the
 postcondition via `iWpBindCore`. `premisesOut` gets the application's goals on success -/
 meta partial def iWpApplyCore {u} {GF : Q(BundledGFunctors.{0, 0, 0})} {hlc : Q(HasLC)}
@@ -488,26 +498,31 @@ meta partial def iWpApplyCore {u} {GF : Q(BundledGFunctors.{0, 0, 0})} {hlc : Q(
     (_hbi : $bi =Q UPred.instBIUPred := ⟨⟩)
     (κ : Q(Wp $prop Exp Val Stuckness) := q(wp.def)) (_hwp : $κ =Q wp.def := ⟨⟩) :
     ProofModeM Q($ehyps ⊢ Wp.wp $s $E $e $Φ) := do
-  let ⟨ehyps', hyps', p, A, posePf⟩ ← iHave hyps q(Wp.wp $s $E $e $Φ) pmt true
-  let mut st : ((ehyps' : Q($prop)) × Hyps bi ehyps' × (e' : Q(Exp)) ×
-    (Q(($ehyps' ∗ □?$p $A ⊢ Wp.wp $s $E $e' $Φ) → $ehyps ⊢ Wp.wp $s $E $e $Φ))) := ⟨_, hyps', e, posePf⟩
+  let mut st : @WpApplyState u GF hlc prop bi ehyps s E e Φ κ :=
+  { hypsC := hyps, eC := e,
+    prefixPf := q(fun (pf : $ehyps ⊢ @Wp.wp $prop Exp Val Stuckness $κ $s $E $e $Φ) => pf) }
+  let mut firstFailed : Option MessageData := none
   repeat
-    let ⟨ehyps', hyps', e', posePf⟩ := st
+    let ⟨hypsC, eC, prefixPf⟩ := st
+    let saved ← ProofModeM.saveState
+    let ⟨ehypsP, hypsP, p, A, posePf⟩ ← iHave hypsC q(Wp.wp $s $E $eC $Φ) pmt true
     let applied ←
-      findECtx (α := Q($ehyps' ∗ □?$p $A ⊢ Wp.wp $s $E $e' $Φ)) e' fun K e'' => do
-        trace[wp_apply] m!"trying to apply {A} to {e''}"
-        iWpBindCore _ ι s E e' Φ K e'' (iApply hyps' p A ·)
+      findECtx (α := Q($ehypsP ∗ □?$p $A ⊢ Wp.wp $s $E $eC $Φ)) eC fun K e' => do
+        trace[wp_apply] m!"trying to apply {A} to {e'}"
+        iWpBindCore _ ι s E eC Φ K e' (iApply hypsP p A ·)
     if let some {result := pf, ..} := applied then
-      return q($posePf $pf)
-    let failed ← addMessageContext m!"cannot apply {A}"
+      return q($prefixPf ($posePf $pf))
+    let failed := firstFailed.getD (← addMessageContext m!"cannot apply {A}")
+    firstFailed := some failed
     match wpApplyKind with
     | .apply => throwIPMError failed
     | .smartApply =>
+      saved.restore (restoreInfo := true)
       try
-        let ⟨_, hyps'', e'', pf⟩ ← iWpPure hyps ι s E e' Φ (failOnUnsolved := true) findAnyPureExec
-        let ⟨e''', pfeq⟩ ← iWpExprSimp e''
-        -- TODO: fill sorry
-        st := ⟨_, hyps'', e''', q(sorry)⟩
+        let ⟨_, hypsN, eN, purePf⟩ ←
+          iWpPure hypsC ι s E eC Φ (failOnUnsolved := true) findAnyPureExec
+        let ⟨eN', pfeq⟩ ← iWpExprSimp eN
+        st := ⟨hypsN, eN', q(fun pf => $prefixPf ($purePf (tac_wp_expr_simp pf $pfeq)))⟩
       catch err =>
         if err.isInterrupt || err.isMaxHeartbeat then throw err
         throwIPMError failed

--- a/Iris/Iris/HeapLang/ProofMode.lean
+++ b/Iris/Iris/HeapLang/ProofMode.lean
@@ -417,6 +417,149 @@ macro "wp_pair" : tactic => `(tactic | wp_pure ((_, _)))
 macro "wp_closure" : tactic => `(tactic | wp_pure (rec &_ &_ := _))
 macro "wp_match" : tactic => `(tactic | (wp_case; wp_closure; wp_lam))
 
+/-! ## The `wp_apply` tactics -/
+
+/-- use `A` directly if it matches `goal`, else eliminate its wands -/
+meta def iWpApplyHyp {u} {prop : Q(Type u)} {bi : Q(BI $prop)}
+    {e' : Q($prop)} (hyps : Hyps bi e') (p : Q(Bool)) (A : Q($prop)) (goal : Q($prop)) :
+    ProofModeM Q($e' ∗ □?$p $A ⊢ $goal) := do
+  if let some _ ← ProofModeM.trySynthInstanceQ q(FromAssumption $p .in $A $goal) then
+    let .some _ ← trySynthInstanceQ q(Std.TCOr (Affine $e') (Absorbing $goal))
+      | throwIPMError "the context {e'} is not affine and goal not absorbing"
+    return q(apply_assumption)
+  iApplyCore hyps p A goal
+
+/-- Pose `pmt`, then apply it at a decomposition `e = K[e']` pushing `K` into the
+postcondition via `tac_wp_bind`. `premisesOut` gets the application's goals on success -/
+meta def iWpApplyCore {u} {GF : Q(BundledGFunctors.{0, 0, 0})} {hlc : Q(HasLC)}
+    {prop : Q(Type u)} {bi : Q(BI $prop)} {ehyps : Q($prop)}
+    (hyps : Hyps bi ehyps) (ι : Q(IrisGS_gen $hlc Exp $GF)) (s : Q(Stuckness)) (E : Q(CoPset))
+    (e : Q(Exp)) (Φ : Q(Val → $prop)) (pmt : PMTerm)
+    (premisesOut : IO.Ref (Array MVarId × Array MVarId))
+    (_hu : QuotedLevelDefEq u 0 := ⟨⟩) (_hprop : $prop =Q IProp $GF := ⟨⟩)
+    (_hbi : $bi =Q UPred.instBIUPred := ⟨⟩)
+    (κ : Q(Wp $prop Exp Val Stuckness) := q(wp.def)) (_hwp : $κ =Q wp.def := ⟨⟩) :
+    ProofModeM Q($ehyps ⊢ Wp.wp $s $E $e $Φ) := do
+  let beforePose := (← get).goals.size
+  let ⟨eΔ, hyps', p, A, posePf⟩ ← iHave hyps q(Wp.wp $s $E $e $Φ) pmt true
+  let afterPose := (← get).goals.size
+  let some {result := pf, ..} ←
+    findECtxOutermost (α := Q($eΔ ∗ □?$p $A ⊢ Wp.wp $s $E $e $Φ)) e fun K e' => do
+      trace[wp_apply] m!"trying to apply {A} to {e'}"
+      match K with
+      | ~q([]) =>
+        let pf ← iWpApplyHyp hyps' p A q(Wp.wp $s $E $e' $Φ)
+        pure (pf : Lean.Expr)
+      | _ =>
+        let Φ' : Q(Val → IProp $GF) ←
+          Qq.withLocalDeclDQ `v q(Val) fun v => do
+            mkLambdaFVars #[v] <|
+              q(Wp.wp $s $E $(← HeapLang.fill K q(.ofVal $v)) $Φ)
+        have _ : $Φ' =Q (fun v : Val =>
+          Wp.wp (PROP := IProp $GF) $s $E (ProgramLogic.fill $K (v : Exp)) $Φ) := ⟨⟩
+        let pf ← iWpApplyHyp hyps' p A q(Wp.wp $s $E $e' $Φ')
+        pure (q(tac_wp_bind $pf) : Lean.Expr)
+    | throwIPMError "cannot apply {A}"
+  premisesOut.set ((← get).goals.extract afterPose, (← get).goals.extract beforePose afterPose)
+  return q($posePf $pf)
+
+/-- Strip a leading `▷` and simplify WP expressions, in the application's goals only -/
+meta def wpApplyPostPass (premises : Array MVarId) : TacticM (Array MVarId) := do
+  let post ← `(tactic| (try inext; try wp_expr_simp))
+  let mut out : Array MVarId := #[]
+  let mut produced : Array MVarId := #[]
+  for g in (← getGoals) do
+    if premises.contains g && !(← g.isAssigned) then
+      let new := (← Tactic.run g (evalTactic post)).toArray
+      out := out ++ new
+      produced := produced ++ new
+    else
+      out := out.push g
+  setGoals out.toList
+  return produced
+
+/-- Apply and post-pass, return the application's goals. Dependee mvars (a lemma's `?Φ`)
+are registered before the snapshot, so they stay out of `premises` despite sorting last. -/
+meta def runWpApply (tacName : Name) (pmt : PMTerm) :
+    TacticM (Array MVarId × Array MVarId) := do
+  let premises ← IO.mkRef ((#[], #[]) : Array MVarId × Array MVarId)
+  ProofModeM.runTacticWp tacName fun mvar {hyps, ι, s, E, e, Φ, ..} => do
+    mvar.assign (← iWpApplyCore hyps ι s E e Φ pmt premises)
+  let (application, specialisation) ← premises.get
+  return (← wpApplyPostPass application, specialisation)
+
+/-- Needed for `wp_apply ... with`. Introduce into the last goal the application produced,
+or a `$$` goal if it produced none. -/
+meta def wpApplyIntro (tacName : Name) (produced specialisation : Array MVarId)
+    (pats : Array (TSyntax `introPat)) : TacticM Unit := do
+  if pats.isEmpty then return
+  let fallback ← specialisation.filterM fun g => return !(← g.isAssigned)
+  let some last := produced.back? <|> fallback.back?
+    | throwError "{tacName}: no goal left for the `with` patterns"
+  let new ← Tactic.run last (evalTactic (← `(tactic| iintro $pats*)))
+  setGoals <| (← getGoals).flatMap fun g => if g == last then new else [g]
+
+/--
+`wp_apply lem` poses the lemma `lem`, whose conclusion must be a `WP e' ...`, and applies
+it to the goal `WP e ...` after binding an evaluation context `K` with `e = K[e']`.
+Premises of `lem` become new goals; a leading `▷` in a premise is stripped, and WP
+premises have their expression simplified. `wp_apply lem $$ pats` additionally
+specialises the premises of `lem` with the given specialisation patterns, and
+`wp_apply lem with %v Hv` introduces into the last goal the application produced.
+-/
+syntax (name := wpApply) "wp_apply " colGt pmTerm
+  (" with" (colGt ppSpace introPat)+)? : tactic
+
+elab_rules : tactic
+  | `(tactic| wp_apply $pmt:pmTerm $[with $pats*]?) => do
+    let (produced, spec) ← runWpApply `wp_apply (← liftMacroM <| PMTerm.parse pmt)
+    wpApplyIntro `wp_apply produced spec (pats.getD #[])
+
+/-- bound on `wp_smart_apply`'s pure steps. -/
+meta def smartApplyFuel : Nat := 10000
+
+/-- Retry the application after single pure steps, bounded. `with` runs after the loop:
+retrying a failed introduction would roll back an application that already succeeded. -/
+meta def runWpSmartApply (pmt : PMTerm) (pats : Array (TSyntax `introPat)) :
+    TacticM Unit := do
+  let mut firstErr : Option Exception := none
+  for _ in [0:smartApplyFuel] do
+    let s ← Tactic.saveState
+    let attempt ←
+      try
+        pure <| Sum.inl (← runWpApply `wp_smart_apply pmt)
+      catch e =>
+        -- an interrupt or heartbeat exhaustion is not a failed application: do not retry it
+        if e.isInterrupt || e.isMaxHeartbeat then throw e else pure (Sum.inr e)
+    match attempt with
+    | .inl (produced, spec) =>
+      wpApplyIntro `wp_smart_apply produced spec pats
+      return
+    | .inr applyErr =>
+      s.restore
+      -- report iteration 0's error: later ones concern goals the user never saw
+      let deadEndErr := firstErr.getD applyErr
+      firstErr := some deadEndErr
+      try evalTactic (← `(tactic| wp_pure_step))
+      catch _ =>
+        s.restore
+        throw deadEndErr
+  throwError "wp_smart_apply: fuel exhausted after {smartApplyFuel} pure steps"
+
+/--
+`wp_smart_apply lem` is like `wp_apply lem`, but when the lemma does not apply,
+it takes single pure steps (`wp_pure`) and retries, until the lemma applies or
+no pure step is possible. `$$` and `with` behave as for `wp_apply`. The retry is
+bounded under `smartApplyFuel` so the tactic does not diverge.
+-/
+syntax (name := wpSmartApply) "wp_smart_apply " colGt pmTerm
+  (" with" (colGt ppSpace introPat)+)? : tactic
+
+elab_rules : tactic
+  | `(tactic| wp_smart_apply $pmt:pmTerm $[with $pats*]?) => do
+    runWpSmartApply (← liftMacroM <| PMTerm.parse pmt) (pats.getD #[])
+
+
 /-! ## Tactic lemmas for the heap tactics -/
 
 /-- Hand out looked-up hypothesis and a wand that restores the context
@@ -944,6 +1087,7 @@ macro "wp_alloc" colGt ppSpace loc:binderIdent : tactic => `(tactic| wp_alloc $l
 -- `set_option trace.wp_bind true` (and analogously for the others).
 initialize registerTraceClass `wp_bind
 initialize registerTraceClass `wp_pure
+initialize registerTraceClass `wp_apply
 initialize registerTraceClass `wp_heap
 initialize registerTraceClass `wp_heap.redex (inherited := true)
 initialize registerTraceClass `wp_heap.lookup (inherited := true)

--- a/Iris/Iris/HeapLang/ProofMode.lean
+++ b/Iris/Iris/HeapLang/ProofMode.lean
@@ -405,17 +405,23 @@ public meta def iWpPure {u}
   let HΦ ← iSolveSidecondition φ (failOnUnsolved := failOnUnsolved)
   return q(tac_wp_pure $inst $HΦ $pf $nextPf)
 
+/-- Find any pure step for `e₁`, as `wp_pure _` does. -/
+public meta def findAnyPureExec (e₁ : Q(Exp)) :
+    ProofModeM ((φ : Q(Prop)) × (n : Q(Nat)) × (e₂ : Q(Exp)) ×
+      Q(ProgramLogic.Language.PureExec $φ $n $e₁ $e₂)) := do
+  let φ  ← mkFreshExprMVarQ q(Prop)
+  let n  ← mkFreshExprMVarQ q(Nat)
+  let e₂ ← mkFreshExprMVarQ q(Exp)
+  let some inst ← ProofModeM.trySynthInstanceQ q(ProgramLogic.Language.PureExec $φ $n $e₁ $e₂)
+    | failure
+  return ⟨φ, n, e₂, inst⟩
+
 elab "wp_pure" failOnUnsolved:("+!failOnUnsolved")? colGt ppSpace focus:hl_exp:10 : tactic =>
   ProofModeM.runTacticWp `wp_pure fun mvar {hyps, ι, s, E, e, Φ, ..} => do
     let focus ← elabTermEnsuringTypeQ (← `(hl($focus))) q(HeapLang.Exp)
     mvar.assign <| ← iWpPure hyps ι s E e Φ failOnUnsolved.isSome fun e₁ => do
       guard <| ← isDefEq e₁ focus
-      let φ ← mkFreshExprMVarQ q(Prop)
-      let n ← mkFreshExprMVarQ q(Nat)
-      let e₂ ← mkFreshExprMVarQ q(Exp)
-      let some inst ← ProofModeM.trySynthInstanceQ q(ProgramLogic.Language.PureExec $φ $n $e₁ $e₂)
-        | failure
-      return ⟨φ, n, e₂, inst⟩
+      findAnyPureExec e₁
 
 macro "wp_pure" : tactic => `(tactic| wp_pure _)
 macro "wp_pure" "+!failOnUnsolved" : tactic => `(tactic| wp_pure +!failOnUnsolved _)

--- a/Iris/Iris/HeapLang/ProofMode.lean
+++ b/Iris/Iris/HeapLang/ProofMode.lean
@@ -481,46 +481,15 @@ meta def iWpApplyCore {u} {GF : Q(BundledGFunctors.{0, 0, 0})} {hlc : Q(HasLC)}
   | throwIPMError "cannot apply {A}"
   return q($posePf $pf)
 
--- /-- Strip a leading `▷` and simplify WP expressions, in the application's goals only -/
--- meta def wpApplyPostPass (premises : Array MVarId) : TacticM (Array MVarId) := do
---   let post ← `(tactic| (try inext; try wp_expr_simp))
---   let mut out : Array MVarId := #[]
---   let mut produced : Array MVarId := #[]
---   for g in (← getGoals) do
---     if premises.contains g && !(← g.isAssigned) then
---       let new := (← Tactic.run g (evalTactic post)).toArray
---       out := out ++ new
---       produced := produced ++ new
---     else
---       out := out.push g
---   setGoals out.toList
---   return produced
-
--- /-- Apply and post-pass, return the application's goals. Dependee mvars (a lemma's `?Φ`)
--- are registered before the snapshot, so they stay out of `premises` despite sorting last. -/
--- meta def runWpApply (tacName : Name) (pmt : PMTerm) :
---     TacticM (Array MVarId × Array MVarId) := do
---   let premises ← IO.mkRef ((#[], #[]) : Array MVarId × Array MVarId)
---   ProofModeM.runTacticWp tacName fun mvar {hyps, ι, s, E, e, Φ, ..} => do
---     mvar.assign (← iWpApplyCore hyps ι s E e Φ pmt premises)
---   let (application, specialisation) ← premises.get
---   return (← wpApplyPostPass application, specialisation)
-
--- /-- Needed for `wp_apply ... with`. Introduce into the last goal the application produced,
--- or a `$$` goal if it produced none. -/
--- meta def wpApplyIntro (tacName : Name) (produced specialisation : Array MVarId)
---     (pats : Array (TSyntax `introPat)) : TacticM Unit := do
---   if pats.isEmpty then return
---   let fallback ← specialisation.filterM fun g => return !(← g.isAssigned)
---   let some last := produced.back? <|> fallback.back?
---     | throwError "{tacName}: no goal left for the `with` patterns"
---   let new ← Tactic.run last (evalTactic (← `(tactic| iintro $pats*)))
---   setGoals <| (← getGoals).flatMap fun g => if g == last then new else [g]
-
-elab "wp_apply_raw" colGt pmt:pmTerm : tactic => do
+meta def wpApplyRaw (tacName : Name) (pmt : TSyntax `pmTerm) : TacticM Unit := do
   let pmt ← liftMacroM <| PMTerm.parse pmt
-  ProofModeM.runTacticWp `wp_apply fun mvar {hyps, ι, s, E, e, Φ, ..} => do
-     mvar.assign (← iWpApplyCore hyps ι s E e Φ pmt)
+  ProofModeM.runTacticWp tacName fun mvar {hyps, ι, s, E, e, Φ, ..} => do
+    mvar.assign (← iWpApplyCore hyps ι s E e Φ pmt)
+
+elab "wp_apply_raw"       colGt pmt:pmTerm : tactic => wpApplyRaw `wp_apply pmt
+elab "wp_smart_apply_raw" colGt pmt:pmTerm : tactic => wpApplyRaw `wp_smart_apply pmt
+/-- Strip a leading `▷` and simplify WP expressions in the goals an application produced. -/
+macro "wp_apply_post" : tactic => `(tactic| ((try inext) <;> (try wp_expr_simp)))
 
 -- TODO: Is there a more efficient way to implement this?
 -- TODO: move this somewhere else
@@ -560,10 +529,10 @@ macro_rules
   | `(tactic| wp_apply $pmt:pmTerm $[with $pats*]?) => do
     let t : TSyntax `tactic ←
       if let some pats := pats then
-        `(tactic|focusLastIrisGoal (iintro $pats*))
+        `(tactic| focusLastIrisGoal (iintro $pats*))
       else
-        `(tactic|skip)
-    `(tactic| focus ((wp_apply_raw $pmt <;> (try inext) <;> (try wp_expr_simp)); $t:tactic))
+        `(tactic| skip)
+    `(tactic| focus (((wp_apply_raw $pmt) <;> wp_apply_post); $t:tactic))
 
 /-- bound on `wp_smart_apply`'s pure steps. -/
 meta def smartApplyFuel : Nat := 10000
@@ -604,10 +573,39 @@ bounded under `smartApplyFuel` so the tactic does not diverge.
 syntax (name := wpSmartApply) "wp_smart_apply " colGt pmTerm
   (" with" (colGt ppSpace introPat)+)? : tactic
 
-elab_rules : tactic
-  | `(tactic| wp_smart_apply $pmt:pmTerm $[with $pats*]?) => do
-    runWpSmartApply pmt (pats.getD #[])
+/-- Run `tac`; if it fails, take one pure step whose side condition is fully discharged and
+retry. Bounded by `smartApplyFuel`. The error reported is the one from the *first* attempt:
+later ones are about goals the user never wrote. -/
+elab "wp_retry_pure" colGt tac:tactic : tactic => do
+  let mut firstErr : Option Exception := none
+  for _ in [0:smartApplyFuel] do
+    let s ← Tactic.saveState
+    let err? ←
+      try
+        evalTactic tac
+        pure none
+      catch e =>
+        -- an interrupt or heartbeat exhaustion is not a failed application: do not retry it
+        if e.isInterrupt || e.isMaxHeartbeat then throw e else pure (some e)
+    match err? with
+    | none => return
+    | some attemptErr =>
+      s.restore
+      let deadEndErr := firstErr.getD attemptErr
+      firstErr := some deadEndErr
+      try evalTactic (← `(tactic| wp_pure +!failOnUnsolved))
+      catch _ =>
+        s.restore
+        throw deadEndErr
+  throwError "wp_retry_pure: fuel exhausted after {smartApplyFuel} pure steps"
 
+macro_rules
+  | `(tactic| wp_smart_apply $pmt:pmTerm $[with $pats*]?) => do
+    let t : TSyntax `tactic ←
+      if let some pats := pats then
+        `(tactic| focusLastIrisGoal (iintro $pats*))
+      else `(tactic| skip)
+    `(tactic| focus ((wp_retry_pure ((wp_smart_apply_raw $pmt) <;> wp_apply_post)); $t:tactic))
 
 /-! ## Tactic lemmas for the heap tactics -/
 

--- a/Iris/Iris/HeapLang/ProofMode.lean
+++ b/Iris/Iris/HeapLang/ProofMode.lean
@@ -500,11 +500,11 @@ meta partial def iWpApplyCore {u} {GF : Q(BundledGFunctors.{0, 0, 0})} {hlc : Q(
     ProofModeM Q($ehyps ⊢ Wp.wp $s $E $e $Φ) := do
   let ⟨_, hypsP, p, A, posePf⟩ ← iHave hyps q(Wp.wp $s $E $e $Φ) pmt true
   let lemIVar ← mkFreshIVarId (isTrue p)
-  let ⟨_, hyps0, addPf⟩ := Hyps.add bi `Hwp lemIVar p A hypsP
+  let ⟨_, hyps0, addPf⟩ := Hyps.add bi .anonymous lemIVar p A hypsP
   let mut st : @WpApplyState u GF hlc prop bi ehyps s E e Φ κ :=
     { hypsC := hyps0, eC := e,
       prefixPf := q(fun pf => $posePf ($(addPf).mp.trans pf)) }
-  let mut firstFailed : Option MessageData := none
+  let failed ← addMessageContext m!"cannot apply {A}"
   repeat
     let ⟨hypsC, eC, prefixPf⟩ := st
     let ⟨ehypsR, hypsR, _, A', p', _, remPf⟩ := Hyps.remove (rp := true) hypsC lemIVar
@@ -514,8 +514,6 @@ meta partial def iWpApplyCore {u} {GF : Q(BundledGFunctors.{0, 0, 0})} {hlc : Q(
         iWpBindCore _ ι s E eC Φ K e' (iApply hypsR p' A' ·)
     if let some {result := pf, ..} := applied then
       return q($prefixPf <| $(remPf).mp.trans $pf)
-    let failed := firstFailed.getD (← addMessageContext m!"cannot apply {A'}")
-    firstFailed := some failed
     match wpApplyKind with
     | .apply => throwIPMError failed
     | .smartApply =>
@@ -525,6 +523,7 @@ meta partial def iWpApplyCore {u} {GF : Q(BundledGFunctors.{0, 0, 0})} {hlc : Q(
         let ⟨eN', pfeq⟩ ← iWpExprSimp eN
         st := ⟨hypsN, eN', q(fun pf => $prefixPf ($purePf (tac_wp_expr_simp pf $pfeq)))⟩
       catch err =>
+        trace[wp_apply] "Error: {err.toMessageData}"
         if err.isInterrupt || err.isMaxHeartbeat then throw err
         throwIPMError failed
 
@@ -541,34 +540,14 @@ elab "wp_smart_apply_raw" colGt pmt:pmTerm : tactic =>
 /-- Strip a leading `▷` and simplify WP expressions in the goals an application produced. -/
 macro "wp_apply_post" : tactic => `(tactic| ((try inext) <;> (try wp_expr_simp)))
 
--- TODO: Is there a more efficient way to implement this?
--- TODO: move this somewhere else
-elab "focusLastIrisGoal" colGt tac:tactic : tactic => do
-  let goals ← getUnsolvedGoals
-  let mut goals_before := []
-  let mut iris_goal := []
-  let mut goals_after := []
-  for g in goals do
-    if isIrisGoal (← g.getType) then
-      goals_before := goals_before ++ iris_goal ++ goals_after
-      iris_goal := [g]
-      goals_after := []
-    else
-      goals_after := goals_after ++ [g]
-  let [g] := iris_goal
-    | throwError "no remaining Iris goal"
-  setGoals [g]
-  evalTactic tac
-  let goals' ← getUnsolvedGoals
-  setGoals (goals_before ++ goals' ++ goals_after)
-
 /--
 `wp_apply lem` poses the lemma `lem`, whose conclusion must be a `WP e' ...`, and applies
 it to the goal `WP e ...` after binding an evaluation context `K` with `e = K[e']`.
 Premises of `lem` become new goals; a leading `▷` in a premise is stripped, and WP
 premises have their expression simplified. `wp_apply lem $$ pats` additionally
 specialises the premises of `lem` with the given specialisation patterns, and
-`wp_apply lem with %v Hv` introduces into the last goal the application produced.
+`wp_apply lem with introPats` introduces the intro patterns introPats in the last Iris goal
+after applying the lemma.
 -/
 syntax (name := wpApply) "wp_apply " colGt pmTerm
   (" with" (colGt ppSpace introPat)+)? : tactic
@@ -585,8 +564,7 @@ macro_rules
 /--
 `wp_smart_apply lem` is like `wp_apply lem`, but when the lemma does not apply,
 it takes single pure steps (`wp_pure`) and retries, until the lemma applies or
-no pure step is possible. `$$` and `with` behave as for `wp_apply`. The retry is
-bounded under `smartApplyFuel` so the tactic does not diverge.
+no pure step is possible. `$$` and `with` behave as for `wp_apply`.
 -/
 syntax (name := wpSmartApply) "wp_smart_apply " colGt pmTerm
   (" with" (colGt ppSpace introPat)+)? : tactic

--- a/Iris/Iris/HeapLang/ProofMode.lean
+++ b/Iris/Iris/HeapLang/ProofMode.lean
@@ -392,12 +392,9 @@ public meta def iWpPure {u}
     (_hprop : $prop =Q IProp $GF := ⟨⟩)
     (_hbi : $bi =Q UPred.instBIUPred := ⟨⟩)
     (κ : Q(Wp $prop Exp Val Stuckness) := q(wp.def))
-    (_hwp : $κ =Q wp.def := ⟨⟩)
-    -- The continuation function: using `iWpFinish` by default
-    (k : {eΔ : Q($prop)} → Hyps bi eΔ → (e' : Q(Exp)) →
-          ProofModeM Q($eΔ ⊢ Wp.wp $s $E $e' $Φ) :=
-      fun hyps' e' => iWpFinish hyps' ι s E e' Φ) :
-      ProofModeM (Q($ehyps ⊢ Wp.wp $s $E $e $Φ)) := do
+    (_hwp : $κ =Q wp.def := ⟨⟩) :
+      ProofModeM ((ehyps' : Q($prop)) × Hyps bi ehyps' × (e' : Q(Exp)) ×
+      (Q(($ehyps' ⊢ Wp.wp $s $E $e' $Φ) → $ehyps ⊢ Wp.wp $s $E $e $Φ))) := do
   let some {result := ⟨φ, n, e₂, inst⟩, K, e' := e₁, ..} ←
     findECtx (α:=((_ : Q(Prop)) × (_ : Q(Nat)) × (_ : Q(Exp)) × Lean.Expr)) e fun _ => findPureExec
   | throwIPMError "Cannot find expression to evaluate"
@@ -406,8 +403,7 @@ public meta def iWpPure {u}
   let ⟨_, hyps', pf⟩ ← iModAction hyps q(modality_laterN $n)
   let ⟨inner, .up _⟩ ← HeapLang.fillQ K e₂
   let HΦ ← iSolveSidecondition φ (failOnUnsolved := failOnUnsolved)
-  let nextPf ← k hyps' inner
-  return q(tac_wp_pure $inst $HΦ $pf $nextPf)
+  return ⟨_, hyps', inner, q(fun nextPf => tac_wp_pure $inst $HΦ $pf nextPf)⟩
 
 /-- Find any pure step for `e₁`, as `wp_pure _` does. -/
 public meta def findAnyPureExec (e₁ : Q(Exp)) :
@@ -423,9 +419,11 @@ public meta def findAnyPureExec (e₁ : Q(Exp)) :
 elab "wp_pure" failOnUnsolved:("+!failOnUnsolved")? colGt ppSpace focus:hl_exp:10 : tactic =>
   ProofModeM.runTacticWp `wp_pure fun mvar {hyps, ι, s, E, e, Φ, ..} => do
     let focus ← elabTermEnsuringTypeQ (← `(hl($focus))) q(HeapLang.Exp)
-    mvar.assign <| ← iWpPure hyps ι s E e Φ failOnUnsolved.isSome fun e₁ => do
+    let ⟨_, hyps', e', pf⟩ ← iWpPure hyps ι s E e Φ failOnUnsolved.isSome fun e₁ => do
       guard <| ← isDefEq e₁ focus
       findAnyPureExec e₁
+    let pf' ← iWpFinish hyps' ι s E e' Φ
+    mvar.assign <| q($pf $pf')
 
 macro "wp_pure" : tactic => `(tactic| wp_pure _)
 macro "wp_pure" "+!failOnUnsolved" : tactic => `(tactic| wp_pure +!failOnUnsolved _)
@@ -443,7 +441,7 @@ macro "wp_pures" : tactic =>
 /-- Beta-reduce the innermost application, unfolding a head hidden behind a definition. -/
 elab "wp_rec" : tactic =>
   ProofModeM.runTacticWp `wp_rec fun mvar {hyps, ι, s, E, e, Φ, ..} => do
-    mvar.assign <| ← iWpPure hyps ι s E e Φ (failOnUnsolved := false) fun e₁ => do
+    let ⟨_, hyps', e', pf⟩ ← iWpPure hyps ι s E e Φ (failOnUnsolved := false) fun e₁ => do
       let ~q(Exp.app (Exp.ofVal $f) (Exp.ofVal $a)) := e₁ | failure
       -- reduce `f` to find a recursive function
       let f' : Q(Val) ← whnf f
@@ -452,6 +450,8 @@ elab "wp_rec" : tactic =>
       -- substitute the folded head `f`, not the unfolded `Val.rec_`
       let e₂ := q(Exp.subst $xb $a (Exp.subst $fb $f $body))
       return ⟨_, _, e₂, q(instPureExecBeta)⟩
+    let pf' ← iWpFinish hyps' ι s E e' Φ
+    mvar.assign <| q($pf $pf')
 
 
 macro "wp_if" : tactic => `(tactic | wp_pure (if _ then _ else _))
@@ -473,16 +473,10 @@ macro "wp_match" : tactic => `(tactic | (wp_case; wp_closure; wp_pure (_ _)))
 
 /-! ## The `wp_apply` tactics -/
 
-/--
-  Indicates whether `wp_apply` or `wp_smart_apply` is used.
-  For `wp_smart_apply`, also include the fuel amount, that is, the number of retries.
--/
+/-- Indicates whether `wp_apply` or `wp_smart_apply` is used. -/
 inductive WpApplyKind where
   | apply
-  | smartApply (fuel : Nat)
-
-/-- bound on `wp_smart_apply`'s pure steps. -/
-meta def smartApplyFuel : Nat := 10000
+  | smartApply
 
 /-- Pose `pmt`, then apply it at a decomposition `e = K[e']` pushing `K` into the
 postcondition via `iWpBindCore`. `premisesOut` gets the application's goals on success -/
@@ -494,28 +488,29 @@ meta partial def iWpApplyCore {u} {GF : Q(BundledGFunctors.{0, 0, 0})} {hlc : Q(
     (_hbi : $bi =Q UPred.instBIUPred := ⟨⟩)
     (κ : Q(Wp $prop Exp Val Stuckness) := q(wp.def)) (_hwp : $κ =Q wp.def := ⟨⟩) :
     ProofModeM Q($ehyps ⊢ Wp.wp $s $E $e $Φ) := do
-  let st ← ProofModeM.saveState
-  let ⟨eΔ, hyps', p, A, posePf⟩ ← iHave hyps q(Wp.wp $s $E $e $Φ) pmt true
-  let applied ←
-    findECtx (α := Q($eΔ ∗ □?$p $A ⊢ Wp.wp $s $E $e $Φ)) e fun K e' => do
-      trace[wp_apply] m!"trying to apply {A} to {e'}"
-      iWpBindCore _ ι s E e Φ K e' (iApply hyps' p A ·)
-  if let some {result := pf, ..} := applied then
-    return q($posePf $pf)
-  let failed ← addMessageContext m!"cannot apply {A}"
-  match wpApplyKind with
-  | .apply => throwIPMError failed
-  | .smartApply 0 =>
-    throwIPMError m!"fuel exhausted after {smartApplyFuel} pure steps; {failed}"
-  | .smartApply (fuel + 1) =>
-    st.restore (restoreInfo := true)
-    try
-      iWpPure hyps ι s E e Φ (failOnUnsolved := true) findAnyPureExec
-        (k := fun hyps'' e'' => iWpApplyCore hyps'' ι s E e'' Φ pmt (.smartApply fuel))
-    catch err =>
-      if err.isInterrupt || err.isMaxHeartbeat then throw err
-      st.restore (restoreInfo := true)
-      throwIPMError failed
+  let ⟨ehyps', hyps', p, A, posePf⟩ ← iHave hyps q(Wp.wp $s $E $e $Φ) pmt true
+  let mut st : ((ehyps' : Q($prop)) × Hyps bi ehyps' × (e' : Q(Exp)) ×
+    (Q(($ehyps' ∗ □?$p $A ⊢ Wp.wp $s $E $e' $Φ) → $ehyps ⊢ Wp.wp $s $E $e $Φ))) := ⟨_, hyps', e, posePf⟩
+  repeat
+    let ⟨ehyps', hyps', e', posePf⟩ := st
+    let applied ←
+      findECtx (α := Q($ehyps' ∗ □?$p $A ⊢ Wp.wp $s $E $e' $Φ)) e' fun K e'' => do
+        trace[wp_apply] m!"trying to apply {A} to {e''}"
+        iWpBindCore _ ι s E e' Φ K e'' (iApply hyps' p A ·)
+    if let some {result := pf, ..} := applied then
+      return q($posePf $pf)
+    let failed ← addMessageContext m!"cannot apply {A}"
+    match wpApplyKind with
+    | .apply => throwIPMError failed
+    | .smartApply =>
+      try
+        let ⟨_, hyps'', e'', pf⟩ ← iWpPure hyps ι s E e' Φ (failOnUnsolved := true) findAnyPureExec
+        let ⟨e''', pfeq⟩ ← iWpExprSimp e''
+        -- TODO: fill sorry
+        st := ⟨_, hyps'', e''', q(sorry)⟩
+      catch err =>
+        if err.isInterrupt || err.isMaxHeartbeat then throw err
+        throwIPMError failed
 
 meta def wpApplyRaw (tacName : Name) (wpApplyKind : WpApplyKind) (pmt : TSyntax `pmTerm) :
     TacticM Unit := do
@@ -526,7 +521,7 @@ meta def wpApplyRaw (tacName : Name) (wpApplyKind : WpApplyKind) (pmt : TSyntax 
 elab "wp_apply_raw" colGt pmt:pmTerm : tactic =>
   wpApplyRaw `wp_apply .apply pmt
 elab "wp_smart_apply_raw" colGt pmt:pmTerm : tactic =>
-  wpApplyRaw `wp_smart_apply (.smartApply smartApplyFuel) pmt
+  wpApplyRaw `wp_smart_apply .smartApply pmt
 /-- Strip a leading `▷` and simplify WP expressions in the goals an application produced. -/
 macro "wp_apply_post" : tactic => `(tactic| ((try inext) <;> (try wp_expr_simp)))
 
@@ -551,8 +546,6 @@ elab "focusLastIrisGoal" colGt tac:tactic : tactic => do
   let goals' ← getUnsolvedGoals
   setGoals (goals_before ++ goals' ++ goals_after)
 
-
-
 /--
 `wp_apply lem` poses the lemma `lem`, whose conclusion must be a `WP e' ...`, and applies
 it to the goal `WP e ...` after binding an evaluation context `K` with `e = K[e']`.
@@ -572,33 +565,6 @@ macro_rules
       else
         `(tactic| skip)
     `(tactic| focus (((wp_apply_raw $pmt) <;> wp_apply_post); $t:tactic))
-
-/-- Retry the application after single pure steps, bounded. `with` runs after the loop:
-retrying a failed introduction would roll back an application that already succeeded. -/
-meta def runWpSmartApply (pmt : TSyntax `pmTerm) (_pats : Array (TSyntax `introPat)) :
-    TacticM Unit := do
-  let mut firstErr : Option Exception := none
-  for _ in [0:smartApplyFuel] do
-    let s ← Tactic.saveState
-    let attempt ←
-      try
-        pure <| Sum.inl (← evalTactic (← `(tactic| wp_apply_raw $pmt)))
-      catch e =>
-        pure (Sum.inr e)
-    match attempt with
-    | .inl _ =>
-      -- wpApplyIntro `wp_smart_apply produced spec pats
-      return
-    | .inr applyErr =>
-      s.restore
-      -- report iteration 0's error: later ones concern goals the user never saw
-      let deadEndErr := firstErr.getD applyErr
-      firstErr := some deadEndErr
-      try evalTactic (← `(tactic| wp_pure +!failOnUnsolved))
-      catch _ =>
-        s.restore
-        throw deadEndErr
-  throwError "wp_smart_apply: fuel exhausted after {smartApplyFuel} pure steps"
 
 /--
 `wp_smart_apply lem` is like `wp_apply lem`, but when the lemma does not apply,

--- a/Iris/Iris/HeapLang/ProofMode.lean
+++ b/Iris/Iris/HeapLang/ProofMode.lean
@@ -498,26 +498,27 @@ meta partial def iWpApplyCore {u} {GF : Q(BundledGFunctors.{0, 0, 0})} {hlc : Q(
     (_hbi : $bi =Q UPred.instBIUPred := ⟨⟩)
     (κ : Q(Wp $prop Exp Val Stuckness) := q(wp.def)) (_hwp : $κ =Q wp.def := ⟨⟩) :
     ProofModeM Q($ehyps ⊢ Wp.wp $s $E $e $Φ) := do
+  let ⟨_, hypsP, p, A, posePf⟩ ← iHave hyps q(Wp.wp $s $E $e $Φ) pmt true
+  let lemIVar ← mkFreshIVarId (isTrue p)
+  let ⟨_, hyps0, addPf⟩ := Hyps.add bi `Hwp lemIVar p A hypsP
   let mut st : @WpApplyState u GF hlc prop bi ehyps s E e Φ κ :=
-  { hypsC := hyps, eC := e,
-    prefixPf := q(fun (pf : $ehyps ⊢ @Wp.wp $prop Exp Val Stuckness $κ $s $E $e $Φ) => pf) }
+    { hypsC := hyps0, eC := e,
+      prefixPf := q(fun pf => $posePf ($(addPf).mp.trans pf)) }
   let mut firstFailed : Option MessageData := none
   repeat
     let ⟨hypsC, eC, prefixPf⟩ := st
-    let saved ← ProofModeM.saveState
-    let ⟨ehypsP, hypsP, p, A, posePf⟩ ← iHave hypsC q(Wp.wp $s $E $eC $Φ) pmt true
+    let ⟨ehypsR, hypsR, _, A', p', _, remPf⟩ := Hyps.remove (rp := true) hypsC lemIVar
     let applied ←
-      findECtx (α := Q($ehypsP ∗ □?$p $A ⊢ Wp.wp $s $E $eC $Φ)) eC fun K e' => do
-        trace[wp_apply] m!"trying to apply {A} to {e'}"
-        iWpBindCore _ ι s E eC Φ K e' (iApply hypsP p A ·)
+      findECtx (α := Q($ehypsR ∗ □?$p' $A' ⊢ Wp.wp $s $E $eC $Φ)) eC fun K e' => do
+        trace[wp_apply] m!"trying to apply {A'} to {e'}"
+        iWpBindCore _ ι s E eC Φ K e' (iApply hypsR p' A' ·)
     if let some {result := pf, ..} := applied then
-      return q($prefixPf ($posePf $pf))
-    let failed := firstFailed.getD (← addMessageContext m!"cannot apply {A}")
+      return q($prefixPf <| $(remPf).mp.trans $pf)
+    let failed := firstFailed.getD (← addMessageContext m!"cannot apply {A'}")
     firstFailed := some failed
     match wpApplyKind with
     | .apply => throwIPMError failed
     | .smartApply =>
-      saved.restore (restoreInfo := true)
       try
         let ⟨_, hypsN, eN, purePf⟩ ←
           iWpPure hypsC ι s E eC Φ (failOnUnsolved := true) findAnyPureExec

--- a/Iris/Iris/HeapLang/ProofMode.lean
+++ b/Iris/Iris/HeapLang/ProofMode.lean
@@ -511,7 +511,10 @@ meta partial def iWpApplyCore {u} {GF : Q(BundledGFunctors.{0, 0, 0})} {hlc : Q(
     st.restore (restoreInfo := true)
     try
       iWpPure hyps ι s E e Φ (failOnUnsolved := true) findAnyPureExec
-        (k := fun hyps'' e'' => iWpApplyCore hyps'' ι s E e'' Φ pmt (.smartApply fuel))
+        (k := fun hyps'' e'' => do
+          let ⟨e₃, pfeq⟩ ← iWpExprSimp e''
+          let pf ← iWpApplyCore hyps'' ι s E e₃ Φ pmt (.smartApply fuel)
+          return q(tac_wp_expr_simp $pf $pfeq))
     catch err =>
       if err.isInterrupt || err.isMaxHeartbeat then throw err
       st.restore (restoreInfo := true)

--- a/Iris/Iris/HeapLang/Tactic.lean
+++ b/Iris/Iris/HeapLang/Tactic.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Fernando Leal, Klaus Kraßnitzer. All rights reserved.
+Copyright (c) 2026 Fernando Leal. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Fernando Leal, Klaus Kraßnitzer
 -/
@@ -57,13 +57,6 @@ where
   | e =>
     extractEctxItem e
 
-public meta partial
-def extractAllEctxItems (e : Q(Exp)) (acc : List Q(ECtxItem) := []) : MetaM (List Q(ECtxItem) × Q(Exp)) := do
-  match ← extractEctxItem e with
-  | (.some Ki, e') => extractAllEctxItems e' (Ki :: acc)
-  | (.none, e) => return (acc, e)
-
-
 open ECtxItem in
 meta partial
 def fillItem (e : Q(Exp)) : Q(ECtxItem) → MetaM Q(Exp)
@@ -119,20 +112,7 @@ structure ECtxResultOf (e : Q(Exp)) (α : Type) where unsafeMk ::
   e' : Q(Exp)
   heq : ProgramLogic.fill $K $e' =Q $e := ⟨⟩
 
-public meta partial
-def findECtx {α : Type _} (ogE : Q(Exp)) (pred : Q(Exp) → ProofModeM α)
-  : ProofModeM (Option (ECtxResultOf ogE α)) := do
-  let (Kis, inner) ← extractAllEctxItems ogE
-  go inner Kis
-where
-  go (e : Q(Exp)) (Kis : List Q(ECtxItem)) : ProofModeM (Option (ECtxResultOf ogE α)) := do
-    if let some a ← observing? <| pred e then
-      return some {result := a, K := quoteList Kis, e' := e}
-    let Ki :: Kis' := Kis | return none
-    go (← fillItem e Ki) Kis'
-
-/-- Like `findECtx`, but outermost-first, and passes the evaluation context to `pred`. -/
-public meta partial def findECtxOutermost {α : Type _} (ogE : Q(Exp))
+public meta partial def findECtx {α : Type _} (ogE : Q(Exp))
     (pred : Q(List ECtxItem) → Q(Exp) → ProofModeM α) :
     ProofModeM (Option (ECtxResultOf ogE α)) :=
   go ogE []

--- a/Iris/Iris/HeapLang/Tactic.lean
+++ b/Iris/Iris/HeapLang/Tactic.lean
@@ -1,6 +1,7 @@
 /-
-Copyright (c) 2026 Fernando Leal. All rights reserved.
+Copyright (c) 2026 Fernando Leal, Klaus Kraßnitzer. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Fernando Leal, Klaus Kraßnitzer
 -/
 module
 
@@ -129,3 +130,16 @@ where
       return some {result := a, K := quoteList Kis, e' := e}
     let Ki :: Kis' := Kis | return none
     go (← fillItem e Ki) Kis'
+
+/-- Like `findECtx`, but outermost-first, and passes the evaluation context to `pred`. -/
+public meta partial def findECtxOutermost {α : Type _} (ogE : Q(Exp))
+    (pred : Q(List ECtxItem) → Q(Exp) → ProofModeM α) :
+    ProofModeM (Option (ECtxResultOf ogE α)) :=
+  go ogE []
+where
+  go (e : Q(Exp)) (acc : List Q(ECtxItem)) : ProofModeM (Option (ECtxResultOf ogE α)) := do
+    let K := quoteList acc
+    if let some a ← observing? <| pred K e then
+      return some {result := a, K, e' := e}
+    let (some Ki, e') ← extractEctxItem e | return none
+    go e' (Ki :: acc)

--- a/Iris/Iris/ProofMode/Tactics/Apply.lean
+++ b/Iris/Iris/ProofMode/Tactics/Apply.lean
@@ -38,7 +38,7 @@ Apply a hypothesis `A` to the `goal` by eliminating the wands recursively
 ## Returns
 The proof of `hyps ∗ □?p A ⊢ goal`
 -/
-private partial def iApplyCore {prop : Q(Type u)} {bi : Q(BI $prop)} {e}
+partial def iApplyCore {prop : Q(Type u)} {bi : Q(BI $prop)} {e}
     (hyps : Hyps bi e) (p : Q(Bool)) (A : Q($prop)) (goal : Q($prop)) :
     ProofModeM Q($e ∗ □?$p $A ⊢ $goal) := do
   let B ← mkFreshExprMVarQ q($prop)

--- a/Iris/Iris/ProofMode/Tactics/Apply.lean
+++ b/Iris/Iris/ProofMode/Tactics/Apply.lean
@@ -28,17 +28,7 @@ theorem apply_assumption [BI PROP] {p : Bool} {P A Q : PROP}
     P ∗ □?p A ⊢ Q :=
   (sep_mono_right inst.from_assumption).trans sep_elim_right
 
-/--
-Apply a hypothesis `A` to the `goal` by eliminating the wands recursively
-
-## Parameters
-- `hyps`: The current proof mode hypothesis context
-- `p`: Persistence flag for `A`
-
-## Returns
-The proof of `hyps ∗ □?p A ⊢ goal`
--/
-partial def iApplyCore {prop : Q(Type u)} {bi : Q(BI $prop)} {e}
+private partial def iApplyCore {prop : Q(Type u)} {bi : Q(BI $prop)} {e}
     (hyps : Hyps bi e) (p : Q(Bool)) (A : Q($prop)) (goal : Q($prop)) :
     ProofModeM Q($e ∗ □?$p $A ⊢ $goal) := do
   let B ← mkFreshExprMVarQ q($prop)
@@ -53,6 +43,20 @@ partial def iApplyCore {prop : Q(Type u)} {bi : Q(BI $prop)} {e}
     | throwIPMError "cannot apply {A} to {goal}"
   let pf' ← iApplyCore hyps' pb B goal
   return q($pf $pf')
+
+
+/-- Apply a hypothesis `A` to the `goal` by eliminating the wands recursively. -/
+def iApply {prop : Q(Type u)} {bi : Q(BI $prop)} {e}
+    (hyps : Hyps bi e) (p : Q(Bool)) (A : Q($prop)) (goal : Q($prop)) :
+    ProofModeM Q($e ∗ □?$p $A ⊢ $goal) := do
+  -- if `□?p A` directly matches goal, behave like `iexact`
+  if let some _ ← ProofModeM.trySynthInstanceQ q(FromAssumption $p .in $A $goal) then
+    -- ensure the context can be discarded
+    let .some _ ← trySynthInstanceQ q(TCOr (Affine $e) (Absorbing $goal))
+      | throwIPMError "the context {e} is not affine and goal not absorbing"
+    return q(apply_assumption)
+  -- otherwise, `A` should be a wand, handled by `iApplyCore`
+  iApplyCore hyps p A goal
 
 /--
   `iapply pmt` matches the conclusion of `pmt : pmTerm` against the goal and
@@ -70,14 +74,6 @@ elab "iapply " colGt pmt:pmTerm : tactic => do
   let pmt ← liftMacroM <| PMTerm.parse pmt
   ProofModeM.runTactic `iapply λ mvar { hyps, goal, .. } => do
   -- elaborate the proof mode term `pmt` to the hypothesis `out`
-  let ⟨e, hyps', p, out, pf⟩ ← iHave hyps goal pmt true
-  -- if `□?p out` directly matches goal, behave like `iexact`
-  if let some _ ← ProofModeM.trySynthInstanceQ q(FromAssumption $p .in $out $goal) then
-    -- ensure the context can be discarded
-    let .some _ ← trySynthInstanceQ q(TCOr (Affine $e) (Absorbing $goal))
-      | throwIPMError "the context {e} is not affine and goal not absorbing"
-    mvar.assign q($pf apply_assumption)
-    return
-  -- otherwise, `out` should be a wand, handled by `iApplyCore`
-  let pf' ← iApplyCore hyps' p out goal
+  let ⟨_, hyps', p, out, pf⟩ ← iHave hyps goal pmt true
+  let pf' ← iApply hyps' p out goal
   mvar.assign q($pf $pf')

--- a/Iris/Iris/ProofMode/Tactics/Basic.lean
+++ b/Iris/Iris/ProofMode/Tactics/Basic.lean
@@ -57,3 +57,23 @@ elab "istop" : tactic => do
     -- check if already in proof mode
     let some irisGoal := parseIrisGoal? goal | throwError "istop: not in proof mode"
     mvar.setType irisGoal.strip
+
+-- TODO: Is there a more efficient way to implement this?
+elab "focusLastIrisGoal" colGt tac:tactic : tactic => do
+  let goals ← getUnsolvedGoals
+  let mut goals_before := []
+  let mut iris_goal := []
+  let mut goals_after := []
+  for g in goals do
+    if isIrisGoal (← g.getType) then
+      goals_before := goals_before ++ iris_goal ++ goals_after
+      iris_goal := [g]
+      goals_after := []
+    else
+      goals_after := goals_after ++ [g]
+  let [g] := iris_goal
+    | throwError "no remaining Iris goal"
+  setGoals [g]
+  evalTactic tac
+  let goals' ← getUnsolvedGoals
+  setGoals (goals_before ++ goals' ++ goals_after)

--- a/Iris/IrisTest/HeapLang.lean
+++ b/Iris/IrisTest/HeapLang.lean
@@ -4,6 +4,7 @@ public import IrisTest.HeapLang.Linter
 public import IrisTest.HeapLang.Notation
 public import IrisTest.HeapLang.WeakestPre
 public import IrisTest.HeapLang.HeapTactics
+public import IrisTest.HeapLang.Apply
 public import IrisTest.HeapLang.Linter
 public import IrisTest.HeapLang.Par
 public import IrisTest.HeapLang.Tactics

--- a/Iris/IrisTest/HeapLang/Apply.lean
+++ b/Iris/IrisTest/HeapLang/Apply.lean
@@ -56,8 +56,7 @@ example {l : Loc} {v : Val} : ⊢@{IProp GF}
   itrivial
 
 -- application under an evaluation context
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF : BundledGFunctors
 inst✝ : HeapLangGS hlc GF
@@ -66,11 +65,12 @@ n : Int
 ⊢
   ⊢ l ↦ some hl_val(#n) -∗ WP hl((#n + #1)) {{ w, ⌜w = hl_val(#(n + 1))⌝ }}
 -/
-#guard_msgs (whitespace := lax) in
+#guard_msgs (trace, drop all, whitespace := lax) in
 example {l : Loc} {n : Int} : ⊢@{IProp GF}
     l ↦ some hl_val(#n) -∗ WP hl(!v(#l) + #1) {{ w, ⌜w = hl_val(#(n + 1 : Int))⌝ }} := by
   iintro Hpt
   wp_apply wp_load $$ Hpt
+  trace_state
 
 -- wp_smart_apply takes pure steps until the lemma applies
 example {l : Loc} {v : Val} : ⊢@{IProp GF}
@@ -103,8 +103,7 @@ example {l : Loc} {Φ : Val → IProp GF} : ⊢@{IProp GF}
   wp_apply H
 
 -- the post-pass must not reach a sibling goal
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF : BundledGFunctors
 inst✝ : HeapLangGS hlc GF
@@ -124,26 +123,27 @@ P : IProp GF
   ∗HP : ▷ P
   ⊢ ▷ P
 -/
-#guard_msgs (whitespace := lax) in
+#guard_msgs (trace, drop all, whitespace := lax) in
 example {l : Loc} {v : Val} {P : IProp GF} : ⊢@{IProp GF}
     ▷ P ∗ (l ↦ some v) -∗ WP hl(!v(#l)) {{ w, ⌜w = v⌝ }} ∗ (▷ P) := by
   iintro ⟨HP, Hpt⟩
   isplitl [Hpt]
   wp_apply wp_load $$ Hpt
+  trace_state
 
 -- also goals that are part of the specialization pattern have ▷ stripped
 -- (this differs from Rocq)
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF : BundledGFunctors
 inst✝ : HeapLangGS hlc GF
 ⊢
   ⊢ WP hl((#2 + #1)) {{ v, ⌜v = hl_val(#3)⌝ }}
 -/
-#guard_msgs (whitespace := lax) in
+#guard_msgs (trace, drop all, whitespace := lax) in
 example : ⊢@{IProp GF} WP hl(v(λ x, x + #1) #2) {{ v, ⌜v = hl_val(#3)⌝ }} := by
   wp_apply beta_spec $$ []
+  trace_state
 
 -- `wp_smart_apply` taking more than one pure step before the lemma applies
 example {l : Loc} {v : Val} : ⊢@{IProp GF}
@@ -155,8 +155,7 @@ example {l : Loc} {v : Val} : ⊢@{IProp GF}
   itrivial
 
 -- the post-pass runs once, in the successful iteration: `▷ ▷` loses exactly one `▷`
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF : BundledGFunctors
 inst✝ : HeapLangGS hlc GF
@@ -166,11 +165,12 @@ H : ▷ ▷ P ⊢ WP hl((v(λ x, (x + #1))) #2) {{ Φ }}
 ⊢
   ⊢ ▷ P
 -/
-#guard_msgs (whitespace := lax) in
+#guard_msgs (trace, drop all, whitespace := lax) in
 example {P : IProp GF} {Φ : Val → IProp GF}
     (H : ▷ ▷ P ⊢ WP hl(v(λ x, x + #1) #2) {{ Φ }}) : ⊢@{IProp GF}
     WP hl(if #true then ((λ x, x + #1) #2) else #0) {{ Φ }} := by
   wp_smart_apply H
+  trace_state
 
 -- out of pure steps: the error is about the original goal, not a mid-reduction one
 /--
@@ -185,8 +185,7 @@ example {l : Loc} {v : Val} : ⊢@{IProp GF}
 -- `wp_wand` is polymorphic in expression and postcondition, so every decomposition
 -- unifies and only the order decides: outermost leaves the expression the caller wrote,
 -- innermost would return a goal about `#l`.
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF : BundledGFunctors
 inst✝ : HeapLangGS hlc GF
@@ -210,10 +209,11 @@ l : Loc
 Φ : Val → IProp GF
 ⊢ Val → IProp GF
 -/
-#guard_msgs (whitespace := lax) in
+#guard_msgs (trace, drop all, whitespace := lax) in
 example {l : Loc} {Φ : Val → IProp GF} : ⊢@{IProp GF}
     WP hl(!v(#l) + #1) {{ Φ }} := by
   wp_apply wp_wand
+  trace_state
 
 -- the same, instrumented: the leftover premise records which decomposition was picked
 example {l : Loc} {Φ : Val → IProp GF} : ⊢@{IProp GF}
@@ -239,8 +239,7 @@ example {l : Loc} {Φ Ψ : Val → IProp GF} : ⊢@{IProp GF}
   iapply HΦ $$ Hw
 
 -- it targets the last goal the application produced, leaving the others untouched
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF : BundledGFunctors
 inst✝ : HeapLangGS hlc GF
@@ -261,16 +260,16 @@ w : Val
   ∗Hw : ⌜w = v⌝
   ⊢ Φ w
 -/
-#guard_msgs (whitespace := lax) in
+#guard_msgs (trace, drop all, whitespace := lax) in
 example {l : Loc} {v : Val} {Φ : Val → IProp GF} : ⊢@{IProp GF}
     (l ↦ some v -∗ (∀ w, ⌜w = v⌝ -∗ Φ w) -∗ WP hl(!v(#l)) {{ Φ }}) -∗
     WP hl(!v(#l)) {{ Φ }} := by
   iintro Hspec
   wp_apply Hspec with %w Hw
+  trace_state
 
 -- test `with` notation
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF : BundledGFunctors
 inst✝ : HeapLangGS hlc GF
@@ -283,13 +282,14 @@ a b c : Val
   ∗Hc : ⌜c = hl_val(#3)⌝
   ⊢ Φ a
 -/
-#guard_msgs (whitespace := lax) in
+#guard_msgs (trace, drop all, whitespace := lax) in
 example {l : Loc} {Φ : Val → IProp GF} : ⊢@{IProp GF}
     ((∀ a b c, ⌜a = hl_val(#1)⌝ -∗ ⌜b = hl_val(#2)⌝ -∗ ⌜c = hl_val(#3)⌝ -∗ Φ a) -∗
       WP hl(!v(#l)) {{ Φ }}) -∗
     WP hl(!v(#l)) {{ Φ }} := by
   iintro Hspec
   wp_apply Hspec with %a %b %c Ha Hb Hc
+  trace_state
 
 -- `with` runs after the loop: a failed introduction must not trigger another retry
 /--
@@ -303,8 +303,7 @@ example {l : Loc} {v : Val} : ⊢@{IProp GF}
   wp_smart_apply wp_load $$ Hpt with %bogus
 
 -- `with` targets a `$$` goal when the application produced none
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF : BundledGFunctors
 inst✝ : HeapLangGS hlc GF
@@ -316,15 +315,15 @@ e : Exp
   ∗HQ : Q
   ⊢ R
 -/
-#guard_msgs (whitespace := lax) in
+#guard_msgs (trace, drop all, whitespace := lax) in
 example {Q R : IProp GF} {e : Exp} {Φ : Val → IProp GF} : ⊢@{IProp GF}
     ((Q -∗ R) -∗ WP hl(&e) {{ Φ }}) -∗ (Q -∗ R) -∗ WP hl(&e) {{ Φ }} := by
   iintro H HQR
   wp_apply H $$ [HQR] with HQ
+  trace_state
 
 -- the continuation handed to a `$$` pattern
-/--
-error: unsolved goals
+/-- trace:
 hlc : HasLC
 GF : BundledGFunctors
 inst✝ : HeapLangGS hlc GF
@@ -335,11 +334,12 @@ v : Val
   ∗Hv : Ψ v
   ⊢ Φ v
 -/
-#guard_msgs (whitespace := lax) in
+#guard_msgs (trace, drop all, whitespace := lax) in
 example {l : Loc} {Φ Ψ : Val → IProp GF} : ⊢@{IProp GF}
     WP hl(!v(#l)) {{ Ψ }} -∗ WP hl(!v(#l)) {{ Φ }} := by
   iintro H
   wp_apply wp_wand $$ H [] with %v Hv
+  trace_state
 
 -- no goal to introduce into
 /-- error: no remaining Iris goal -/

--- a/Iris/IrisTest/HeapLang/Apply.lean
+++ b/Iris/IrisTest/HeapLang/Apply.lean
@@ -341,6 +341,41 @@ example {l : Loc} {Φ Ψ : Val → IProp GF} : ⊢@{IProp GF}
   wp_apply wp_wand $$ H [] with %v Hv
   trace_state
 
+
+-- `wp_apply ... with` when there are mvars after the last Iris goal
+/--
+trace: hlc : HasLC
+GF : BundledGFunctors
+inst✝ : HeapLangGS hlc GF
+l : Loc
+Φ : Val → IProp GF
+⊢ ⏎
+  ⊢ ⌜l = ?_⌝
+
+hlc : HasLC
+GF : BundledGFunctors
+inst✝ : HeapLangGS hlc GF
+l : Loc
+Φ : Val → IProp GF
+l' : Loc
+x✝ : l = l'
+⊢ ⏎
+  ⊢ WP hl(!#l') {{ Φ }}
+
+hlc : HasLC
+GF : BundledGFunctors
+inst✝ : HeapLangGS hlc GF
+l : Loc
+Φ : Val → IProp GF
+⊢ Loc
+-/
+#guard_msgs (trace, drop all, whitespace := lax) in
+example {l : Loc} {Φ : Val → IProp GF} : ⊢@{IProp GF}
+    (∀ l', ⌜l = l'⌝ -∗ (∀ l', ⌜l = l'⌝ -∗ WP hl(!v(#l')) {{ Φ }}) -∗ WP hl(!v(#l)) {{ Φ }}) -∗ WP hl(!v(#l)) {{ Φ }} := by
+  iintro H
+  wp_apply H with %l' %_
+  trace_state
+
 -- no goal to introduce into
 /-- error: no remaining Iris goal -/
 #guard_msgs (whitespace := lax) in

--- a/Iris/IrisTest/HeapLang/Apply.lean
+++ b/Iris/IrisTest/HeapLang/Apply.lean
@@ -1,0 +1,349 @@
+/-
+Copyright (c) 2026 Klaus Kraßnitzer. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Klaus Kraßnitzer
+-/
+module
+
+public import Iris.BI
+public import Iris.Instances
+public import Iris.HeapLang.Notation
+public import Iris.HeapLang.ProofMode
+public import Iris.HeapLang.PrimitiveLaws
+public import Iris.ProgramLogic.WeakestPre
+
+/-! Tests for `wp_apply` and `wp_smart_apply`. Several exercise machinery shared by
+both: evaluation-context search order, and the post-pass that must touch only the
+goals an application created. -/
+
+namespace Iris.HeapLang
+
+variable {hlc : HasLC} {GF : BundledGFunctors} [HeapLangGS hlc GF]
+set_option linter.unusedVariables false
+set_option pp.mvars false
+
+-- direct application of a WP hypothesis from the Iris context
+example {Φ : Val → IProp GF} : ⊢@{IProp GF}
+    WP hl(#1 + #2) {{ Φ }} -∗ WP hl(#1 + #2) {{ Φ }} := by
+  iintro H
+  wp_apply H
+
+-- a beta-redex step lemma whose premise is a later'd WP
+theorem beta_spec {v : Val} {Φ : Val → IProp GF} :
+    ▷ WP hl(v(&v) + #1) {{ Φ }} ⊢ WP hl(v(λ x, x + #1) v(&v)) {{ Φ }} := by
+  iintro H
+  wp_pure
+  iexact H
+
+-- the later'd WP premise is post-processed: the later is stripped
+example : ⊢@{IProp GF} WP hl(v(λ x, x + #1) #2) {{ v, ⌜v = hl_val(#3)⌝ }} := by
+  wp_apply beta_spec
+  wp_pure
+  itrivial
+
+-- with a raw lambda, wp_smart_apply first takes the closure-formation pure step
+example : ⊢@{IProp GF} WP hl((λ x, x + #1) #2) {{ v, ⌜v = hl_val(#3)⌝ }} := by
+  wp_smart_apply beta_spec
+  wp_pure
+  itrivial
+
+-- application at the head of the expression, discharging the points-to premise
+example {l : Loc} {v : Val} : ⊢@{IProp GF}
+    l ↦ some v -∗ WP hl(!v(#l)) {{ w, ⌜w = v⌝ }} := by
+  iintro Hpt
+  wp_apply wp_load $$ Hpt
+  iintro Hpt
+  itrivial
+
+-- application under an evaluation context
+/--
+error: unsolved goals
+hlc : HasLC
+GF : BundledGFunctors
+inst✝ : HeapLangGS hlc GF
+l : Loc
+n : Int
+⊢
+  ⊢ l ↦ some hl_val(#n) -∗ WP hl((#n + #1)) {{ w, ⌜w = hl_val(#(n + 1))⌝ }}
+-/
+#guard_msgs (whitespace := lax) in
+example {l : Loc} {n : Int} : ⊢@{IProp GF}
+    l ↦ some hl_val(#n) -∗ WP hl(!v(#l) + #1) {{ w, ⌜w = hl_val(#(n + 1 : Int))⌝ }} := by
+  iintro Hpt
+  wp_apply wp_load $$ Hpt
+
+-- wp_smart_apply takes pure steps until the lemma applies
+example {l : Loc} {v : Val} : ⊢@{IProp GF}
+    l ↦ some v -∗ WP hl(if #true then !v(#l) else #42) {{ w, ⌜w = v⌝ }} := by
+  iintro Hpt
+  wp_smart_apply wp_load $$ Hpt
+  iintro Hpt
+  itrivial
+
+-- plain wp_apply fails when a pure step is needed
+/-- error: wp_apply: cannot apply iprop(▷ (l ↦ some v -∗ ?_ v) -∗ WP hl(!#l) @ ?_ ; ?_ {{ ?_ }} ) -/
+#guard_msgs (whitespace := lax) in
+example {l : Loc} {v : Val} : ⊢@{IProp GF}
+    l ↦ some v -∗ WP hl(if #true then !v(#l) else #42) {{ w, ⌜w = v⌝ }} := by
+  iintro Hpt
+  wp_apply wp_load $$ Hpt
+
+-- wp_apply fails when the lemma matches no evaluation context
+/-- error: wp_apply: cannot apply iprop(▷ (l ↦ some v -∗ ?_ v) -∗ WP hl(!#l) @ ?_ ; ?_ {{ ?_ }} ) -/
+#guard_msgs (whitespace := lax) in
+example {l : Loc} {v : Val} : ⊢@{IProp GF}
+    l ↦ some v -∗ WP hl(#1 + #2) {{ w, ⌜w = v⌝ }} := by
+  iintro Hpt
+  wp_apply wp_load $$ Hpt
+
+-- under a non-empty context, so the remainder goes into the postcondition
+example {l : Loc} {Φ : Val → IProp GF} : ⊢@{IProp GF}
+    WP hl(!v(#l)) {{ w, WP hl(v(&w) + #1) {{ Φ }} }} -∗ WP hl(!v(#l) + #1) {{ Φ }} := by
+  iintro H
+  wp_apply H
+
+-- the post-pass must not reach a sibling goal
+/--
+error: unsolved goals
+hlc : HasLC
+GF : BundledGFunctors
+inst✝ : HeapLangGS hlc GF
+l : Loc
+v : Val
+P : IProp GF
+⊢
+  ⊢ l ↦ some v -∗ ⌜v = v⌝
+
+hlc : HasLC
+GF : BundledGFunctors
+inst✝ : HeapLangGS hlc GF
+l : Loc
+v : Val
+P : IProp GF
+⊢
+  ∗HP : ▷ P
+  ⊢ ▷ P
+-/
+#guard_msgs (whitespace := lax) in
+example {l : Loc} {v : Val} {P : IProp GF} : ⊢@{IProp GF}
+    ▷ P ∗ (l ↦ some v) -∗ WP hl(!v(#l)) {{ w, ⌜w = v⌝ }} ∗ (▷ P) := by
+  iintro ⟨HP, Hpt⟩
+  isplitl [Hpt]
+  wp_apply wp_load $$ Hpt
+
+-- a specialisation goal predates the application, so it keeps its `▷` too
+/--
+error: unsolved goals
+hlc : HasLC
+GF : BundledGFunctors
+inst✝ : HeapLangGS hlc GF
+⊢
+  ⊢ ▷ WP hl((#2 + #1)) {{ v, ⌜v = hl_val(#3)⌝ }}
+-/
+#guard_msgs (whitespace := lax) in
+example : ⊢@{IProp GF} WP hl(v(λ x, x + #1) #2) {{ v, ⌜v = hl_val(#3)⌝ }} := by
+  wp_apply beta_spec $$ []
+
+-- `wp_smart_apply` taking more than one pure step before the lemma applies
+example {l : Loc} {v : Val} : ⊢@{IProp GF}
+    l ↦ some v -∗
+      WP hl(if #true then (if #true then !v(#l) else #0) else #42) {{ w, ⌜w = v⌝ }} := by
+  iintro Hpt
+  wp_smart_apply wp_load $$ Hpt
+  iintro Hpt
+  itrivial
+
+-- the post-pass runs once, in the successful iteration: `▷ ▷` loses exactly one `▷`
+/--
+error: unsolved goals
+hlc : HasLC
+GF : BundledGFunctors
+inst✝ : HeapLangGS hlc GF
+P : IProp GF
+Φ : Val → IProp GF
+H : ▷ ▷ P ⊢ WP hl((v(λ x, (x + #1))) #2) {{ Φ }}
+⊢
+  ⊢ ▷ P
+-/
+#guard_msgs (whitespace := lax) in
+example {P : IProp GF} {Φ : Val → IProp GF}
+    (H : ▷ ▷ P ⊢ WP hl(v(λ x, x + #1) #2) {{ Φ }}) : ⊢@{IProp GF}
+    WP hl(if #true then ((λ x, x + #1) #2) else #0) {{ Φ }} := by
+  wp_smart_apply H
+
+-- out of pure steps: the error is about the original goal, not a mid-reduction one
+/--
+error: wp_smart_apply: cannot apply iprop(▷ (l ↦ some v -∗ ?_ v) -∗ WP hl(!#l) @ ?_ ; ?_ {{ ?_ }} )
+-/
+#guard_msgs (whitespace := lax) in
+example {l : Loc} {v : Val} : ⊢@{IProp GF}
+    l ↦ some v -∗ WP hl(#1 + #2) {{ w, ⌜w = v⌝ }} := by
+  iintro Hpt
+  wp_smart_apply wp_load $$ Hpt
+
+-- `wp_wand` is polymorphic in expression and postcondition, so every decomposition
+-- unifies and only the order decides: outermost leaves the expression the caller wrote,
+-- innermost would return a goal about `#l`.
+/--
+error: unsolved goals
+hlc : HasLC
+GF : BundledGFunctors
+inst✝ : HeapLangGS hlc GF
+l : Loc
+Φ : Val → IProp GF
+⊢
+  ⊢ WP hl((!#l + #1)) {{ ?_ }}
+
+hlc : HasLC
+GF : BundledGFunctors
+inst✝ : HeapLangGS hlc GF
+l : Loc
+Φ : Val → IProp GF
+⊢
+  ⊢ ∀ v, ?_ v -∗ Φ v
+
+hlc : HasLC
+GF : BundledGFunctors
+inst✝ : HeapLangGS hlc GF
+l : Loc
+Φ : Val → IProp GF
+⊢ Val → IProp GF
+-/
+#guard_msgs (whitespace := lax) in
+example {l : Loc} {Φ : Val → IProp GF} : ⊢@{IProp GF}
+    WP hl(!v(#l) + #1) {{ Φ }} := by
+  wp_apply wp_wand
+
+-- the same, instrumented: the leftover premise records which decomposition was picked
+example {l : Loc} {Φ : Val → IProp GF} : ⊢@{IProp GF}
+    (∀ (e : Exp) (Ψ : Val → IProp GF), ⌜e = hl(!v(#l) + #1)⌝ -∗ WP hl(&e) {{ Ψ }}) -∗
+    WP hl(!v(#l) + #1) {{ Φ }} := by
+  iintro H
+  wp_apply H
+  itrivial
+
+-- `with` subsumes a following `iintro`
+example {l : Loc} {v : Val} : ⊢@{IProp GF}
+    l ↦ some v -∗ WP hl(if #true then !v(#l) else #0) {{ w, ⌜w = v⌝ }} := by
+  iintro Hpt
+  wp_smart_apply wp_load $$ Hpt with Hpt
+  itrivial
+
+-- binders and hypotheses mix in one pattern list
+example {l : Loc} {Φ Ψ : Val → IProp GF} : ⊢@{IProp GF}
+    WP hl(!v(#l)) {{ Ψ }} -∗ (∀ w, Ψ w -∗ WP hl(v(&w) + #1) {{ Φ }}) -∗
+    WP hl(!v(#l) + #1) {{ Φ }} := by
+  iintro H HΦ
+  wp_apply wp_wand $$ H with %w Hw
+  iapply HΦ $$ Hw
+
+-- it targets the last goal the application produced, leaving the others untouched
+/--
+error: unsolved goals
+hlc : HasLC
+GF : BundledGFunctors
+inst✝ : HeapLangGS hlc GF
+l : Loc
+v : Val
+Φ : Val → IProp GF
+⊢
+  ⊢ l ↦ some v
+
+hlc : HasLC
+GF : BundledGFunctors
+inst✝ : HeapLangGS hlc GF
+l : Loc
+v : Val
+Φ : Val → IProp GF
+w : Val
+⊢
+  ∗Hw : ⌜w = v⌝
+  ⊢ Φ w
+-/
+#guard_msgs (whitespace := lax) in
+example {l : Loc} {v : Val} {Φ : Val → IProp GF} : ⊢@{IProp GF}
+    (l ↦ some v -∗ (∀ w, ⌜w = v⌝ -∗ Φ w) -∗ WP hl(!v(#l)) {{ Φ }}) -∗
+    WP hl(!v(#l)) {{ Φ }} := by
+  iintro Hspec
+  wp_apply Hspec with %w Hw
+
+-- test `with` notation
+/--
+error: unsolved goals
+hlc : HasLC
+GF : BundledGFunctors
+inst✝ : HeapLangGS hlc GF
+l : Loc
+Φ : Val → IProp GF
+a b c : Val
+⊢
+  ∗Ha : ⌜a = hl_val(#1)⌝
+  ∗Hb : ⌜b = hl_val(#2)⌝
+  ∗Hc : ⌜c = hl_val(#3)⌝
+  ⊢ Φ a
+-/
+#guard_msgs (whitespace := lax) in
+example {l : Loc} {Φ : Val → IProp GF} : ⊢@{IProp GF}
+    ((∀ a b c, ⌜a = hl_val(#1)⌝ -∗ ⌜b = hl_val(#2)⌝ -∗ ⌜c = hl_val(#3)⌝ -∗ Φ a) -∗
+      WP hl(!v(#l)) {{ Φ }}) -∗
+    WP hl(!v(#l)) {{ Φ }} := by
+  iintro Hspec
+  wp_apply Hspec with %a %b %c Ha Hb Hc
+
+-- `with` runs after the loop: a failed introduction must not trigger another retry
+/--
+error: iintro: iprop(l ↦ some v -∗ ⌜v = v⌝) cannot be turned into a universal quantifier
+  or pure hypothesis
+-/
+#guard_msgs (whitespace := lax) in
+example {l : Loc} {v : Val} : ⊢@{IProp GF}
+    l ↦ some v -∗ WP hl(if #true then !v(#l) else #0) {{ w, ⌜w = v⌝ }} := by
+  iintro Hpt
+  wp_smart_apply wp_load $$ Hpt with %bogus
+
+-- `with` targets a `$$` goal when the application produced none
+/--
+error: unsolved goals
+hlc : HasLC
+GF : BundledGFunctors
+inst✝ : HeapLangGS hlc GF
+Q R : IProp GF
+e : Exp
+Φ : Val → IProp GF
+⊢
+  ∗HQR : Q -∗ R
+  ∗HQ : Q
+  ⊢ R
+-/
+#guard_msgs (whitespace := lax) in
+example {Q R : IProp GF} {e : Exp} {Φ : Val → IProp GF} : ⊢@{IProp GF}
+    ((Q -∗ R) -∗ WP hl(&e) {{ Φ }}) -∗ (Q -∗ R) -∗ WP hl(&e) {{ Φ }} := by
+  iintro H HQR
+  wp_apply H $$ [HQR] with HQ
+
+-- the continuation handed to a `$$` pattern
+/--
+error: unsolved goals
+hlc : HasLC
+GF : BundledGFunctors
+inst✝ : HeapLangGS hlc GF
+l : Loc
+Φ Ψ : Val → IProp GF
+v : Val
+⊢
+  ∗Hv : Ψ v
+  ⊢ Φ v
+-/
+#guard_msgs (whitespace := lax) in
+example {l : Loc} {Φ Ψ : Val → IProp GF} : ⊢@{IProp GF}
+    WP hl(!v(#l)) {{ Ψ }} -∗ WP hl(!v(#l)) {{ Φ }} := by
+  iintro H
+  wp_apply wp_wand $$ H [] with %v Hv
+
+-- no goal to introduce into
+/-- error: wp_apply: no goal left for the `with` patterns -/
+#guard_msgs (whitespace := lax) in
+example {Φ : Val → IProp GF} {v : Val} : ⊢@{IProp GF}
+    WP hl(v(&v)) {{ Φ }} -∗ WP hl(v(&v)) {{ Φ }} := by
+  iintro H
+  wp_apply H with Hx

--- a/Iris/IrisTest/HeapLang/Apply.lean
+++ b/Iris/IrisTest/HeapLang/Apply.lean
@@ -131,14 +131,15 @@ example {l : Loc} {v : Val} {P : IProp GF} : ⊢@{IProp GF}
   isplitl [Hpt]
   wp_apply wp_load $$ Hpt
 
--- a specialisation goal predates the application, so it keeps its `▷` too
+-- also goals that are part of the specialization pattern have ▷ stripped
+-- (this differs from Rocq)
 /--
 error: unsolved goals
 hlc : HasLC
 GF : BundledGFunctors
 inst✝ : HeapLangGS hlc GF
 ⊢
-  ⊢ ▷ WP hl((#2 + #1)) {{ v, ⌜v = hl_val(#3)⌝ }}
+  ⊢ WP hl((#2 + #1)) {{ v, ⌜v = hl_val(#3)⌝ }}
 -/
 #guard_msgs (whitespace := lax) in
 example : ⊢@{IProp GF} WP hl(v(λ x, x + #1) #2) {{ v, ⌜v = hl_val(#3)⌝ }} := by
@@ -341,7 +342,7 @@ example {l : Loc} {Φ Ψ : Val → IProp GF} : ⊢@{IProp GF}
   wp_apply wp_wand $$ H [] with %v Hv
 
 -- no goal to introduce into
-/-- error: wp_apply: no goal left for the `with` patterns -/
+/-- error: no remaining Iris goal -/
 #guard_msgs (whitespace := lax) in
 example {Φ : Val → IProp GF} {v : Val} : ⊢@{IProp GF}
     WP hl(v(&v)) {{ Φ }} -∗ WP hl(v(&v)) {{ Φ }} := by

--- a/Iris/IrisTest/HeapLang/WeakestPre.lean
+++ b/Iris/IrisTest/HeapLang/WeakestPre.lean
@@ -255,14 +255,14 @@ hlc : HasLC
 GF : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF
 v1 v2 : Val
-⊢ ⏎
-  ⊢ |={⊤}=> True
+⊢ v1.compareSafe v2 = true
 
 hlc : HasLC
 GF : BundledGFunctors
 ι : IrisGS_gen hlc Exp GF
 v1 v2 : Val
-⊢ v1.compareSafe v2 = true
+⊢ ⏎
+  ⊢ |={⊤}=> True
 -/
 #guard_msgs (trace, drop error) in
 example (v1 v2 : Val) : ⊢@{IProp GF} WP hl(&v1 = &v2) {{ v, True }} := by


### PR DESCRIPTION
## Description

This PR ports Rocq's `wp_apply` and `wp_smart_apply`. `wp_apply lem` poses `lem` whose conclusion must be a `WP` and applies it at the first evaluation context decomposition that fits and pushes the ectx into the postcondition. `wp_smart_apply lem` retries after single pure steps until the lemma applies. Both accept specialisation patterns (via `$$`) and a `with` clause for subsequent `iintros`. 

This addresses the remaining parts of #480.

The PR consists of four commits that fall into distinct files:

| commit | file |
|---|---|
| [feat: outermost-first evaluation context search](https://github.com/leanprover-community/iris-lean/commit/b6d906ae036ed537294cab706bc80489130d3882) | `HeapLang/Tactic.lean` |
| [refactor: make `iApplyCore` public](https://github.com/leanprover-community/iris-lean/commit/71988a9c7a3ba6895f92b86632861643b5a66160) | `ProofMode/Tactics/Apply.lean` |
| [feat: implement `wp_apply` and `wp_smart_apply`](https://github.com/leanprover-community/iris-lean/commit/7aa3b9397c32a839dbd6c7d6e60e832ffb64eae1) | `HeapLang/ProofMode.lean`, tests |
| [refactor: use `wp_apply` in HeapLang examples](https://github.com/leanprover-community/iris-lean/commit/41ac4250f9f1ed31ca1349456caa338d4036eaef) | ten `HeapLang/Lib/` files |

The first commit adds an outermost-first sibling to `findECtx`, which — contrary to Rocq's `reshape_expr` — is innermost-first (see discussion below). The second commit makes `iApplyCore` public, the third commit implements `wp_apply` and `wp_smart_apply`. Finally, the fourth commit refactors the existing HeapLang examples to use `wp_apply` (31 call sites, -55 lines of boilerplate in the HeapLang example files).

I chose to give `wp_smart_apply` a fuel (`smartApplyFuel`) so it doesn't diverge. I don't think this can occur in practice besides inline syntactically recursive self-application (like `WP hl((rec f x := f x) #1) {{ Φ }}`), hence I also picked a pretty high value (~60s on my machine with heartbeats disabled).

### Evaluation context search order

As outlined, `findECtx` is *innermost-first* contrary to its Rocq counterpart (`reshape_expr`). For most tactics, this does not matter since there's usually only a single matching site for call-by-value redexes. Where it *does* matter is a search that commits, like the current implementation of `wp_rec` (as outlined in #603) that runs `wp_bind (_ _)` which matches *any application* and commits before knowing whether the subsequent `iapply` succeeds. Incidentally, this design plays well with the current innermost-first `findECtx` since sites like `f x y = App (App f x) y` would be decomposed inside-out, but would break on a global change to outermost-first. With the `wp_rec` reimplementation from #657 both decomposition orders should work in all currently existing tactics.

`wp_apply` however makes a point for outermost-first decomposition order: Considering an expression-polymorphic lemma like `wp_wand` where `iapply` succeeds in every decomposition, I argue that the user would expect it to apply to the outermost expression instead of the innermost one. For example, `wp_apply wp_wand` on `WP (!#l + #1) {{ Φ }}` should, in my opinion, apply `wp_wand` on the whole expression and not the innermost `#l` which is not even a redex. There is however a point to be made about pinning the premises of `wp_apply`'d lemmas such that the expression is fixed before the search runs (which is what happens most of the time in the iris developments I scoured), or using `iapply` directly when wanting to target the whole expression. 

The use of `findECtxOutermost` in `wp_apply` only is certainly debatable and I'd appreciate the maintainer's input on this question.

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 