### PR TITLE
chore: Bump Rocq and fix stale aliases

### DIFF
--- a/Iris/Iris/Algebra/Mra.lean
+++ b/Iris/Iris/Algebra/Mra.lean
@@ -154,8 +154,7 @@ instance : CMRA.Discrete (Mra R) where
 #rocq_ignore mra_unit "Replaced by the `unit` field of UCMRA instance."
 #rocq_ignore mraUR "Use Mra."
 
--- FIXME: upstream name `auth_ucmra_mixin` should be `mra_ucmra_mixin`
-@[rocq_alias auth_ucmra_mixin]
+@[rocq_alias mra_ucmra_mixin]
 instance (R : α → α → Prop) : UCMRA (Mra R) where
   unit := mk []
   unit_valid := trivial

--- a/Iris/Iris/Algebra/Numbers.lean
+++ b/Iris/Iris/Algebra/Numbers.lean
@@ -197,7 +197,6 @@ scoped instance instUCMRA [LawfulLeftIdentity (α := α) (· + ·) zero] : UCMRA
   unit_valid := trivial
   unit_left_id := left_id _
   pcore_unit := rfl
-#rocq_ignore max_Z_unit_instance "Rocq has no `max_Z_UCMRA`."
 #rocq_ignore max_natUR "Use the (ℕ, max) Universal Core instance."
 #rocq_ignore max_nat_ucmra_mixin "Use the (ℕ, max) Universal Core instance."
 #rocq_ignore max_nat_unit_instance "Use the (ℕ, max) Universal Core instance."

--- a/Iris/Iris/BI/BI.lean
+++ b/Iris/Iris/BI/BI.lean
@@ -162,7 +162,6 @@ attribute [rw_mono_rule, rocq_alias bi.persistently_mono] BI.persistently_mono
 attribute [rocq_alias bi.persistently_idemp_2] BI.persistently_idem_2
 attribute [rocq_alias bi.persistently_and_2] BI.persistently_and_2
 attribute [rocq_alias bi.persistently_emp_2] BI.persistently_emp_2
-attribute [rocq_alias bi.persistently_exist_1] BI.persistently_sExists_1
 attribute [rocq_alias interface.bi.persistently_absorbing] BI.persistently_absorb_l
 attribute [rocq_alias bi.persistently_and_sep_elim] BI.persistently_and_l
 

--- a/scripts/ROCQ_REVISION
+++ b/scripts/ROCQ_REVISION
@@ -1,1 +1,1 @@
-fc4ada8c680cfca3a48ad0a1aaff073c7b28e2db
+44bcb00091ebfe8fbba3a9597f542b49f7f78d90


### PR DESCRIPTION
## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
