### PR TITLE
feat: ProgramLogic/Atomic

### DIFF
--- a/Iris/Iris/BI/Lib/Atomic.lean
+++ b/Iris/Iris/BI/Lib/Atomic.lean
@@ -307,7 +307,7 @@ theorem aupd_intro {Eo Ei : CoPset} {P Q : PROP} {α : TA.Arg → PROP}
   iapply HAU $$ [$]
 
 @[rocq_alias aacc_intro]
-theorem aacc_intro {Eo Ei : CoPset} {α : TA.Arg → PROP} {P : PROP}
+private theorem aacc_intro {Eo Ei : CoPset} {α : TA.Arg → PROP} {P : PROP}
     {β Φ : TA.Arg → TB.Arg → PROP} (HEi : Ei ⊆ Eo) :
     ∀.. x, α x -∗
       ((α x ={Eo}=∗ P) ∧ (∀.. y, β x y ={Eo}=∗ Φ x y)) -∗ atomic_acc Eo Ei α P β Φ := by

--- a/Iris/Iris/BI/Lib/Atomic.lean
+++ b/Iris/Iris/BI/Lib/Atomic.lean
@@ -280,7 +280,7 @@ set_option synthInstance.checkSynthOrder false in
 @[rocq_alias elim_mod_aupd]
 instance elim_mod_aupd {φ} {io : InOut} {Eo Ei E : CoPset} {α : TA.Arg → PROP}
     {β Φ : TA.Arg → TB.Arg → PROP} {Q Q' : PROP}
-    [H : ∀ R, ElimModal φ false io false iprop(|={E,Ei}=> R) R Q Q'] :
+    [H : ∀ R, ElimModal φ false .in false iprop(|={E,Ei}=> R) R Q Q'] :
     ElimModal (φ ∧ Eo ⊆ E) false io false (atomic_update Eo Ei α β Φ)
       iprop(∃.. x, α x ∗ ((α x ={Ei,E}=∗ atomic_update Eo Ei α β Φ) ∧
         (∀.. y, β x y ={Ei,E}=∗ Φ x y))) Q Q' where
@@ -307,7 +307,7 @@ theorem aupd_intro {Eo Ei : CoPset} {P Q : PROP} {α : TA.Arg → PROP}
   iapply HAU $$ [$]
 
 @[rocq_alias aacc_intro]
-private theorem aacc_intro {Eo Ei : CoPset} {α : TA.Arg → PROP} {P : PROP}
+theorem aacc_intro {Eo Ei : CoPset} {α : TA.Arg → PROP} {P : PROP}
     {β Φ : TA.Arg → TB.Arg → PROP} (HEi : Ei ⊆ Eo) :
     ∀.. x, α x -∗
       ((α x ={Eo}=∗ P) ∧ (∀.. y, β x y ={Eo}=∗ Φ x y)) -∗ atomic_acc Eo Ei α P β Φ := by

--- a/Iris/Iris/ProgramLogic.lean
+++ b/Iris/Iris/ProgramLogic.lean
@@ -4,6 +4,7 @@ public import Iris.ProgramLogic.AbstractEctxLangCompleteness
 public import Iris.ProgramLogic.AbstractLangCompleteness
 public import Iris.ProgramLogic.AbstractWeakestPre
 public import Iris.ProgramLogic.Adequacy
+public import Iris.ProgramLogic.Atomic
 public import Iris.ProgramLogic.EctxiLanguage
 public import Iris.ProgramLogic.EctxLanguage
 public import Iris.ProgramLogic.EctxLifting

--- a/Iris/Iris/ProgramLogic/Atomic.lean
+++ b/Iris/Iris/ProgramLogic/Atomic.lean
@@ -43,8 +43,6 @@ If you don't need a private postcondition, you can leave it away, e.g.:
   code @ E
 <<{ ∃∃ y, atomic_postcondition | RET return_value }>>
 ```
-Unlike in Iris Rocq, where combinatorial explosion forces one notation per variant, every binder
-group and the private postcondition are optional parts of a single notation here.
 -/
 
 namespace Iris
@@ -169,7 +167,7 @@ variable {α : TA.Arg → IProp GF} {β : TA.Arg → TB.Arg → IProp GF}
 variable {POST : TA.Arg → TB.Arg → TP.Arg → Option (IProp GF)}
 variable {f : TA.Arg → TB.Arg → TP.Arg → Val}
 
-/-- Atomic triples imply sequential triples. -/
+
 @[rocq_alias atomic_wp_seq]
 theorem atomic_wp_seq :
     atomic_wp e E α β POST f ⊢
@@ -178,23 +176,52 @@ theorem atomic_wp_seq :
   iintro Hwp %Φ %x Hα HΦ
   iapply wp_frame_wand $$ HΦ
   iapply Hwp
-  iunfold atomic_update
-  iapply greatest_fixpoint_coiter _ (fun _ => α x) $$ [] Hα
-  iintro !> %_ Hα
-  iunfold atomic_update_pre, atomic_acc
-  iapply fupd_mask_intro empty_subset
-  iintro Hclose
-  iexists x
-  iframe Hα
-  isplit
-  · iintro Hα
-    imod Hclose
-    itrivial
-  · iintro %y Hβ
-    imod Hclose
+  iauintro
+  iaaccintro Hα
+  · iintro Hα !> //
+  · iintro %y Hβ !>
     isimp only [Tele.app_bind]
-    iintro !> %z Hpost HΦ
+    iintro %z Hpost HΦ
     iapply HΦ $$ Hβ Hpost
+
+@[rocq_alias atomic_wp_inv]
+theorem atomic_wp_inv {N : Namespace} {I : IProp GF} (HN : (↑N : CoPset) ⊆ E) :
+    atomic_wp e (E \ ↑N) (λ.. x, iprop(▷ I ∗ α x)) (λ.. x y, iprop(▷ I ∗ β x y)) POST f ⊢
+    inv N I -∗ atomic_wp e E α β POST f := by
+  iunfold atomic_wp
+  iintro Hwp #Hinv %Φ AU
+  iapply Hwp
+  iauintro
+  iinv N with HI
+  · exact ⟨fun x hx => mem_diff.mpr ⟨CoPset.mem_full, fun h => (mem_diff.mp h).right hx⟩, trivial⟩
+  have HE : (⊤ \ E : CoPset) ⊆ (⊤ \ (E \ ↑N)) \ ↑N := by
+    intro x hx
+    simp only [mem_diff] at hx ⊢
+    exact ⟨⟨CoPset.mem_full, fun h => hx.right h.left⟩, fun h => hx.right (HN x h)⟩
+  iapply aacc_aupd HE $$ AU
+  iintro %x Hα
+  iaaccintro %x [HI Hα]
+  · -- the atomic precondition `▷ I ∗ α x`
+    isimp only [Tele.app_bind]
+    iframe
+  · iintro H
+    isimp only [Tele.app_bind] at H
+    icases H with ⟨HI, Hα⟩
+    iintro !> {$Hα} AU !>
+    -- `iinv` δ-reduced the `-∗?` of `POST` in the goal, so reduce it in `AU` too.
+    iunfold BIBase.wandM at AU
+    iframe HI AU
+  · iintro %y H
+    isimp only [Tele.app_bind] at H
+    icases H with ⟨HI, Hβ⟩
+    imodintro
+    isimp only [Tele.app_bind]
+    iright
+    iexists y
+    iintro {$Hβ} HΦ !>
+    iunfold BIBase.wandM at HΦ
+    iframe HI HΦ
+
 
 /-- This version matches the Texan triple, i.e., with a later in front of the
 `(∀.. y, β x y -∗ Φ (f x y))`. -/
@@ -254,54 +281,6 @@ theorem atomic_wp_mask_weaken {E₁ E₂ : CoPset} (HE : E₁ ⊆ E₂) :
   iintro Hwp %Φ AU
   iapply Hwp
   iapply atomic_update_mask_weaken (diff_subset_diff_right HE) $$ AU
-
-/-- We can open invariants around atomic triples.
-(Just for demonstration purposes; we always use `iinv` in proofs.) -/
-@[rocq_alias atomic_wp_inv]
-theorem atomic_wp_inv {N : Namespace} {I : IProp GF} (HN : (↑N : CoPset) ⊆ E) :
-    atomic_wp e (E \ ↑N) (λ.. x, iprop(▷ I ∗ α x)) (λ.. x y, iprop(▷ I ∗ β x y)) POST f ⊢
-    inv N I -∗ atomic_wp e E α β POST f := by
-  iunfold atomic_wp
-  iintro Hwp #Hinv %Φ AU
-  iapply Hwp
-  iunfold atomic_update
-  iapply greatest_fixpoint_coiter _
-    (fun _ => atomic_update (⊤ \ E) ∅ α β
-      (λ.. x y, iprop(∀.. z, POST x y z -∗? Φ (f x y z)))) $$ [] AU
-  iintro !> %_ AU
-  iunfold atomic_update_pre
-  iinv N with HI
-  · exact ⟨fun x hx => mem_diff.mpr ⟨CoPset.mem_full, fun h => (mem_diff.mp h).right hx⟩, trivial⟩
-  have HE : (⊤ \ E : CoPset) ⊆ (⊤ \ (E \ ↑N)) \ ↑N := by
-    intro x hx
-    simp only [mem_diff] at hx ⊢
-    exact ⟨⟨CoPset.mem_full, fun h => hx.right h.left⟩, fun h => hx.right (HN x h)⟩
-  iapply aacc_aupd HE $$ AU
-  iintro %x Hα
-  iapply aacc_intro subset_refl $$ %x [HI Hα]
-  · isimp only [Tele.app_bind]
-    iframe
-  isplit
-  · iintro H
-    isimp only [Tele.app_bind] at H
-    icases H with ⟨HI, Hα⟩
-    imodintro
-    iframe Hα
-    iintro AU !>
-    -- `iinv` δ-reduced the `-∗?` of `POST` in the goal, so reduce it in `AU` too.
-    iunfold BIBase.wandM at AU
-    iframe HI AU
-  · iintro %y H
-    isimp only [Tele.app_bind] at H
-    icases H with ⟨HI, Hβ⟩
-    imodintro
-    isimp only [Tele.app_bind]
-    iright
-    iexists y
-    iframe Hβ
-    iintro HΦ !>
-    iunfold BIBase.wandM at HΦ
-    iframe HI HΦ
 
 end lemmas
 

--- a/Iris/Iris/ProgramLogic/Atomic.lean
+++ b/Iris/Iris/ProgramLogic/Atomic.lean
@@ -11,39 +11,7 @@ public import Iris.ProgramLogic.WeakestPre
 
 @[expose] public section
 
-/-!
-# Logically atomic Hoare triples
-
-This file declares notation for logically atomic Hoare triples, and some generic lemmas about
-them. To enable the definition of a shared theory applying to triples with any number of binders,
-the triples themselves are defined via telescopes, but as a user you need not be concerned with
-that. You can just use the following notation:
-```
-<<{ ∀∀ x, atomic_precondition }>>
-  code @ E
-<<{ ∃∃ y, atomic_postcondition | z, RET return_value ; private_postcondition }>>
-```
-Here, `x` (which can be any number of binders, including 0) is bound in all of the atomic pre- and
-postcondition and the private (non-atomic) postcondition and the return value, `y` (which can be
-any number of binders, including 0) is bound in both postconditions and the return value, and `z`
-(which can be any number of binders, including 0) is bound in the return value and the private
-postcondition.
-
-Note that atomic triples are *not* implicitly persistent, unlike Texan triples. If you need a
-private (non-atomic) precondition, you can use a magic wand:
-```
-private_precondition -∗
-<<{ ∀∀ x, atomic_precondition }>>
-  code @ E
-<<{ ∃∃ y, atomic_postcondition | z, RET return_value ; private_postcondition }>>
-```
-If you don't need a private postcondition, you can leave it away, e.g.:
-```
-<<{ ∀∀ x, atomic_precondition }>>
-  code @ E
-<<{ ∃∃ y, atomic_postcondition | RET return_value }>>
-```
--/
+/-!  # Logically atomic Hoare triples -/
 
 namespace Iris
 open ProgramLogic Language Language.Notation Std Std.LawfulSet BI ProofMode
@@ -121,16 +89,6 @@ def awpRetGroup (zs : Array Ident) : DelabM (Option (TSyntax ``awpRetBinders)) :
   if zs.isEmpty then return none
   return some (← `(awpRetBinders| $(← auPlainBinders zs), ))
 
-/-- Delaborate the body of the private postcondition, which is an `Option`. -/
-def delabOptionBody : DelabM (Option Term) := do
-  let e ← getExpr
-  if e.isAppOfArity ``Option.some 2 then
-    return some (← unpackIprop (← withNaryArg 1 delab))
-  else if e.isAppOfArity ``Option.none 1 then
-    return none
-  else
-    failure
-
 @[app_delab Iris.atomic_wp]
 def delabAtomicWp : Delab := do
   let e ← getExpr
@@ -145,7 +103,12 @@ def delabAtomicWp : Delab := do
     Tele.withFun nB fun ys => return (ys, ← delab)
   let (zs, POST) ← withNaryArg 15 <| Tele.withFunUsing nA (xs.map (·.getId)) fun _ =>
     Tele.withFunUsing nB (ys.map (·.getId)) fun _ =>
-      Tele.withFun nP fun zs => return (zs, ← delabOptionBody)
+      Tele.withFun nP fun zs => do
+        let e ← getExpr
+        match_expr e with
+        | Option.some _ _ => return (zs, some (← unpackIprop (← withNaryArg 1 delab)))
+        | Option.none _ => return (zs, none)
+        | _ => failure
   let v ← withNaryArg 16 <| Tele.withFunUsing nA (xs.map (·.getId)) fun _ =>
     Tele.withFunUsing nB (ys.map (·.getId)) fun _ =>
       Tele.withFunUsing nP (zs.map (·.getId)) fun _ => delab
@@ -178,7 +141,7 @@ theorem atomic_wp_seq :
   iapply Hwp
   iauintro
   iaaccintro Hα
-  · iintro Hα !> //
+  · iintro $
   · iintro %y Hβ !>
     isimp only [Tele.app_bind]
     iintro %z Hpost HΦ
@@ -194,32 +157,24 @@ theorem atomic_wp_inv {N : Namespace} {I : IProp GF} (HN : (↑N : CoPset) ⊆ E
   iauintro
   iinv N with HI
   · exact ⟨fun x hx => mem_diff.mpr ⟨CoPset.mem_full, fun h => (mem_diff.mp h).right hx⟩, trivial⟩
-  have HE : (⊤ \ E : CoPset) ⊆ (⊤ \ (E \ ↑N)) \ ↑N := by
-    intro x hx
+  iapply aacc_aupd $$ AU
+  · intro x hx
     simp only [mem_diff] at hx ⊢
     exact ⟨⟨CoPset.mem_full, fun h => hx.right h.left⟩, fun h => hx.right (HN x h)⟩
-  iapply aacc_aupd HE $$ AU
   iintro %x Hα
-  iaaccintro %x [HI Hα]
-  · -- the atomic precondition `▷ I ∗ α x`
-    isimp only [Tele.app_bind]
+  iaaccintro %x [HI Hα] <;> isimp only [Tele.app_bind]
+  · iframe
+  · iintro ⟨HI, $⟩
+    iintro !> AU !>
+    simp []
     iframe
-  · iintro H
-    isimp only [Tele.app_bind] at H
-    icases H with ⟨HI, Hα⟩
-    iintro !> {$Hα} AU !>
-    -- `iinv` δ-reduced the `-∗?` of `POST` in the goal, so reduce it in `AU` too.
-    iunfold BIBase.wandM at AU
-    iframe HI AU
   · iintro %y H
-    isimp only [Tele.app_bind] at H
     icases H with ⟨HI, Hβ⟩
     imodintro
-    isimp only [Tele.app_bind]
     iright
     iexists y
     iintro {$Hβ} HΦ !>
-    iunfold BIBase.wandM at HΦ
+    simp []
     iframe HI HΦ
 
 
@@ -227,12 +182,10 @@ theorem atomic_wp_inv {N : Namespace} {I : IProp GF} (HN : (↑N : CoPset) ⊆ E
 `(∀.. y, β x y -∗ Φ (f x y))`. -/
 @[rocq_alias atomic_wp_seq_step]
 theorem atomic_wp_seq_step [toVal_e : TCEq (toVal e) none] :
-    atomic_wp e E α β POST f ⊢
+    atomic_wp e E α β POST f -∗
     ∀ Φ, ∀.. x, α x -∗ ▷ (∀.. y, β x y -∗ ∀.. z, POST x y z -∗? Φ (f x y z)) -∗ WP e {{ Φ }} := by
   iintro Hwp %Φ %x Hα HΦ
-  iapply wp_step_fupd (P := iprop(∀.. y, β x y -∗ ∀.. z, POST x y z -∗? Φ (f x y z)))
-    toVal_e.to_eq subset_refl $$ [HΦ]
-  · iapply step_fupd_intro subset_refl $$ HΦ
+  iapply wp_step_fupd toVal_e.to_eq subset_refl $$ [$HΦ //]
   iapply atomic_wp_seq $$ Hwp Hα
   iintro %y Hβ %z Hpost HΦ
   iapply HΦ $$ Hβ Hpost
@@ -263,8 +216,7 @@ theorem persistent_seq_wp_atomic {α : Tele.Arg .nil → IProp GF}
   iunfold atomic_wp
   iintro Hwp %Φ HΦ
   iapply fupd_wp
-  imod HΦ with ⟨%⟨⟩, Hα, Hclose, -⟩
-  iintuitionistic Hα
+  imod HΦ with ⟨%⟨⟩, #Hα, Hclose, -⟩
   imod Hclose $$ Hα with HΦ
   iapply wp_fupd
   iapply Hwp $$ Hα

--- a/Iris/Iris/ProgramLogic/Atomic.lean
+++ b/Iris/Iris/ProgramLogic/Atomic.lean
@@ -1,0 +1,308 @@
+/-
+Copyright (c) 2026. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
+module
+
+public import Iris.BI.Lib.Atomic
+public import Iris.Instances.Lib.Invariants
+public import Iris.ProgramLogic.WeakestPre
+
+@[expose] public section
+
+/-!
+# Logically atomic Hoare triples
+
+This file declares notation for logically atomic Hoare triples, and some generic lemmas about
+them. To enable the definition of a shared theory applying to triples with any number of binders,
+the triples themselves are defined via telescopes, but as a user you need not be concerned with
+that. You can just use the following notation:
+```
+<<{ ∀∀ x, atomic_precondition }>>
+  code @ E
+<<{ ∃∃ y, atomic_postcondition | z, RET return_value ; private_postcondition }>>
+```
+Here, `x` (which can be any number of binders, including 0) is bound in all of the atomic pre- and
+postcondition and the private (non-atomic) postcondition and the return value, `y` (which can be
+any number of binders, including 0) is bound in both postconditions and the return value, and `z`
+(which can be any number of binders, including 0) is bound in the return value and the private
+postcondition.
+
+Note that atomic triples are *not* implicitly persistent, unlike Texan triples. If you need a
+private (non-atomic) precondition, you can use a magic wand:
+```
+private_precondition -∗
+<<{ ∀∀ x, atomic_precondition }>>
+  code @ E
+<<{ ∃∃ y, atomic_postcondition | z, RET return_value ; private_postcondition }>>
+```
+If you don't need a private postcondition, you can leave it away, e.g.:
+```
+<<{ ∀∀ x, atomic_precondition }>>
+  code @ E
+<<{ ∃∃ y, atomic_postcondition | RET return_value }>>
+```
+Unlike in Iris Rocq, where combinatorial explosion forces one notation per variant, every binder
+group and the private postcondition are optional parts of a single notation here.
+-/
+
+namespace Iris
+open ProgramLogic Language Language.Notation Std Std.LawfulSet BI ProofMode
+
+section definition
+
+variable {hlc : outParam HasLC} {Expr State Obs Val}
+variable [Λ : Language Expr State Obs Val]
+variable {GF : BundledGFunctors} [ι : IrisGS_gen hlc Expr GF] {TA TB TP : Tele}
+
+/-- A logically atomic Hoare triple: `e` refines the atomic update from `α` to `β`, and returns
+`f x y z` while handing back the private postcondition `POST x y z`.
+
+The inner mask is hard-coded to be empty, because we have yet to find an example where we want it
+to be anything else. The mask `E` is the *implementation* mask; the mask left to the client of the
+triple is `⊤ \ E`.
+
+For the non-atomic postcondition, we use an `Option`, combined with a `-∗?`. This is to avoid
+introducing spurious `emp -∗` into proofs that do not need a non-atomic postcondition (which is
+most of them). -/
+@[rocq_alias atomic_wp]
+def atomic_wp (e : Expr) (E : CoPset) (α : TA.Arg → IProp GF)
+    (β : TA.Arg → TB.Arg → IProp GF) (POST : TA.Arg → TB.Arg → TP.Arg → Option (IProp GF))
+    (f : TA.Arg → TB.Arg → TP.Arg → Val) : IProp GF :=
+  iprop(∀ Φ, atomic_update (⊤ \ E) ∅ α β
+    (λ.. x y, iprop(∀.. z, POST x y z -∗? Φ (f x y z))) -∗ WP e {{ Φ }})
+
+end definition
+
+/-! ## Notation -/
+
+public meta section
+open Lean PrettyPrinter Delaborator SubExpr
+
+/-- The `z₁ … zₙ,` binder group of the return value of an atomic triple. -/
+syntax awpRetBinders := explicitBinders ", "
+
+/-- `<<{ ∀∀ x, α }>> e @ E <<{ ∃∃ y, β | z, RET v ; POST }>>` is the logically atomic Hoare
+triple `atomic_wp e E α β POST f` over the telescopes bound by `∀∀ …`, `∃∃ …` and `z …`. Every
+binder group and the private postcondition `; POST` may be omitted. -/
+syntax:max (name := atomicWpNotation)
+  ppGroup("<<{ " (auAllBinders)? term " }>>" ppSpace term:max " @ " term:max ppSpace
+    "<<{ " (auExBinders)? term " | " (atomic(awpRetBinders))? &"RET " term
+      (" ; " term)? " }>>") : term
+
+/-- The telescopes and the telescopic functions `α`, `β`, `POST` and `f` of an atomic triple. -/
+def awpArgs (xs : Option (TSyntax ``auAllBinders)) (ys : Option (TSyntax ``auExBinders))
+    (zs : Option (TSyntax ``awpRetBinders)) (α β v : Term) (POST : Option Term) :
+    MacroM (Term × Term × Term × Term × Term × Term × Term) := do
+  let xstx? := xs.map fun xs => (⟨xs.raw[1]⟩ : TSyntax ``Lean.explicitBinders)
+  let ystx? := ys.map fun ys => (⟨ys.raw[1]⟩ : TSyntax ``Lean.explicitBinders)
+  let zstx? := zs.map fun zs => (⟨zs.raw[0]⟩ : TSyntax ``Lean.explicitBinders)
+  let TA ← Tele.expandLiteral xstx?
+  let TB ← Tele.expandLiteral ystx?
+  let TP ← Tele.expandLiteral zstx?
+  let POSTArg ← match POST with
+    | some POST => `(some iprop($POST))
+    | none => `(none)
+  let underAll (body : Term) : MacroM Term := do
+    Tele.expandFun TA xstx? (← Tele.expandFun TB ystx? (← Tele.expandFun TP zstx? body))
+  return (TA, TB, TP,
+    ← Tele.expandFun TA xstx? (← `(iprop($α))),
+    ← Tele.expandFun TA xstx? (← Tele.expandFun TB ystx? (← `(iprop($β)))),
+    ← underAll POSTArg, ← underAll v)
+
+macro_rules
+  | `(iprop(<<{%$tk $[$xs]? $α }>> $e @ $E <<{ $[$ys]? $β | $[$zs]? RET $v $[; $POST]? }>>)) => do
+    let (TA, TB, TP, α, β, POST, f) ← awpArgs xs ys zs α β v POST
+    ``($(wrapIprop tk ``atomic_wp) (TA := $TA) (TB := $TB) (TP := $TP) $e $E $α $β $POST $f)
+
+/-! ### Delaboration -/
+
+/-- The `z₁ … zₙ,` group, or `none` for the empty telescope. -/
+def awpRetGroup (zs : Array Ident) : DelabM (Option (TSyntax ``awpRetBinders)) := do
+  if zs.isEmpty then return none
+  return some (← `(awpRetBinders| $(← auPlainBinders zs), ))
+
+/-- Delaborate the body of the private postcondition, which is an `Option`. -/
+def delabOptionBody : DelabM (Option Term) := do
+  let e ← getExpr
+  if e.isAppOfArity ``Option.some 2 then
+    return some (← unpackIprop (← withNaryArg 1 delab))
+  else if e.isAppOfArity ``Option.none 1 then
+    return none
+  else
+    failure
+
+@[app_delab Iris.atomic_wp]
+def delabAtomicWp : Delab := do
+  let e ← getExpr
+  unless e.isAppOfArity ``atomic_wp 17 do failure
+  let some nA := Tele.literalArity? (e.getArg! 8) | failure
+  let some nB := Tele.literalArity? (e.getArg! 9) | failure
+  let some nP := Tele.literalArity? (e.getArg! 10) | failure
+  let prog ← withNaryArg 11 delab
+  let E ← withNaryArg 12 delab
+  let (xs, α) ← withNaryArg 13 <| Tele.withFun nA fun xs => return (xs, ← delab)
+  let (ys, β) ← withNaryArg 14 <| Tele.withFunUsing nA (xs.map (·.getId)) fun _ =>
+    Tele.withFun nB fun ys => return (ys, ← delab)
+  let (zs, POST) ← withNaryArg 15 <| Tele.withFunUsing nA (xs.map (·.getId)) fun _ =>
+    Tele.withFunUsing nB (ys.map (·.getId)) fun _ =>
+      Tele.withFun nP fun zs => return (zs, ← delabOptionBody)
+  let v ← withNaryArg 16 <| Tele.withFunUsing nA (xs.map (·.getId)) fun _ =>
+    Tele.withFunUsing nB (ys.map (·.getId)) fun _ =>
+      Tele.withFunUsing nP (zs.map (·.getId)) fun _ => delab
+  `(iprop(<<{ $[$(← auAllGroup xs)]? $(← unpackIprop α) }>> $prog @ $E
+      <<{ $[$(← auExGroup ys)]? $(← unpackIprop β) | $[$(← awpRetGroup zs)]? RET $v
+        $[; $POST]? }>>))
+
+end
+
+/-! ## Theory -/
+
+section lemmas
+
+variable {hlc : outParam HasLC} {Expr State Obs Val}
+variable [Λ : Language Expr State Obs Val]
+variable {GF : BundledGFunctors} [ι : IrisGS_gen hlc Expr GF]
+variable {TA TB TP : Tele} {e : Expr} {E : CoPset}
+variable {α : TA.Arg → IProp GF} {β : TA.Arg → TB.Arg → IProp GF}
+variable {POST : TA.Arg → TB.Arg → TP.Arg → Option (IProp GF)}
+variable {f : TA.Arg → TB.Arg → TP.Arg → Val}
+
+/-- Atomic triples imply sequential triples. -/
+@[rocq_alias atomic_wp_seq]
+theorem atomic_wp_seq :
+    atomic_wp e E α β POST f ⊢
+    ∀ Φ, ∀.. x, α x -∗ (∀.. y, β x y -∗ ∀.. z, POST x y z -∗? Φ (f x y z)) -∗ WP e {{ Φ }} := by
+  iunfold atomic_wp
+  iintro Hwp %Φ %x Hα HΦ
+  iapply wp_frame_wand $$ HΦ
+  iapply Hwp
+  iunfold atomic_update
+  iapply greatest_fixpoint_coiter _ (fun _ => α x) $$ [] Hα
+  iintro !> %_ Hα
+  iunfold atomic_update_pre, atomic_acc
+  iapply fupd_mask_intro empty_subset
+  iintro Hclose
+  iexists x
+  iframe Hα
+  isplit
+  · iintro Hα
+    imod Hclose
+    itrivial
+  · iintro %y Hβ
+    imod Hclose
+    isimp only [Tele.app_bind]
+    iintro !> %z Hpost HΦ
+    iapply HΦ $$ Hβ Hpost
+
+/-- This version matches the Texan triple, i.e., with a later in front of the
+`(∀.. y, β x y -∗ Φ (f x y))`. -/
+@[rocq_alias atomic_wp_seq_step]
+theorem atomic_wp_seq_step [toVal_e : TCEq (toVal e) none] :
+    atomic_wp e E α β POST f ⊢
+    ∀ Φ, ∀.. x, α x -∗ ▷ (∀.. y, β x y -∗ ∀.. z, POST x y z -∗? Φ (f x y z)) -∗ WP e {{ Φ }} := by
+  iintro Hwp %Φ %x Hα HΦ
+  iapply wp_step_fupd (P := iprop(∀.. y, β x y -∗ ∀.. z, POST x y z -∗? Φ (f x y z)))
+    toVal_e.to_eq subset_refl $$ [HΦ]
+  · iapply step_fupd_intro subset_refl $$ HΦ
+  iapply atomic_wp_seq $$ Hwp Hα
+  iintro %y Hβ %z Hpost HΦ
+  iapply HΦ $$ Hβ Hpost
+
+/-- Sequential triples with the empty mask for a physically atomic `e` are atomic. -/
+@[rocq_alias atomic_seq_wp_atomic]
+theorem atomic_seq_wp_atomic [Atomic .WeaklyAtomic e] :
+    (∀ Φ, ∀.. x, α x -∗ (∀.. y, β x y -∗ ∀.. z, POST x y z -∗? Φ (f x y z)) -∗ WP e @ ∅ {{ Φ }}) ⊢
+    atomic_wp e E α β POST f := by
+  iunfold atomic_wp
+  iintro Hwp %Φ AU
+  imod AU with ⟨%x, Hα, -, Hclose⟩
+  iapply Hwp $$ Hα
+  iintro %y Hβ %z Hpost
+  imod Hclose $$ Hβ with HΦ
+  isimp only [Tele.app_bind] at HΦ
+  iapply HΦ $$ Hpost
+
+/-- Sequential triples with a persistent precondition and no initial quantifier are atomic. -/
+@[rocq_alias persistent_seq_wp_atomic]
+theorem persistent_seq_wp_atomic {α : Tele.Arg .nil → IProp GF}
+    {β : Tele.Arg .nil → TB.Arg → IProp GF}
+    {POST : Tele.Arg .nil → TB.Arg → TP.Arg → Option (IProp GF)}
+    {f : Tele.Arg .nil → TB.Arg → TP.Arg → Val} [Persistent (α .nil)] :
+    (∀ Φ, α .nil -∗
+      (∀.. y, β .nil y -∗ ∀.. z, POST .nil y z -∗? Φ (f .nil y z)) -∗ WP e {{ Φ }}) ⊢
+    atomic_wp e E α β POST f := by
+  iunfold atomic_wp
+  iintro Hwp %Φ HΦ
+  iapply fupd_wp
+  imod HΦ with ⟨%⟨⟩, Hα, Hclose, -⟩
+  iintuitionistic Hα
+  imod Hclose $$ Hα with HΦ
+  iapply wp_fupd
+  iapply Hwp $$ Hα
+  iintro !> %y Hβ %z Hpost
+  imod HΦ with ⟨%⟨⟩, -, -, Hclose⟩
+  imod Hclose $$ Hβ with HΦ
+  isimp only [Tele.app_bind] at HΦ
+  iapply HΦ $$ Hpost
+
+@[rocq_alias atomic_wp_mask_weaken]
+theorem atomic_wp_mask_weaken {E₁ E₂ : CoPset} (HE : E₁ ⊆ E₂) :
+    atomic_wp e E₁ α β POST f ⊢ atomic_wp e E₂ α β POST f := by
+  iunfold atomic_wp
+  iintro Hwp %Φ AU
+  iapply Hwp
+  iapply atomic_update_mask_weaken (diff_subset_diff_right HE) $$ AU
+
+/-- We can open invariants around atomic triples.
+(Just for demonstration purposes; we always use `iinv` in proofs.) -/
+@[rocq_alias atomic_wp_inv]
+theorem atomic_wp_inv {N : Namespace} {I : IProp GF} (HN : (↑N : CoPset) ⊆ E) :
+    atomic_wp e (E \ ↑N) (λ.. x, iprop(▷ I ∗ α x)) (λ.. x y, iprop(▷ I ∗ β x y)) POST f ⊢
+    inv N I -∗ atomic_wp e E α β POST f := by
+  iunfold atomic_wp
+  iintro Hwp #Hinv %Φ AU
+  iapply Hwp
+  iunfold atomic_update
+  iapply greatest_fixpoint_coiter _
+    (fun _ => atomic_update (⊤ \ E) ∅ α β
+      (λ.. x y, iprop(∀.. z, POST x y z -∗? Φ (f x y z)))) $$ [] AU
+  iintro !> %_ AU
+  iunfold atomic_update_pre
+  iinv N with HI
+  · exact ⟨fun x hx => mem_diff.mpr ⟨CoPset.mem_full, fun h => (mem_diff.mp h).right hx⟩, trivial⟩
+  have HE : (⊤ \ E : CoPset) ⊆ (⊤ \ (E \ ↑N)) \ ↑N := by
+    intro x hx
+    simp only [mem_diff] at hx ⊢
+    exact ⟨⟨CoPset.mem_full, fun h => hx.right h.left⟩, fun h => hx.right (HN x h)⟩
+  iapply aacc_aupd HE $$ AU
+  iintro %x Hα
+  iapply aacc_intro subset_refl $$ %x [HI Hα]
+  · isimp only [Tele.app_bind]
+    iframe
+  isplit
+  · iintro H
+    isimp only [Tele.app_bind] at H
+    icases H with ⟨HI, Hα⟩
+    imodintro
+    iframe Hα
+    iintro AU !>
+    -- `iinv` δ-reduced the `-∗?` of `POST` in the goal, so reduce it in `AU` too.
+    iunfold BIBase.wandM at AU
+    iframe HI AU
+  · iintro %y H
+    isimp only [Tele.app_bind] at H
+    icases H with ⟨HI, Hβ⟩
+    imodintro
+    isimp only [Tele.app_bind]
+    iright
+    iexists y
+    iframe Hβ
+    iintro HΦ !>
+    iunfold BIBase.wandM at HΦ
+    iframe HI HΦ
+
+end lemmas
+
+end Iris

--- a/Iris/Iris/Std/GenSets.lean
+++ b/Iris/Iris/Std/GenSets.lean
@@ -451,6 +451,12 @@ theorem diff_subset_left {s₁ s₂ : S} : s₁ \ s₂ ⊆ s₁ := by
   intro y G; rw [mem_diff] at G
   exact G.left
 
+/-- Difference is antitone in its second argument. -/
+theorem diff_subset_diff_right {s t₁ t₂ : S} (H : t₁ ⊆ t₂) : s \ t₂ ⊆ s \ t₁ := by
+  intro x hx
+  rw [mem_diff] at hx ⊢
+  exact ⟨hx.left, fun h => hx.right (H x h)⟩
+
 theorem diff_self_diff_of_subset {s u : S} : s ⊆ u → u \ (u \ s) = s := by
   intro su
   apply eq_subset

--- a/Iris/IrisTest/Atomic.lean
+++ b/Iris/IrisTest/Atomic.lean
@@ -111,9 +111,7 @@ example : (AU <{ ∃∃ x, α x }> @ Eo, Ei <{ ∀∀ y, β x y, COMM Ψ x y }>)
 
 end atomicNotation
 
-/-! Tests for the logically atomic Hoare triple notation. Unlike Iris Rocq, a single notation
-covers all 16 combinations of (non-)empty binder groups and a present/absent private
-postcondition. -/
+/-! Tests for the logically atomic Hoare triple notation. -/
 
 section atomicWpNotation
 variable {hlc : HasLC} {Expr State Obs Val : Type _} [Language Expr State Obs Val]

--- a/Iris/IrisTest/Atomic.lean
+++ b/Iris/IrisTest/Atomic.lean
@@ -5,12 +5,12 @@ Authors: Markus de Medeiros
 -/
 module
 
-public import Iris.BI.Lib.Atomic
+public import Iris.ProgramLogic.Atomic
 
 @[expose] public section
 
 namespace IrisTest
-open Iris Iris.Std BI ProofMode
+open Iris ProgramLogic BI ProofMode Std
 
 /-! Tests for the `AU`/`AACC` notation inside `iprop(…)`: every combination of (non-)empty
 telescopes parses, elaborates to the corresponding `atomic_update`/`atomic_acc` application, and
@@ -110,4 +110,77 @@ example : (AU <{ ∃∃ x, α x }> @ Eo, Ei <{ ∀∀ y, β x y, COMM Ψ x y }>)
   aupd_aacc
 
 end atomicNotation
+
+/-! Tests for the logically atomic Hoare triple notation. Unlike Iris Rocq, a single notation
+covers all 16 combinations of (non-)empty binder groups and a present/absent private
+postcondition. -/
+
+section atomicWpNotation
+variable {hlc : HasLC} {Expr State Obs Val : Type _} [Language Expr State Obs Val]
+variable {GF : BundledGFunctors} [IrisGS_gen hlc Expr GF]
+variable (e : Expr) (E : CoPset) (w : Val) (P : IProp GF)
+  (α : Nat → IProp GF) (β : Nat → Bool → IProp GF) (γ : Nat → Bool → Unit → IProp GF)
+  (g : Nat → Bool → Unit → Val)
+
+/-! All binder groups and the private postcondition present. -/
+
+/--
+info: iprop(<<{ ∀∀ x, α x }>> e @ E <<{ ∃∃ y, β x y | z, RET g x y z ; γ x y z }>>) : IProp GF
+-/
+#guard_msgs (whitespace := lax) in
+#check iprop(<<{ ∀∀ x, α x }>> e @ E <<{ ∃∃ y, β x y | z, RET g x y z ; γ x y z }>>)
+
+/-! No `RET` binders. -/
+
+/-- info: iprop(<<{ ∀∀ x, α x }>> e @ E <<{ ∃∃ y, β x y | RET w ; P }>>) : IProp GF -/
+#guard_msgs in
+#check iprop(<<{ ∀∀ x, α x }>> e @ E <<{ ∃∃ y, β x y | RET w ; P }>>)
+
+/-! No private postcondition. -/
+
+/-- info: iprop(<<{ ∀∀ x, α x }>> e @ E <<{ ∃∃ y, β x y | RET w }>>) : IProp GF -/
+#guard_msgs in
+#check iprop(<<{ ∀∀ x, α x }>> e @ E <<{ ∃∃ y, β x y | RET w }>>)
+
+/-! Empty `∀∀` telescope. -/
+
+/-- info: iprop(<<{ P }>> e @ E <<{ ∃∃ y, β 0 y | RET w }>>) : IProp GF -/
+#guard_msgs in
+#check iprop(<<{ P }>> e @ E <<{ ∃∃ y, β 0 y | RET w }>>)
+
+/-! Empty `∃∃` telescope. -/
+
+/-- info: iprop(<<{ ∀∀ x, α x }>> e @ E <<{ β 0 true | RET w }>>) : IProp GF -/
+#guard_msgs in
+#check iprop(<<{ ∀∀ x, α x }>> e @ E <<{ β 0 true | RET w }>>)
+
+/-! All telescopes empty, no private postcondition. -/
+
+/-- info: iprop(<<{ P }>> e @ E <<{ P | RET w }>>) : IProp GF -/
+#guard_msgs in
+#check iprop(<<{ P }>> e @ E <<{ P | RET w }>>)
+
+/-! The implementation mask may be a compound term, in parentheses. -/
+
+/-- info: iprop(<<{ P }>> e @ (⊤ \ E) <<{ P | RET w ; P }>>) : IProp GF -/
+#guard_msgs in
+#check iprop(<<{ P }>> e @ (⊤ \ E) <<{ P | RET w ; P }>>)
+
+/-! Several binders per group, with type ascriptions. Binder types are inferred from the bodies,
+so they are not printed. -/
+
+/--
+info: iprop(<<{ ∀∀ x₁ x₂, α x₁ ∗ α x₂ }>> e @ E
+    <<{ ∃∃ y₁ y₂, β x₁ y₁ ∗ β x₂ y₂ | RET w }>>) : IProp GF
+-/
+#guard_msgs (whitespace := lax) in
+#check iprop(<<{ ∀∀ (x₁ : Nat) (x₂ : Nat), α x₁ ∗ α x₂ }>> e @ E
+  <<{ ∃∃ (y₁ : Bool) (y₂ : Bool), β x₁ y₁ ∗ β x₂ y₂ | RET w }>>)
+
+/-! The notation elaborates to exactly the term the theory is stated with. -/
+example : (<<{ ∀∀ x, α x }>> e @ E <<{ ∃∃ y, β x y | RET w }>>) ⊢
+    <<{ ∀∀ x, α x }>> e @ ⊤ <<{ ∃∃ y, β x y | RET w }>> :=
+  atomic_wp_mask_weaken CoPset.subseteq_top
+
+end atomicWpNotation
 end IrisTest


### PR DESCRIPTION
## Description
Port the atomic part of ProgramLogic

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
