### PR TITLE
feat: ProgramLogic loose ends 

### DIFF
--- a/Iris/Iris/ProgramLogic/EctxiLanguage.lean
+++ b/Iris/Iris/ProgramLogic/EctxiLanguage.lean
@@ -37,8 +37,9 @@ export EctxItemLanguage (fillItem)
 
 -- attribute [rocq_alias fill_item] EctxItemLanguage.fillItem
 attribute [rocq_alias fill_item_inj] EctxItemLanguage.fillItem_inj
-attribute [rocq_alias fill_item_val] EctxItemLanguage.fillItem
+attribute [rocq_alias fill_item_val] EctxItemLanguage.fillItem_val
 attribute [rocq_alias fill_item_no_val_inj] EctxItemLanguage.fillItem_no_val_inj
+attribute [rocq_alias base_ctx_step_val] EctxItemLanguage.base_ctx_step_val
 
 attribute [simp] EctxItemLanguage.fillItem_inj
 attribute [grind →] EctxItemLanguage.fillItem_val
@@ -124,6 +125,7 @@ instance instEctxLanguage : EctxLanguage Expr Λ.Ectx State Obs Val where
 
 attribute [rocq_alias ectxi_lang] Iris.ProgramLogic.EctxLanguage.instLanguage
 
+@[rocq_alias fill_not_val]
 theorem fill_not_val {K} {e : Expr} : toVal e = none → toVal (fill K e) = none := by
   grind only [=> EctxLanguage.fill_not_val]
 

--- a/Iris/Iris/ProgramLogic/EctxiLanguage.lean
+++ b/Iris/Iris/ProgramLogic/EctxiLanguage.lean
@@ -39,7 +39,7 @@ export EctxItemLanguage (fillItem)
 attribute [rocq_alias fill_item_inj] EctxItemLanguage.fillItem_inj
 attribute [rocq_alias fill_item_val] EctxItemLanguage.fillItem_val
 attribute [rocq_alias fill_item_no_val_inj] EctxItemLanguage.fillItem_no_val_inj
-attribute [rocq_alias base_ctx_step_val] EctxItemLanguage.base_ctx_step_val
+attribute [rocq_alias ectxi_language.base_ctx_step_val] EctxItemLanguage.base_ctx_step_val
 
 attribute [simp] EctxItemLanguage.fillItem_inj
 attribute [grind →] EctxItemLanguage.fillItem_val
@@ -125,7 +125,7 @@ instance instEctxLanguage : EctxLanguage Expr Λ.Ectx State Obs Val where
 
 attribute [rocq_alias ectxi_lang] Iris.ProgramLogic.EctxLanguage.instLanguage
 
-@[rocq_alias fill_not_val]
+@[rocq_alias ectxi_language.fill_not_val]
 theorem fill_not_val {K} {e : Expr} : toVal e = none → toVal (fill K e) = none := by
   grind only [=> EctxLanguage.fill_not_val]
 

--- a/Iris/Iris/ProgramLogic/TotalAdequacy.lean
+++ b/Iris/Iris/ProgramLogic/TotalAdequacy.lean
@@ -55,6 +55,7 @@ def pre (X : List Expr → IProp GF) (t₁ : List Expr) : IProp GF := iprop%
     stateInterp σ₁ ns κs nt ={⊤}=∗
       ∃ nt', ⌜κ = []⌝ ∗ stateInterp σ₂ (ns + 1) κs nt' ∗ X t₂
 
