### PR TITLE
draft: HeapLang twp examples

### DIFF
--- a/Iris/Iris/HeapLang.lean
+++ b/Iris/Iris/HeapLang.lean
@@ -12,3 +12,4 @@ public import Iris.HeapLang.ProofMode
 public import Iris.HeapLang.Semantics
 public import Iris.HeapLang.Syntax
 public import Iris.HeapLang.Tactic
+public import Iris.HeapLang.TotalAdequacy

--- a/Iris/Iris/HeapLang/PrimitiveLaws.lean
+++ b/Iris/Iris/HeapLang/PrimitiveLaws.lean
@@ -216,6 +216,30 @@ theorem wp_fork {e : Exp} :
   imodintro
   iframe
 
+@[rocq_alias heap_lang.twp_fork]
+theorem twp_fork {e : Exp} :
+    WP e @ s; ⊤ [{ _v, True }] -∗
+    Φ (hl_val(#())) -∗
+    WP hl(fork(&e)) @ s; E [{ Φ }] := by
+  iintro Hwp HΦ
+  iapply twp.lift_atomic_base_step rfl
+  iintro %σ₁ %ns %obs %nt Hσ !>
+  isplit
+  · ipureintro
+    exact ⟨hl(#BaseLit.unit), σ₁, [e], by constructor⟩
+  iintro %κ %e₂ %σ₂ %eₜ %Hstep
+  rcases Hstep
+  imodintro
+  isplit; itrivial
+  iframe Hσ
+  isplitr [Hwp]
+  · iexists hl_val(#())
+    isplit
+    · ipureintro; rfl
+    · iframe HΦ
+  · iapply BI.BigSepL.bigSepL_singleton
+    iframe Hwp
+
 /-! ## Multi-cell allocation -/
 
 @[rocq_alias heap_lang.heap_array_to_seq_pointsto]
@@ -293,18 +317,25 @@ theorem wp_allocN_seq (v : Val) {n : Int} (hn : 0 < n) :
   iapply HΦ
   itrivial
 
+@[rocq_alias heap_lang.twp_alloc]
+theorem twp_alloc (v : Val) :
+    [{ True }] hl(ref(&v)) @ s; E [{ l, RET hl_val(#l); l ↦ some v ∗ metaToken l ⊤ }] := by
+  iintro %Φ - HΦ
+  iapply twp_allocN_seq (by omega)
+  · itrivial
+  iintro %l H
+  rw [Int.toNat_one, List.range_one, BI.BigSepL.bigSepL_singleton.to_eq,
+    show l + 0 = l from loc_add_zero l]
+  iapply HΦ $$ H
+
 @[rocq_alias heap_lang.wp_alloc]
 theorem wp_alloc (v : Val) :
     {{ True }} hl(ref(&v)) @ s; E {{ l, RET hl_val(#l); l ↦ some v }} := by
   iintro %Φ _ HΦ
   iapply twp.wp_step _ rfl $$ HΦ
-  iapply twp_allocN_seq (by omega)
+  iapply twp_alloc
   · itrivial
-  iintro %l H HΦ
-  ihave Hpt : iprop(l ↦ some v) $$ [H]
-  · rw [Int.toNat_one, List.range_one, BI.BigSepL.bigSepL_singleton.to_eq]
-    rw [show l + 0 = l from loc_add_zero l]
-    exact BI.sep_elim_left
+  iintro %l ⟨Hpt, -⟩ HΦ
   iapply HΦ $$ Hpt
 
 @[rocq_alias heap_lang.twp_load]
@@ -487,40 +518,44 @@ theorem wp_cmpXchg_true {l : Loc} {v' : Val} {e1 : Exp} {v1 : Val} {e2 : Exp} {v
   iapply HΦ
   itrivial
 
+@[rocq_alias heap_lang.twp_free]
+theorem twp_free {l : Loc} {v : Val} :
+    [{ l ↦ some v }] hl(free(#l)) @ s; E [{ RET hl_val(#()); l ↦ none }] := by
+  iintro %Φ Hpt HΦ
+  iapply twp.lift_atomic_base_step_no_fork rfl
+  isimp [stateInterp]
+  iintro %σ₁ %ns %obs %nt ⟨Hσ, Hobs⟩ !>
+  ihave %Hpt : ⌜σ₁.get? l = .some (.some v)⌝ $$ [Hσ Hpt]
+  · icases genHeap_valid $$ [$Hσ $Hpt] with >%_
+    itrivial
+  isplit
+  · ipureintro
+    refine ⟨.val (.lit .unit), σ₁.initHeap l 1 none, [], .freeS l v σ₁ ?_⟩
+    grind
+  iintro %κ %e₂ %σ₂ %efs %Hstep
+  rcases Hstep
+  simp only [Int.toNat_one, List.range_one, List.foldl_cons, Int.cast_ofNat_Int,
+    List.foldl_nil]
+  rw [show l + (0 : Int) = l by cases l; simp only [HAdd.hAdd, Loc.mk.injEq]; grind]
+  imod genHeap_update (v₂ := none) $$ [$Hσ $Hpt] with ⟨Hσ, Hpt⟩
+  imodintro
+  isplit; itrivial
+  isplit; itrivial
+  iframe Hσ Hobs
+  iexists hl_val(#())
+  isplit
+  · ipureintro; rfl
+  · iapply HΦ $$ Hpt
+
 @[rocq_alias heap_lang.wp_free]
 theorem wp_free {l : Loc} {v : Val} :
     {{ ▷ l ↦ some v }} hl(free(#l)) @ s; E {{ RET hl_val(#()); l ↦ none }} := by
   iintro %Φ >Hpt HΦ
-  iapply wp_lift_atomic_step rfl
-  iintro %σ₁ %ns %obs %obs' %nt Hσ !>
-  icases (stateInterp_split σ₁ ns (obs ++ obs') nt).mp $$ Hσ with ⟨Hσ, Hproph⟩
-  ihave %Hpt : ⌜σ₁.get? l = .some (.some v)⌝ $$ [Hσ Hpt]
-  · icases genHeap_valid $$ [$Hσ $Hpt] with >%Heq'
-    itrivial
-  ihave %Hred : ⌜BaseStep.Reducible (hl(free(#l)), σ₁)⌝ $$ []
-  · ipureintro
-    exists [], hl_val(#()), σ₁.initHeap l 1 none, []
-    refine BaseStep.freeS l v _ ?_
-    grind
-  isplitr
-  · ipureintro
-    cases s <;> simp only [Stuckness.MaybeReducible]
-    exact primStep_reducible_of_baseStep_reducible Hred
-  iintro !> %e₂ %σ₂ %eₜ %Heq Hcr
-  rcases baseStep_of_primStep_of_baseStep_reducible Hred Heq with ⟨v'', H⟩
-  ihave Hproph := (prophMapInterp_nil_append obs' σ₁.usedProphId).mp $$ Hproph
-  simp only [stateInterp, Int.toNat_one, List.range_one, List.foldl_cons, Int.cast_ofNat_Int,
-    List.foldl_nil, Algebra.BigOpL.bigOpL_nil]
-  rw [show l + (0 : Int) = l by cases l; simp only [HAdd.hAdd, Loc.mk.injEq]; grind]
-  imod genHeap_update (v₂ := none) $$ [$Hσ $Hpt] with ⟨Hσ, Hpt⟩
-  imodintro
-  iframe Hσ Hproph
-  isplit <;> try itrivial
-  iexists hl_val(#())
-  isplit
-  · ipureintro; simp [toVal]; rfl
-  · iapply HΦ
-    itrivial
+  iapply twp.wp_step _ rfl $$ HΦ
+  iapply twp_free $$ Hpt
+  iintro Hpt HΦ
+  iapply HΦ
+  itrivial
 
 @[rocq_alias heap_lang.twp_xchg]
 theorem twp_xchg {l : Loc} {v w : Val} :

--- a/Iris/Iris/HeapLang/TotalAdequacy.lean
+++ b/Iris/Iris/HeapLang/TotalAdequacy.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2026. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
+module
+
+public import Iris.HeapLang.PrimitiveLaws
+public import Iris.ProgramLogic.TotalAdequacy
+
+/-! # Total adequacy of HeapLang -/
+
+@[expose] public section
+namespace Iris.HeapLang
+
+open ProgramLogic Language Std FromMathlib
+
+/-- A total weakest precondition for `e` makes the thread pool `[e]` strongly normalizing.
+
+Rocq additionally hands the caller `inv_heap_inv`; that premise is dropped here because
+`inv_pointsto` is not yet ported. -/
+@[rocq_alias heap_lang.heap_total]
+theorem heap_total [HeapLangGpreS hlc GF] (s : Stuckness) (e : Exp) (σ : State)
+    (φ : Val → Prop) (m : Nat)
+    (Hwp : ∀ [HeapLangGS hlc GF], ⊢@{IProp GF} £ m -∗ WP e @ s; ⊤ [{ v, ⌜φ v⌝ }]) :
+    Relation.StronglyNormalizing ErasedStep ([e], σ) := by
+  refine twp_total (hlc := hlc) (GF := GF) s e σ (fun v => iprop(⌜φ v⌝)) 0 m ?_
+  iintro %Hinv
+  imod iOwn_alloc (E := GhostMapG.elem) (HeapView.Auth (H := HeapF) (.own 1)
+      (Std.PartialMap.map (fun v : Option Val => toAgree (DiscreteO.mk v)) σ.heap))
+    HeapView.auth_one_valid with ⟨%γh, Hh⟩
+  imod iOwn_alloc (E := GhostMapG.elem) (HeapView.Auth (H := HeapF) (.own 1)
+      (Std.PartialMap.map (fun g : GName => toAgree (DiscreteO.mk g)) (∅ : HeapF GName)))
+    HeapView.auth_one_valid with ⟨%γm, Hm⟩
+  imod (ProphMap.init (H := ProphMapF) ([] : List Observation) σ.usedProphId)
+    with ⟨%Gproph, Hproph⟩
+  letI instHeapLangGS : HeapLangGS hlc GF := ⟨⟨γh, γm⟩, Gproph⟩
+  imodintro
+  iexists (fun σ _ κs _ => iprop(genHeapInterp σ.heap ∗ prophMapInterp κs σ.usedProphId))
+  iexists (fun _ => 0), (fun _ => iprop(True)), (fun _ _ _ _ => fupd_intro)
+  simp only []
+  ihave #Hwp := @Hwp _
+  iframe Hwp Hproph
+  simp only [genHeapInterp]
+  iexists (∅ : HeapF GName)
+  unfold ghost_map_auth
+  iframe Hh Hm
+  ipureintro
+  intro k hk
+  simp [Std.PartialMap.dom, LawfulPartialMap.get?_empty] at hk
+
+end Iris.HeapLang


### PR DESCRIPTION
## Description

These should really use the twp tactics, so this PR should not be merged until it can be updated with those plus the other missing examples 


## Checklist
* [ ] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [ ] I have added my name to the `authors` section of any appropriate files

## Generative AI Guidelines
AI assistance is permitted when making contributions to Iris-Lean, however, generative AI systems tend to produce code which takes a long time to review. 
Please carefully review your code to ensure it meets the following standards.

- Your PR should avoid duplicating constructions found in Iris-Lean or in the Lean standard library.
- `have` statements that do not aid readability or code reuse should be inlined. 
- Your proofs should be shortened such that their overall structure is explicable to a human reader. As a goal, aim to express one idea per line.
- In general, proofs should not perform substantially more case splitting than their Rocq counterparts.

In our experience, a good place to begin refactoring is by re-arranging and combining independent tactic invocations. 
We also find that pointing generative AI systems to the Mathlib code style guidelines can help them perform some of this refactoring work. 