+@[rocq_alias twptp_pre_mono']
 instance pre_mono_inst : BIMonoPred (pre (ι := ι)) where
   mono_pred := by
     intro X Y _ _

--- a/Iris/Iris/ProgramLogic/TotalWeakestPre.lean
+++ b/Iris/Iris/ProgramLogic/TotalWeakestPre.lean
@@ -151,7 +151,7 @@ instance ne {s : Stuckness} {E} {e : Expr} :
     refine NonExpansive.ne (f := bi_least_fixpoint (Internal.pre' s)) ?_
     exact ⟨.rfl, .rfl, HΦ⟩
 
-#rocq_ignore twp_proper "Derivable from twp_ne with OFE.eq_dist"
+#rocq_ignore twp_proper "OFE is Leibniz; use equality"
 
 @[rocq_alias twp_value_fupd']
 theorem value_fupd' {s : Stuckness} {E} {Φ : Val → IProp GF} {v : Val} :
@@ -349,16 +349,16 @@ theorem to_wp {s : Stuckness} {E} {e : Expr} {Φ : Val → IProp GF} :
 Since total weakest preconditions do not use up later credits, the premise receives `£ n`. -/
 @[rocq_alias twp_wp_fupdN_strong]
 theorem to_wp_fupdN_strong {s : Stuckness} {E₁ E₂ : CoPset} {e : Expr} {P : IProp GF}
-    {Φ : Val → IProp GF} {n : Nat} (toVal_e : toVal e = none) (E₂E₁ : E₂ ⊆ E₁) :
+    {Φ : Val → IProp GF} {n : Nat} (toVal_e : toVal e = none) (HSub : E₂ ⊆ E₁) :
     (∀ (σ : State) ns obs nt, stateInterp σ ns obs nt ={E₁,∅}=∗ ⌜n ≤ ι.numLatersPerStep ns + 1⌝)
-    ∧ ((|={E₁,E₂}=> £ n -∗ |={∅}▷=>^[n] |={E₂,E₁}=> P)
+    ∧ ((|={E₁,E₂}=> £ n ={∅}▷=∗^[n] |={E₂,E₁}=> P)
     ∗ WP e @ s ; E₂ [{ v, P ={E₁}=∗ Φ v }]) ⊢
     WP e @ s ; E₁ {{ Φ }} := by
   match n with
   | 0 =>
     iintro ⟨-, Hp, Hwp⟩
     iapply to_wp
-    iapply strong_mono (Std.IsPreorder.le_refl _) E₂E₁ $$ Hwp
+    iapply strong_mono (Std.IsPreorder.le_refl _) HSub $$ Hwp
     iintro %v HΦ
     dsimp only [Nat.repeat]
     imod Hp
@@ -389,11 +389,11 @@ theorem to_wp_fupdN_strong {s : Stuckness} {E₁ E₂ : CoPset} {e : Expr} {P : 
       imod Hwp with ⟨%⟨⟩, Hσ₂, Hwp, Hefs⟩
       imod Hp
       imodintro
-      simp only [List.nil_append]
+      dsimp only [List.nil_append]
       iframe Hσ₂
       isplitl [Hwp Hp]
       · iapply to_wp
-        iapply strong_mono (Std.IsPreorder.le_refl _) E₂E₁ $$ Hwp
+        iapply strong_mono (Std.IsPreorder.le_refl _) HSub $$ Hwp
         iintro %v HΦ
         iapply HΦ $$ Hp
       · iapply BI.BigSepL.bigSepL_impl $$ Hefs

--- a/Iris/Iris/ProgramLogic/TotalWeakestPre.lean
+++ b/Iris/Iris/ProgramLogic/TotalWeakestPre.lean
@@ -61,6 +61,7 @@ def pre (s : Stuckness) (twp : CoPset → Expr → (Val → IProp GF) → IProp 
 
 namespace Internal
 
+@[rocq_alias twp_pre']
 abbrev pre' (s : Stuckness) (X : Args Expr Val GF → IProp GF) : Args Expr Val GF → IProp GF
   | (E, e, Φ) => pre s (fun E e Φ => X (E, e, Φ)) E e Φ
 
@@ -149,6 +150,8 @@ instance ne {s : Stuckness} {E} {e : Expr} :
   ne {n Φ₁ Φ₂} HΦ := by
     refine NonExpansive.ne (f := bi_least_fixpoint (Internal.pre' s)) ?_
     exact ⟨.rfl, .rfl, HΦ⟩
+
+#rocq_ignore twp_proper "Derivable from twp_ne with OFE.eq_dist"
 
 @[rocq_alias twp_value_fupd']
 theorem value_fupd' {s : Stuckness} {E} {Φ : Val → IProp GF} {v : Val} :
@@ -342,6 +345,64 @@ theorem to_wp {s : Stuckness} {E} {e : Expr} {Φ : Val → IProp GF} :
       iintro !> %k %ef %Hef !>Hef
       iapply IH $$ Hef
 
+/-- Similar to `wp_step_fupdN_strong`, but with a total weakest precondition in the premise.
+Since total weakest preconditions do not use up later credits, the premise receives `£ n`. -/
+@[rocq_alias twp_wp_fupdN_strong]
+theorem to_wp_fupdN_strong {s : Stuckness} {E₁ E₂ : CoPset} {e : Expr} {P : IProp GF}
+    {Φ : Val → IProp GF} {n : Nat} (toVal_e : toVal e = none) (E₂E₁ : E₂ ⊆ E₁) :
+    (∀ (σ : State) ns obs nt, stateInterp σ ns obs nt ={E₁,∅}=∗ ⌜n ≤ ι.numLatersPerStep ns + 1⌝)
+    ∧ ((|={E₁,E₂}=> £ n -∗ |={∅}▷=>^[n] |={E₂,E₁}=> P)
+    ∗ WP e @ s ; E₂ [{ v, P ={E₁}=∗ Φ v }]) ⊢
+    WP e @ s ; E₁ {{ Φ }} := by
+  match n with
+  | 0 =>
+    iintro ⟨-, Hp, Hwp⟩
+    iapply to_wp
+    iapply strong_mono (Std.IsPreorder.le_refl _) E₂E₁ $$ Hwp
+    iintro %v HΦ
+    dsimp only [Nat.repeat]
+    imod Hp
+    imod lc_zero with Hlc
+    imod Hp $$ Hlc with Hp
+    iapply HΦ $$ Hp
+  | n+1 =>
+    simp only [(wp_unfold (e := e)).to_eq, (unfold (e := e)).to_eq, wp.pre, pre, toVal_e]
+    iintro H %σ₁ %ns %obs %obs' %nt Hσ₁
+    by_cases Hn : n ≤ ι.numLatersPerStep ns
+    · icases H with ⟨-, >Hp, Hwp⟩
+      imod Hwp $$ Hσ₁ with ⟨%Hred, Hwp⟩
+      imodintro
+      isplitr
+      · ipureintro
+        grind
+      iintro %e₂ %σ₂ %eₜ %Hstep Hcred
+      ispecialize Hwp $$ %obs %e₂ %σ₂ %eₜ %Hstep
+      dsimp only [Nat.repeat]
+      imod Hp $$ [Hcred] with Hp
+      · iapply lc_weaken (n + 1) (Nat.succ_le_succ Hn) $$ Hcred
+      iintro !> !>
+      imod Hp
+      imodintro
+      iapply step_fupdN_le Hn LawfulSet.subset_refl
+      iapply step_fupdN_wand $$ Hp
+      iintro Hp
+      imod Hwp with ⟨%⟨⟩, Hσ₂, Hwp, Hefs⟩
+      imod Hp
+      imodintro
+      simp only [List.nil_append]
+      iframe Hσ₂
+      isplitl [Hwp Hp]
+      · iapply to_wp
+        iapply strong_mono (Std.IsPreorder.le_refl _) E₂E₁ $$ Hwp
+        iintro %v HΦ
+        iapply HΦ $$ Hp
+      · iapply BI.BigSepL.bigSepL_impl $$ Hefs
+        iintro !> %k %ef %_ Hef
+        iapply to_wp $$ Hef
+    · icases H with ⟨Hbound, -⟩
+      imod Hbound $$ Hσ₁ with %h
+      grind only
+
 @[rocq_alias twp_mono]
 theorem mono {s : Stuckness} {E} {e : Expr} {Φ Ψ : Val → IProp GF}
     (H : ∀ v, Φ v ⊢ Ψ v) :
@@ -350,6 +411,8 @@ theorem mono {s : Stuckness} {E} {e : Expr} {Φ Ψ : Val → IProp GF}
   iapply strong_mono (Std.IsPreorder.le_refl _) LawfulSet.subset_refl $$ H
   iintro %v _
   iapply H $$ [$]
+
+#rocq_ignore twp_mono' "No `Proper` typeclass in Lean"
 
 @[rocq_alias twp_stuck_mono]
 theorem stuck_mono {s₁ s₂ : Stuckness} {E} {e : Expr} {Φ : Val → IProp GF} (H : s₁ ≤ s₂) :


### PR DESCRIPTION
## Description
A few more 100%'s

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
