### PR TITLE
feat: `iauintro` and `iaaccintro`

### DIFF
--- a/Iris/Iris/BI/Lib/Atomic.lean
+++ b/Iris/Iris/BI/Lib/Atomic.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Markus de Medeiros
+Authors: Markus de Medeiros, Alvin Tang
 -/
 module
 

--- a/Iris/Iris/BI/Lib/Atomic.lean
+++ b/Iris/Iris/BI/Lib/Atomic.lean
@@ -514,15 +514,16 @@ elab "iaaccintro" spats:(colGt ppSpace specPat)+ : tactic => do
     have Eo : Q(CoPset) := Eo
     have Ei : Q(CoPset) := Ei
     let mask : Q($Ei ⊆ $Eo) ← iSolveSidecondition q($Ei ⊆ $Eo)
+    -- Handle the argument for the telescopic quantifier
     let xTy := (← whnf <| ← inferType α).bindingDomain!
     let x ← match t with
       | some t => Term.elabTermEnsuringType t xTy
-      | none   => mkFreshExprMVar xTy (userName := `x)
-    let lemPf ← mkAppM ``aacc_intro_wand #[Eo, Ei, α, P, β, Φ, mask, x]
-    let_expr BIBase.EmpValid _ _ A := ← inferType lemPf
-      | throwIPMError "internal error: unexpected statement of aacc_intro_wand"
-    have A : Q($prop) := A
-    have lem : Q(⊢ □?false $A) := lemPf
+      | none => mkFreshExprMVar xTy
+    let pfAacc ← mkAppM ``aacc_intro_wand #[Eo, Ei, α, P, β, Φ, mask, x]
+    let A : Q($prop) ← mkFreshExprMVarQ prop
+    unless ← isDefEq (← inferType pfAacc) q(⊢ $A) do
+      throwIPMError "internal error: unexpected statement of aacc_intro_wand"
+    have pfAacc : Q(⊢ □?false $A) := pfAacc
     -- Discharge the atomic precondition `α x` using the given specialisation patterns
     let ⟨e', hyps', pb, B, pfSpec⟩ ← iSpecializeCore hyps q(false) A goal spats
     -- The closing conjunction of the abort and the commit continuation remains
@@ -535,7 +536,7 @@ elab "iaaccintro" spats:(colGt ppSpace specPat)+ : tactic => do
       $e ∗ □?false $A ⊢ $goal) := pfSpec
     let pfAbort ← addBIGoal hyps' abortGoal `abort
     let pfCommit ← addBIGoal hyps' commitGoal `commit
-    mvar.assign q(tac_aacc_intro $lem $pfSpec $pfAbort $pfCommit)
+    mvar.assign q(tac_aacc_intro $pfAacc $pfSpec $pfAbort $pfCommit)
 
 end
 

--- a/Iris/Iris/BI/Lib/Atomic.lean
+++ b/Iris/Iris/BI/Lib/Atomic.lean
@@ -478,10 +478,58 @@ theorem tac_aupd_intro {e eI eS : PROP} {Eo Ei : CoPset} {α : TA.Arg → PROP}
   exact h.mp.trans <| aupd_intro (h.mpr.trans H)
 
 public meta section
+open Lean Meta Qq Expr
 
-elab "iauintro " : tactic => do
+def isEmp (e : Expr) : Bool := e.consumeMData.isAppOfArity ``emp 2
+
+def splitIntuitionisticSpatial {prop : Q(Type u)} {bi : Q(BI $prop)} :
+    ∀ {e : Q($prop)}, Hyps bi e →
+      (eI : Q($prop)) × (eS : Q($prop)) × Q($e ⊣⊢ $eI ∗ $eS) × Q($eI ⊢ □ $eI)
+  | _, .emp _ =>
+    ⟨q(iprop(emp)), q(iprop(emp)), q(emp_sep_rev), q(intuitionistically_emp.mpr)⟩
+  | _, .hyp _ _ _ p ty _ =>
+    match matchBool p with
+    | .inl _ =>
+      ⟨q(iprop(□ $ty)), q(iprop(emp)), q(sep_emp_rev), q(intuitionistically_idem.mpr)⟩
+    | .inr _ =>
+      ⟨q(iprop(emp)), ty, q(emp_sep_rev), q(intuitionistically_emp.mpr)⟩
+  | _, .sep _ _ _ _ lhs rhs =>
+    let ⟨eIl, eSl, pfl, pIl⟩ := splitIntuitionisticSpatial lhs
+    let ⟨eIr, eSr, pfr, pIr⟩ := splitIntuitionisticSpatial rhs
+    -- The `emp` branches retype an equivalence that only definitionally has the stated type,
+    -- in the same way `Hyps.buildAccuProof` retypes its accumulator.
+    let ⟨eI, hI, pI⟩ : (eI : Q($prop)) × Q(iprop($eIl ∗ $eIr) ⊣⊢ $eI) × Q($eI ⊢ □ $eI) :=
+      if isEmp eIl then
+        let h : Q(iprop(emp) ∗ $eIr ⊣⊢ $eIr) := q(emp_sep)
+        ⟨eIr, h, pIr⟩
+      else if isEmp eIr then
+        let h : Q($eIl ∗ iprop(emp) ⊣⊢ $eIl) := q(sep_emp)
+        ⟨eIl, h, pIl⟩
+      else
+        ⟨q(iprop($eIl ∗ $eIr)), q(.rfl),
+          q((sep_mono $pIl $pIr).trans intuitionistically_sep_mpr)⟩
+    let ⟨eS, hS⟩ : (eS : Q($prop)) × Q(iprop($eSl ∗ $eSr) ⊣⊢ $eS) :=
+      if isEmp eSl then
+        let h : Q(iprop(emp) ∗ $eSr ⊣⊢ $eSr) := q(emp_sep)
+        ⟨eSr, h⟩
+      else if isEmp eSr then
+        let h : Q($eSl ∗ iprop(emp) ⊣⊢ $eSl) := q(sep_emp)
+        ⟨eSl, h⟩
+      else ⟨q(iprop($eSl ∗ $eSr)), q(.rfl)⟩
+    ⟨eI, eS, q((split_ss $pfl $pfr).trans (sep_congr $hI $hS)), pI⟩
+
+elab "iauintro" : tactic => do
   ProofModeM.runTactic `iauintro λ mvar { prop, bi, e, hyps, goal, .. } => do
-    sorry
+    let some args := (← instantiateMVars goal).consumeMData.appM? ``atomic_update
+      | throwIPMError "the goal {goal} is not an atomic update"
+    -- split the context into its intuitionistic and its spatial part
+    let ⟨eI, eS, hsplit, hI⟩ := splitIntuitionisticSpatial hyps
+    -- `atomic_acc` takes the arguments of `atomic_update` with the abort condition inserted directly after `α`
+    let ACRaw ← mkAppOptM ``atomic_acc <|
+      (args.take 8 |>.push eS |>.append (args.extract 8 args.size)).map some
+    have AC : Q($prop) := ACRaw
+    let m ← addBIGoal hyps AC
+    mvar.assign <| ← mkAppM ``tac_aupd_intro #[hsplit, hI, m]
 
 elab "iaaccintro " spats:(colGt specPat)+ : tactic => do
   ProofModeM.runTactic `iaaccintro λ mvar { prop, bi, e, hyps, goal, .. } => do

--- a/Iris/Iris/BI/Lib/Atomic.lean
+++ b/Iris/Iris/BI/Lib/Atomic.lean
@@ -505,48 +505,45 @@ elab "iauintro" : tactic => do
 elab "iaaccintro" tele?:(" %" term:max)? spats:(colGt ppSpace specPat)+ : tactic => do
   let spats ← liftMacroM <| spats.toList.mapM (SpecPat.parse ·.raw)
   ProofModeM.runTactic `iaaccintro λ mvar { prop, e, hyps, goal, .. } => do
-  let some args := (← instantiateMVars goal).consumeMData.appM? ``atomic_acc
-    | throwIPMError "the goal {goal} is not an atomic accessor"
-  have Eo : Q(CoPset) := args[5]!
-  have Ei : Q(CoPset) := args[6]!
-
-  let mask : Q($Ei ⊆ $Eo) ← iSolveSidecondition q($Ei ⊆ $Eo)
-
-  -- instantiate `aacc_intro` with the arguments of the goal; the first eleven arguments of
-  -- `aacc_intro_wand` are exactly those of `atomic_acc`
-  let αTy ← whnf <| ← inferType args[7]!
-  let x ← match tele? with
-    | some t => Term.elabTermEnsuringType t αTy.bindingDomain!
-    | none   => mkFreshExprMVar αTy.bindingDomain! (userName := `x)
-  let lemPf ← mkAppOptM ``aacc_intro_wand <|
-    (args.map some).push (some mask) |>.push (some x)
-  let lemTy ← instantiateMVars <| ← inferType lemPf
-  let some ARaw :=
-      (match lemTy.consumeMData.appM? ``BIBase.EmpValid with
-        | some #[_, _, A] => some A
-        | _ =>
-          match lemTy.consumeMData.appM? ``Entails with
-          | some #[_, _, _, A] => some A
-          | _ => none)
-    | throwIPMError "internal error: unexpected statement of aacc_intro_wand"
-  have A : Q($prop) := ARaw
-  let pa : Q(Bool) := q(false)
-  have lem : Q(⊢ □?$pa $A) := lemPf
-  -- discharge the atomic precondition `α x` using the given specialisation patterns
-  let ⟨e', hyps', pb, B, pfSpec⟩ ← iSpecializeCore hyps pa A goal spats
-  -- what is left has to be the closing conjunction of the abort and the commit continuation
-  let ~q(iprop(($Pab ∧ $Pcom) -∗ $Q)) := B
-    | throwIPMError "the specialisation patterns must discharge the atomic precondition only, \
-        leaving {B} instead of the abort and commit continuations"
-  unless ← isDefEq Q goal do
-    throwIPMError "internal error: {Q} is not the atomic accessor being proved"
-  -- `B` only definitionally has the shape required by `tac_aacc_intro`, so retype `pfSpec`
-  have pfSpec :
-      Q(($e' ∗ □?$pb iprop(($Pab ∧ $Pcom) -∗ $goal) ⊢ $goal) → $e ∗ □?$pa $A ⊢ $goal) := pfSpec
-  let mAb ← addBIGoal hyps' Pab `abort
-  let mCom ← addBIGoal hyps' Pcom `commit
-  let pf : Q($e ⊢ $goal) := q(tac_aacc_intro $lem $pfSpec (and_intro $mAb $mCom))
-  mvar.assign pf
+    let some args := (← instantiateMVars goal).consumeMData.appM? ``atomic_acc
+      | throwIPMError "the goal {goal} is not an atomic accessor"
+    have Eo : Q(CoPset) := args[5]!
+    have Ei : Q(CoPset) := args[6]!
+    let mask : Q($Ei ⊆ $Eo) ← iSolveSidecondition q($Ei ⊆ $Eo)
+    -- instantiate `aacc_intro` with the arguments of the goal; the first eleven arguments of
+    -- `aacc_intro_wand` are exactly those of `atomic_acc`
+    let αTy ← whnf <| ← inferType args[7]!
+    let x ← match tele? with
+      | some t => Term.elabTermEnsuringType t αTy.bindingDomain!
+      | none   => mkFreshExprMVar αTy.bindingDomain! (userName := `x)
+    let lemPf ← mkAppOptM ``aacc_intro_wand <|
+      (args.map some).push (some mask) |>.push (some x)
+    let lemTy ← instantiateMVars <| ← inferType lemPf
+    let some ARaw :=
+        (match lemTy.consumeMData.appM? ``BIBase.EmpValid with
+          | some #[_, _, A] => some A
+          | _ =>
+            match lemTy.consumeMData.appM? ``Entails with
+            | some #[_, _, _, A] => some A
+            | _ => none)
+      | throwIPMError "internal error: unexpected statement of aacc_intro_wand"
+    have A : Q($prop) := ARaw
+    let pa : Q(Bool) := q(false)
+    have lem : Q(⊢ □?$pa $A) := lemPf
+    -- discharge the atomic precondition `α x` using the given specialisation patterns
+    let ⟨e', hyps', pb, B, pfSpec⟩ ← iSpecializeCore hyps pa A goal spats
+    -- what is left has to be the closing conjunction of the abort and the commit continuation
+    let ~q(iprop(($Pab ∧ $Pcom) -∗ $Q)) := B
+      | throwIPMError "the specialisation patterns must discharge the atomic precondition only, \
+          leaving {B} instead of the abort and commit continuations"
+    unless ← isDefEq Q goal do
+      throwIPMError "internal error: {Q} is not the atomic accessor being proved"
+    -- `B` only definitionally has the shape required by `tac_aacc_intro`, so retype `pfSpec`
+    have pfSpec :
+        Q(($e' ∗ □?$pb iprop(($Pab ∧ $Pcom) -∗ $goal) ⊢ $goal) → $e ∗ □?$pa $A ⊢ $goal) := pfSpec
+    let mAb ← addBIGoal hyps' Pab `abort
+    let mCom ← addBIGoal hyps' Pcom `commit
+    mvar.assign q(tac_aacc_intro $lem $pfSpec (and_intro $mAb $mCom))
 
 end
 

--- a/Iris/Iris/BI/Lib/Atomic.lean
+++ b/Iris/Iris/BI/Lib/Atomic.lean
@@ -464,19 +464,20 @@ end lemmas
 
 section ProofMode
 
-variable [BI PROP] {TA TB : Tele}
+variable [BI PROP] [BIFUpdate PROP] {TA TB : Tele}
 
 @[rocq_alias tac_aupd_intro]
-theorem tac_aupd_intro [BIFUpdate PROP] {e eI eS : PROP} {Eo Ei : CoPset} {α : TA.Arg → PROP}
+theorem tac_aupd_intro {e eI eS : PROP} {Eo Ei : CoPset} {α : TA.Arg → PROP}
     {β Φ : TA.Arg → TB.Arg → PROP} (hsplit : e ⊣⊢ eI ∗ eS) (hI : eI ⊢ □ eI)
     (H : e ⊢ atomic_acc Eo Ei α eS β Φ) :
     e ⊢ atomic_update Eo Ei α β Φ := by
   have h : e ⊣⊢ <pers> eI ∧ eS := calc
-    _ ⊣⊢ eI ∗ eS        := hsplit.trans .rfl
+    _ ⊣⊢ eI ∗ eS        := hsplit
     _ ⊣⊢ □ eI ∗ eS      := sep_congr_left ⟨hI, intuitionistically_elim⟩
     _ ⊣⊢ <pers> eI ∧ eS := persistently_and_intuitionistically_sep_left.symm
   exact h.mp.trans <| aupd_intro (h.mpr.trans H)
 
+omit [BIFUpdate PROP] in
 theorem tac_aacc_intro {pa pb : Bool} {e e' A R Q : PROP} (hlem : ⊢ □?pa A)
     (hspec : (e' ∗ □?pb (R -∗ Q) ⊢ Q) → e ∗ □?pa A ⊢ Q) (hR : e' ⊢ R) : e ⊢ Q :=
   have hA : emp ⊢ □?pa A := hlem
@@ -487,57 +488,19 @@ theorem tac_aacc_intro {pa pb : Bool} {e e' A R Q : PROP} (hlem : ⊢ □?pa A)
 public meta section
 open Lean Meta Elab Qq Expr
 
-def isEmp (e : Expr) : Bool := e.consumeMData.isAppOfArity ``emp 2
-
-def splitIntuitionisticSpatial {prop : Q(Type u)} {bi : Q(BI $prop)} :
-    ∀ {e : Q($prop)}, Hyps bi e →
-      (eI : Q($prop)) × (eS : Q($prop)) × Q($e ⊣⊢ $eI ∗ $eS) × Q($eI ⊢ □ $eI)
-  | _, .emp _ =>
-    ⟨q(iprop(emp)), q(iprop(emp)), q(emp_sep_rev), q(intuitionistically_emp.mpr)⟩
-  | _, .hyp _ _ _ p ty _ =>
-    match matchBool p with
-    | .inl _ =>
-      ⟨q(iprop(□ $ty)), q(iprop(emp)), q(sep_emp_rev), q(intuitionistically_idem.mpr)⟩
-    | .inr _ =>
-      ⟨q(iprop(emp)), ty, q(emp_sep_rev), q(intuitionistically_emp.mpr)⟩
-  | _, .sep _ _ _ _ lhs rhs =>
-    let ⟨eIl, eSl, pfl, pIl⟩ := splitIntuitionisticSpatial lhs
-    let ⟨eIr, eSr, pfr, pIr⟩ := splitIntuitionisticSpatial rhs
-    -- The `emp` branches retype an equivalence that only definitionally has the stated type,
-    -- in the same way `Hyps.buildAccuProof` retypes its accumulator.
-    let ⟨eI, hI, pI⟩ : (eI : Q($prop)) × Q(iprop($eIl ∗ $eIr) ⊣⊢ $eI) × Q($eI ⊢ □ $eI) :=
-      if isEmp eIl then
-        let h : Q(iprop(emp) ∗ $eIr ⊣⊢ $eIr) := q(emp_sep)
-        ⟨eIr, h, pIr⟩
-      else if isEmp eIr then
-        let h : Q($eIl ∗ iprop(emp) ⊣⊢ $eIl) := q(sep_emp)
-        ⟨eIl, h, pIl⟩
-      else
-        ⟨q(iprop($eIl ∗ $eIr)), q(.rfl),
-          q((sep_mono $pIl $pIr).trans intuitionistically_sep_mpr)⟩
-    let ⟨eS, hS⟩ : (eS : Q($prop)) × Q(iprop($eSl ∗ $eSr) ⊣⊢ $eS) :=
-      if isEmp eSl then
-        let h : Q(iprop(emp) ∗ $eSr ⊣⊢ $eSr) := q(emp_sep)
-        ⟨eSr, h⟩
-      else if isEmp eSr then
-        let h : Q($eSl ∗ iprop(emp) ⊣⊢ $eSl) := q(sep_emp)
-        ⟨eSl, h⟩
-      else ⟨q(iprop($eSl ∗ $eSr)), q(.rfl)⟩
-    ⟨eI, eS, q((split_ss $pfl $pfr).trans (sep_congr $hI $hS)), pI⟩
-
 elab "iauintro" : tactic => do
   ProofModeM.runTactic `iauintro λ mvar { prop, bi, e, hyps, goal, .. } => do
     let some args := (← instantiateMVars goal).consumeMData.appM? ``atomic_update
       | throwIPMError "the goal {goal} is not an atomic update"
     -- split the context into its intuitionistic and its spatial part
-    let ⟨eI, eS, hsplit, pfInt⟩ := splitIntuitionisticSpatial hyps
+    let ⟨eI, eS, hsplit, pfInt⟩ := hyps.splitIntuitionisticSpatial
     -- `atomic_acc` takes the arguments of `atomic_update` with the abort condition inserted directly after `α`
     let AC : Q($prop) ← mkAppOptM ``atomic_acc <|
       (args.take 8 |>.push eS |>.append (args.extract 8 args.size)).map some
     let pf ← addBIGoal hyps AC
     mvar.assign <| ← mkAppM ``tac_aupd_intro #[hsplit, pfInt, pf]
 
-theorem aacc_intro_wand [BIFUpdate PROP] (Eo Ei : CoPset) (α : TA.Arg → PROP) (P : PROP)
+theorem aacc_intro_wand (Eo Ei : CoPset) (α : TA.Arg → PROP) (P : PROP)
     (β Φ : TA.Arg → TB.Arg → PROP) (HEi : Ei ⊆ Eo) :
     ⊢ (∀.. x, α x -∗
         ((α x ={Eo}=∗ P) ∧ (∀.. y, β x y ={Eo}=∗ Φ x y)) -∗ atomic_acc Eo Ei α P β Φ) :=

--- a/Iris/Iris/BI/Lib/Atomic.lean
+++ b/Iris/Iris/BI/Lib/Atomic.lean
@@ -464,10 +464,10 @@ end lemmas
 
 section ProofMode
 
-variable [BI PROP] [BIFUpdate PROP] {TA TB : Tele}
+variable [BI PROP] {TA TB : Tele}
 
 @[rocq_alias tac_aupd_intro]
-theorem tac_aupd_intro {e eI eS : PROP} {Eo Ei : CoPset} {α : TA.Arg → PROP}
+theorem tac_aupd_intro [BIFUpdate PROP] {e eI eS : PROP} {Eo Ei : CoPset} {α : TA.Arg → PROP}
     {β Φ : TA.Arg → TB.Arg → PROP} (hsplit : e ⊣⊢ eI ∗ eS) (hI : eI ⊢ □ eI)
     (H : e ⊢ atomic_acc Eo Ei α eS β Φ) :
     e ⊢ atomic_update Eo Ei α β Φ := by
@@ -477,8 +477,15 @@ theorem tac_aupd_intro {e eI eS : PROP} {Eo Ei : CoPset} {α : TA.Arg → PROP}
     _ ⊣⊢ <pers> eI ∧ eS := persistently_and_intuitionistically_sep_left.symm
   exact h.mp.trans <| aupd_intro (h.mpr.trans H)
 
+theorem tac_aacc_intro {pa pb : Bool} {e e' A R Q : PROP} (hlem : ⊢ □?pa A)
+    (hspec : (e' ∗ □?pb (R -∗ Q) ⊢ Q) → e ∗ □?pa A ⊢ Q) (hR : e' ⊢ R) : e ⊢ Q :=
+  have hA : emp ⊢ □?pa A := hlem
+  have hstep : e' ∗ □?pb (R -∗ Q) ⊢ Q :=
+    (sep_mono hR intuitionisticallyIf_elim).trans wand_elim_right
+  sep_emp.mpr.trans <| (sep_mono_right hA).trans <| hspec hstep
+
 public meta section
-open Lean Meta Qq Expr
+open Lean Meta Elab Qq Expr
 
 def isEmp (e : Expr) : Bool := e.consumeMData.isAppOfArity ``emp 2
 
@@ -523,17 +530,59 @@ elab "iauintro" : tactic => do
     let some args := (← instantiateMVars goal).consumeMData.appM? ``atomic_update
       | throwIPMError "the goal {goal} is not an atomic update"
     -- split the context into its intuitionistic and its spatial part
-    let ⟨eI, eS, hsplit, hI⟩ := splitIntuitionisticSpatial hyps
+    let ⟨eI, eS, hsplit, pfInt⟩ := splitIntuitionisticSpatial hyps
     -- `atomic_acc` takes the arguments of `atomic_update` with the abort condition inserted directly after `α`
-    let ACRaw ← mkAppOptM ``atomic_acc <|
+    let AC : Q($prop) ← mkAppOptM ``atomic_acc <|
       (args.take 8 |>.push eS |>.append (args.extract 8 args.size)).map some
-    have AC : Q($prop) := ACRaw
-    let m ← addBIGoal hyps AC
-    mvar.assign <| ← mkAppM ``tac_aupd_intro #[hsplit, hI, m]
+    let pf ← addBIGoal hyps AC
+    mvar.assign <| ← mkAppM ``tac_aupd_intro #[hsplit, pfInt, pf]
 
-elab "iaaccintro " spats:(colGt specPat)+ : tactic => do
+theorem aacc_intro_wand [BIFUpdate PROP] (Eo Ei : CoPset) (α : TA.Arg → PROP) (P : PROP)
+    (β Φ : TA.Arg → TB.Arg → PROP) (HEi : Ei ⊆ Eo) :
+    ⊢ (∀.. x, α x -∗
+        ((α x ={Eo}=∗ P) ∧ (∀.. y, β x y ={Eo}=∗ Φ x y)) -∗ atomic_acc Eo Ei α P β Φ) :=
+  sorry
+
+elab "iaaccintro" spats:(colGt ppSpace specPat)+ : tactic => do
+  let spats ← liftMacroM <| spats.toList.mapM (SpecPat.parse ·.raw)
   ProofModeM.runTactic `iaaccintro λ mvar { prop, bi, e, hyps, goal, .. } => do
-    sorry
+  let some args := (← instantiateMVars goal).consumeMData.appM? ``atomic_acc
+    | throwIPMError "the goal {goal} is not an atomic accessor"
+  have Eo : Q(CoPset) := args[5]!
+  have Ei : Q(CoPset) := args[6]!
+
+  let mask : Q($Ei ⊆ $Eo) ← iSolveSidecondition q($Ei ⊆ $Eo)
+
+  -- instantiate `aacc_intro` with the arguments of the goal; the first eleven arguments of
+  -- `aacc_intro_wand` are exactly those of `atomic_acc`
+  let lemPf ← mkAppOptM ``aacc_intro_wand <| (args.map some).push (some mask)
+  let lemTy ← instantiateMVars <| ← inferType lemPf
+  let some ARaw :=
+      (match lemTy.consumeMData.appM? ``BIBase.EmpValid with
+        | some #[_, _, A] => some A
+        | _ =>
+          match lemTy.consumeMData.appM? ``Entails with
+          | some #[_, _, _, A] => some A
+          | _ => none)
+    | throwIPMError "internal error: unexpected statement of aacc_intro_wand"
+  have A : Q($prop) := ARaw
+  let pa : Q(Bool) := q(false)
+  have lem : Q(⊢ □?$pa $A) := lemPf
+  -- discharge the atomic precondition `α x` using the given specialisation patterns
+  let ⟨e', hyps', pb, B, pfSpec⟩ ← iSpecializeCore hyps pa A goal spats
+  -- what is left has to be the closing conjunction of the abort and the commit continuation
+  let ~q(iprop(($Pab ∧ $Pcom) -∗ $Q)) := B
+    | throwIPMError "the specialisation patterns must discharge the atomic precondition only, \
+        leaving {B} instead of the abort and commit continuations"
+  unless ← isDefEq Q goal do
+    throwIPMError "internal error: {Q} is not the atomic accessor being proved"
+  -- `B` only definitionally has the shape required by `tac_aacc_intro`, so retype `pfSpec`
+  have pfSpec :
+      Q(($e' ∗ □?$pb iprop(($Pab ∧ $Pcom) -∗ $goal) ⊢ $goal) → $e ∗ □?$pa $A ⊢ $goal) := pfSpec
+  let mAb ← addBIGoal hyps' Pab `abort
+  let mCom ← addBIGoal hyps' Pcom `commit
+  let pf : Q($e ⊢ $goal) := q(tac_aacc_intro $lem $pfSpec (and_intro $mAb $mCom))
+  mvar.assign pf
 
 end
 

--- a/Iris/Iris/BI/Lib/Atomic.lean
+++ b/Iris/Iris/BI/Lib/Atomic.lean
@@ -485,6 +485,11 @@ theorem tac_aacc_intro {pa pb : Bool} {e e' A R Q : PROP} (hlem : ⊢ □?pa A)
     (sep_mono hR intuitionisticallyIf_elim).trans wand_elim_right
   sep_emp.mpr.trans <| (sep_mono_right hA).trans <| hspec hstep
 
+theorem aacc_intro_wand (Eo Ei : CoPset) (α : TA.Arg → PROP) (P : PROP)
+    (β Φ : TA.Arg → TB.Arg → PROP) (HEi : Ei ⊆ Eo) (x : TA.Arg) :
+    ⊢ (α x -∗ ((α x ={Eo}=∗ P) ∧ (∀.. y, β x y ={Eo}=∗ Φ x y)) -∗ atomic_acc Eo Ei α P β Φ) :=
+  (Tele.tforall_forall _).mp (aacc_intro HEi) x
+
 public meta section
 open Lean Meta Elab Qq Expr
 
@@ -497,15 +502,9 @@ elab "iauintro" : tactic => do
     let AC ← mkAppM ``atomic_acc #[Eo, Ei, α, eS, β, Φ]
     mvar.assign <| ← mkAppM ``tac_aupd_intro #[hsplit, pfInt, ← addBIGoal hyps AC]
 
-theorem aacc_intro_wand (Eo Ei : CoPset) (α : TA.Arg → PROP) (P : PROP)
-    (β Φ : TA.Arg → TB.Arg → PROP) (HEi : Ei ⊆ Eo) :
-    ⊢ (∀.. x, α x -∗
-        ((α x ={Eo}=∗ P) ∧ (∀.. y, β x y ={Eo}=∗ Φ x y)) -∗ atomic_acc Eo Ei α P β Φ) :=
-  sorry
-
-elab "iaaccintro" spats:(colGt ppSpace specPat)+ : tactic => do
+elab "iaaccintro" tele?:(" %" term:max)? spats:(colGt ppSpace specPat)+ : tactic => do
   let spats ← liftMacroM <| spats.toList.mapM (SpecPat.parse ·.raw)
-  ProofModeM.runTactic `iaaccintro λ mvar { prop, bi, e, hyps, goal, .. } => do
+  ProofModeM.runTactic `iaaccintro λ mvar { prop, e, hyps, goal, .. } => do
   let some args := (← instantiateMVars goal).consumeMData.appM? ``atomic_acc
     | throwIPMError "the goal {goal} is not an atomic accessor"
   have Eo : Q(CoPset) := args[5]!
@@ -515,7 +514,12 @@ elab "iaaccintro" spats:(colGt ppSpace specPat)+ : tactic => do
 
   -- instantiate `aacc_intro` with the arguments of the goal; the first eleven arguments of
   -- `aacc_intro_wand` are exactly those of `atomic_acc`
-  let lemPf ← mkAppOptM ``aacc_intro_wand <| (args.map some).push (some mask)
+  let αTy ← whnf <| ← inferType args[7]!
+  let x ← match tele? with
+    | some t => Term.elabTermEnsuringType t αTy.bindingDomain!
+    | none   => mkFreshExprMVar αTy.bindingDomain! (userName := `x)
+  let lemPf ← mkAppOptM ``aacc_intro_wand <|
+    (args.map some).push (some mask) |>.push (some x)
   let lemTy ← instantiateMVars <| ← inferType lemPf
   let some ARaw :=
       (match lemTy.consumeMData.appM? ``BIBase.EmpValid with

--- a/Iris/Iris/BI/Lib/Atomic.lean
+++ b/Iris/Iris/BI/Lib/Atomic.lean
@@ -529,7 +529,7 @@ elab "iaaccintro" spats:(colGt ppSpace specPat)+ : tactic => do
     -- The closing conjunction of the abort and the commit continuation remains
     let ~q(iprop(($abortGoal ∧ $commitGoal) -∗ $Q)) := B
       | throwIPMError "the specialisation patterns must discharge the atomic precondition only, \
-          leaving {B} instead of the abort and commit continuations"
+          leaving {B}"
     unless ← isDefEq Q goal do
       throwIPMError "internal error: {Q} is not the atomic accessor being proved"
     have pfSpec : Q(($e' ∗ □?$pb iprop(($abortGoal ∧ $commitGoal) -∗ $goal) ⊢ $goal) →

--- a/Iris/Iris/BI/Lib/Atomic.lean
+++ b/Iris/Iris/BI/Lib/Atomic.lean
@@ -8,7 +8,7 @@ module
 public import Iris.BI.Lib.Fixpoint
 public import Iris.BI.Updates
 public import Iris.BI.Telescopes
-public import Iris.ProofMode
+public meta import Iris.ProofMode
 public meta import Iris.Std.RocqPorting
 
 @[expose] public section
@@ -476,6 +476,18 @@ theorem tac_aupd_intro {e eI eS : PROP} {Eo Ei : CoPset} {α : TA.Arg → PROP}
     _ ⊣⊢ □ eI ∗ eS      := sep_congr_left ⟨hI, intuitionistically_elim⟩
     _ ⊣⊢ <pers> eI ∧ eS := persistently_and_intuitionistically_sep_left.symm
   exact h.mp.trans <| aupd_intro (h.mpr.trans H)
+
+public meta section
+
+elab "iauintro " : tactic => do
+  ProofModeM.runTactic `iauintro λ mvar { prop, bi, e, hyps, goal, .. } => do
+    sorry
+
+elab "iaaccintro " spats:(colGt specPat)+ : tactic => do
+  ProofModeM.runTactic `iaaccintro λ mvar { prop, bi, e, hyps, goal, .. } => do
+    sorry
+
+end
 
 end ProofMode
 

--- a/Iris/Iris/BI/Lib/Atomic.lean
+++ b/Iris/Iris/BI/Lib/Atomic.lean
@@ -504,20 +504,18 @@ elab "iauintro" : tactic => do
 
 elab "iaaccintro" tele?:(" %" term:max)? spats:(colGt ppSpace specPat)+ : tactic => do
   let spats ← liftMacroM <| spats.toList.mapM (SpecPat.parse ·.raw)
+
   ProofModeM.runTactic `iaaccintro λ mvar { prop, e, hyps, goal, .. } => do
-    let some args := (← instantiateMVars goal).consumeMData.appM? ``atomic_acc
+    let_expr atomic_acc _ _ _ _ _ Eo Ei α P β Φ := goal
       | throwIPMError "the goal {goal} is not an atomic accessor"
-    have Eo : Q(CoPset) := args[5]!
-    have Ei : Q(CoPset) := args[6]!
+    have Eo : Q(CoPset) := Eo
+    have Ei : Q(CoPset) := Ei
     let mask : Q($Ei ⊆ $Eo) ← iSolveSidecondition q($Ei ⊆ $Eo)
-    -- instantiate `aacc_intro` with the arguments of the goal; the first eleven arguments of
-    -- `aacc_intro_wand` are exactly those of `atomic_acc`
-    let αTy ← whnf <| ← inferType args[7]!
+    let αTy ← whnf <| ← inferType α
     let x ← match tele? with
       | some t => Term.elabTermEnsuringType t αTy.bindingDomain!
       | none   => mkFreshExprMVar αTy.bindingDomain! (userName := `x)
-    let lemPf ← mkAppOptM ``aacc_intro_wand <|
-      (args.map some).push (some mask) |>.push (some x)
+    let lemPf ← mkAppM ``aacc_intro_wand #[Eo, Ei, α, P, β, Φ, mask, x]
     let lemTy ← instantiateMVars <| ← inferType lemPf
     let some ARaw :=
         (match lemTy.consumeMData.appM? ``BIBase.EmpValid with
@@ -528,21 +526,20 @@ elab "iaaccintro" tele?:(" %" term:max)? spats:(colGt ppSpace specPat)+ : tactic
             | _ => none)
       | throwIPMError "internal error: unexpected statement of aacc_intro_wand"
     have A : Q($prop) := ARaw
-    let pa : Q(Bool) := q(false)
-    have lem : Q(⊢ □?$pa $A) := lemPf
+    have lem : Q(⊢ □?false $A) := lemPf
     -- discharge the atomic precondition `α x` using the given specialisation patterns
-    let ⟨e', hyps', pb, B, pfSpec⟩ ← iSpecializeCore hyps pa A goal spats
+    let ⟨e', hyps', pb, B, pfSpec⟩ ← iSpecializeCore hyps q(false) A goal spats
     -- what is left has to be the closing conjunction of the abort and the commit continuation
-    let ~q(iprop(($Pab ∧ $Pcom) -∗ $Q)) := B
+    let ~q(iprop(($abortGoal ∧ $commitGoal) -∗ $Q)) := B
       | throwIPMError "the specialisation patterns must discharge the atomic precondition only, \
           leaving {B} instead of the abort and commit continuations"
     unless ← isDefEq Q goal do
       throwIPMError "internal error: {Q} is not the atomic accessor being proved"
     -- `B` only definitionally has the shape required by `tac_aacc_intro`, so retype `pfSpec`
     have pfSpec :
-        Q(($e' ∗ □?$pb iprop(($Pab ∧ $Pcom) -∗ $goal) ⊢ $goal) → $e ∗ □?$pa $A ⊢ $goal) := pfSpec
-    let mAb ← addBIGoal hyps' Pab `abort
-    let mCom ← addBIGoal hyps' Pcom `commit
+        Q(($e' ∗ □?$pb iprop(($abortGoal ∧ $commitGoal) -∗ $goal) ⊢ $goal) → $e ∗ □?false $A ⊢ $goal) := pfSpec
+    let mAb ← addBIGoal hyps' abortGoal `abort
+    let mCom ← addBIGoal hyps' commitGoal `commit
     mvar.assign q(tac_aacc_intro $lem $pfSpec (and_intro $mAb $mCom))
 
 end

--- a/Iris/Iris/BI/Lib/Atomic.lean
+++ b/Iris/Iris/BI/Lib/Atomic.lean
@@ -489,16 +489,13 @@ public meta section
 open Lean Meta Elab Qq Expr
 
 elab "iauintro" : tactic => do
-  ProofModeM.runTactic `iauintro λ mvar { prop, bi, e, hyps, goal, .. } => do
-    let some args := (← instantiateMVars goal).consumeMData.appM? ``atomic_update
+  ProofModeM.runTactic `iauintro λ mvar { hyps, goal, .. } => do
+    let_expr atomic_update _ _ _ _ _ Eo Ei α β Φ := goal
       | throwIPMError "the goal {goal} is not an atomic update"
-    -- split the context into its intuitionistic and its spatial part
-    let ⟨eI, eS, hsplit, pfInt⟩ := hyps.splitIntuitionisticSpatial
-    -- `atomic_acc` takes the arguments of `atomic_update` with the abort condition inserted directly after `α`
-    let AC : Q($prop) ← mkAppOptM ``atomic_acc <|
-      (args.take 8 |>.push eS |>.append (args.extract 8 args.size)).map some
-    let pf ← addBIGoal hyps AC
-    mvar.assign <| ← mkAppM ``tac_aupd_intro #[hsplit, pfInt, pf]
+    -- Split the context into its intuitionistic and spatial parts
+    let ⟨_, eS, hsplit, pfInt⟩ := hyps.splitIntuitionisticSpatial
+    let AC ← mkAppM ``atomic_acc #[Eo, Ei, α, eS, β, Φ]
+    mvar.assign <| ← mkAppM ``tac_aupd_intro #[hsplit, pfInt, ← addBIGoal hyps AC]
 
 theorem aacc_intro_wand (Eo Ei : CoPset) (α : TA.Arg → PROP) (P : PROP)
     (β Φ : TA.Arg → TB.Arg → PROP) (HEi : Ei ⊆ Eo) :

--- a/Iris/Iris/BI/Lib/Atomic.lean
+++ b/Iris/Iris/BI/Lib/Atomic.lean
@@ -501,8 +501,12 @@ elab "iauintro" : tactic => do
     let newGoal ← mkAppM ``atomic_acc #[Eo, Ei, α, eS, β, Φ]
     mvar.assign <| ← mkAppM ``tac_aupd_intro #[pfSplit, pfInt, ← addBIGoal hyps newGoal]
 
-elab "iaaccintro" tele?:(" %" term:max)? spats:(colGt ppSpace specPat)+ : tactic => do
+elab "iaaccintro" spats:(colGt ppSpace specPat)+ : tactic => do
   let spats ← liftMacroM <| spats.toList.mapM (SpecPat.parse ·.raw)
+  -- A leading specialisation pattern `%t` gives the telescope argument
+  let (t, spats) := match spats with
+    | ⟨_, .pure t⟩ :: rest => (some t, rest)
+    | _                    => (none, spats)
 
   ProofModeM.runTactic `iaaccintro λ mvar { prop, e, hyps, goal, .. } => do
     let_expr atomic_acc _ _ _ _ _ Eo Ei α P β Φ := goal
@@ -510,10 +514,10 @@ elab "iaaccintro" tele?:(" %" term:max)? spats:(colGt ppSpace specPat)+ : tactic
     have Eo : Q(CoPset) := Eo
     have Ei : Q(CoPset) := Ei
     let mask : Q($Ei ⊆ $Eo) ← iSolveSidecondition q($Ei ⊆ $Eo)
-    let αTy ← whnf <| ← inferType α
-    let x ← match tele? with
-      | some t => Term.elabTermEnsuringType t αTy.bindingDomain!
-      | none   => mkFreshExprMVar αTy.bindingDomain! (userName := `x)
+    let xTy := (← whnf <| ← inferType α).bindingDomain!
+    let x ← match t with
+      | some t => Term.elabTermEnsuringType t xTy
+      | none   => mkFreshExprMVar xTy (userName := `x)
     let lemPf ← mkAppM ``aacc_intro_wand #[Eo, Ei, α, P, β, Φ, mask, x]
     let_expr BIBase.EmpValid _ _ A := ← inferType lemPf
       | throwIPMError "internal error: unexpected statement of aacc_intro_wand"

--- a/Iris/Iris/BI/Lib/Atomic.lean
+++ b/Iris/Iris/BI/Lib/Atomic.lean
@@ -515,14 +515,7 @@ elab "iaaccintro" tele?:(" %" term:max)? spats:(colGt ppSpace specPat)+ : tactic
       | some t => Term.elabTermEnsuringType t αTy.bindingDomain!
       | none   => mkFreshExprMVar αTy.bindingDomain! (userName := `x)
     let lemPf ← mkAppM ``aacc_intro_wand #[Eo, Ei, α, P, β, Φ, mask, x]
-    let lemTy ← inferType lemPf
-    let some A :=
-        match lemTy.consumeMData.appM? ``BIBase.EmpValid with
-          | some #[_, _, A] => some A
-          | _ =>
-            match lemTy.consumeMData.appM? ``Entails with
-            | some #[_, _, _, A] => some A
-            | _ => none
+    let_expr BIBase.EmpValid _ _ A := ← inferType lemPf
       | throwIPMError "internal error: unexpected statement of aacc_intro_wand"
     have A : Q($prop) := A
     have lem : Q(⊢ □?false $A) := lemPf

--- a/Iris/Iris/BI/Lib/Atomic.lean
+++ b/Iris/Iris/BI/Lib/Atomic.lean
@@ -492,6 +492,11 @@ theorem aacc_intro_wand (Eo Ei : CoPset) (α : TA.Arg → PROP) (P : PROP)
 public meta section
 open Lean Meta Elab Qq Expr
 
+/--
+`iauintro` turns a goal that is an atomic update (`atomic_update`) into the
+corresponding atomic accessor (`atomic_acc`), whose abort condition is the
+separating conjunction of the spatial hypotheses.
+-/
 elab "iauintro" : tactic => do
   ProofModeM.runTactic `iauintro λ mvar { hyps, goal, .. } => do
     let_expr atomic_update _ _ _ _ _ Eo Ei α β Φ := goal
@@ -501,6 +506,17 @@ elab "iauintro" : tactic => do
     let newGoal ← mkAppM ``atomic_acc #[Eo, Ei, α, eS, β, Φ]
     mvar.assign <| ← mkAppM ``tac_aupd_intro #[pfSplit, pfInt, ← addBIGoal hyps newGoal]
 
+/--
+`iaaccintro spats` prove an atomic accessor by applying `aacc_intro`, where
+the specialisation patterns `spats` discharge the atomic precondition.
+There are three subgoals:
+- the mask side condition `Ei ⊆ Eo`,
+- the abort goal, and
+- the commit goal.
+
+The mask side condition is discharged automatically, if possible.
+The latter two subgoals keep the hypotheses left over by the specialisation patterns.
+-/
 elab "iaaccintro" spats:(colGt ppSpace specPat)+ : tactic => do
   let spats ← liftMacroM <| spats.toList.mapM (SpecPat.parse ·.raw)
   -- A leading specialisation pattern `%t` gives the telescope argument

--- a/Iris/Iris/BI/Lib/Atomic.lean
+++ b/Iris/Iris/BI/Lib/Atomic.lean
@@ -478,11 +478,11 @@ theorem tac_aupd_intro {e eI eS : PROP} {Eo Ei : CoPset} {α : TA.Arg → PROP}
   exact h.mp.trans <| aupd_intro (h.mpr.trans H)
 
 omit [BIFUpdate PROP] in
-theorem tac_aacc_intro {pa pb : Bool} {e e' A R Q : PROP} (hlem : ⊢ □?pa A)
-    (hspec : (e' ∗ □?pb (R -∗ Q) ⊢ Q) → e ∗ □?pa A ⊢ Q) (hR : e' ⊢ R) : e ⊢ Q := calc
+theorem tac_aacc_intro {pa pb : Bool} {e e' A R1 R2 Q : PROP} (hlem : ⊢ □?pa A)
+    (hspec : (e' ∗ □?pb ((R1 ∧ R2) -∗ Q) ⊢ Q) → e ∗ □?pa A ⊢ Q) (hR1 : e' ⊢ R1) (hR2 : e' ⊢ R2) : e ⊢ Q := calc
   e ⊢ e ∗ emp    := sep_emp.mpr
   _ ⊢ e ∗ □?pa A := sep_mono_right hlem
-  _ ⊢ Q          := hspec <| (sep_mono hR intuitionisticallyIf_elim).trans wand_elim_right
+  _ ⊢ Q          := hspec <| (sep_mono (and_intro hR1 hR2) intuitionisticallyIf_elim).trans wand_elim_right
 
 theorem aacc_intro_wand (Eo Ei : CoPset) (α : TA.Arg → PROP) (P : PROP)
     (β Φ : TA.Arg → TB.Arg → PROP) (HEi : Ei ⊆ Eo) (x : TA.Arg) :
@@ -497,9 +497,9 @@ elab "iauintro" : tactic => do
     let_expr atomic_update _ _ _ _ _ Eo Ei α β Φ := goal
       | throwIPMError "the goal {goal} is not an atomic update"
     -- Split the context into its intuitionistic and spatial parts
-    let ⟨_, eS, hsplit, pfInt⟩ := hyps.splitIntuitionisticSpatial
-    let AC ← mkAppM ``atomic_acc #[Eo, Ei, α, eS, β, Φ]
-    mvar.assign <| ← mkAppM ``tac_aupd_intro #[hsplit, pfInt, ← addBIGoal hyps AC]
+    let ⟨_, eS, pfSplit, pfInt⟩ := hyps.splitIntuitionisticSpatial
+    let newGoal ← mkAppM ``atomic_acc #[Eo, Ei, α, eS, β, Φ]
+    mvar.assign <| ← mkAppM ``tac_aupd_intro #[pfSplit, pfInt, ← addBIGoal hyps newGoal]
 
 elab "iaaccintro" tele?:(" %" term:max)? spats:(colGt ppSpace specPat)+ : tactic => do
   let spats ← liftMacroM <| spats.toList.mapM (SpecPat.parse ·.raw)
@@ -515,31 +515,30 @@ elab "iaaccintro" tele?:(" %" term:max)? spats:(colGt ppSpace specPat)+ : tactic
       | some t => Term.elabTermEnsuringType t αTy.bindingDomain!
       | none   => mkFreshExprMVar αTy.bindingDomain! (userName := `x)
     let lemPf ← mkAppM ``aacc_intro_wand #[Eo, Ei, α, P, β, Φ, mask, x]
-    let lemTy ← instantiateMVars <| ← inferType lemPf
-    let some ARaw :=
-        (match lemTy.consumeMData.appM? ``BIBase.EmpValid with
+    let lemTy ← inferType lemPf
+    let some A :=
+        match lemTy.consumeMData.appM? ``BIBase.EmpValid with
           | some #[_, _, A] => some A
           | _ =>
             match lemTy.consumeMData.appM? ``Entails with
             | some #[_, _, _, A] => some A
-            | _ => none)
+            | _ => none
       | throwIPMError "internal error: unexpected statement of aacc_intro_wand"
-    have A : Q($prop) := ARaw
+    have A : Q($prop) := A
     have lem : Q(⊢ □?false $A) := lemPf
-    -- discharge the atomic precondition `α x` using the given specialisation patterns
+    -- Discharge the atomic precondition `α x` using the given specialisation patterns
     let ⟨e', hyps', pb, B, pfSpec⟩ ← iSpecializeCore hyps q(false) A goal spats
-    -- what is left has to be the closing conjunction of the abort and the commit continuation
+    -- The closing conjunction of the abort and the commit continuation remains
     let ~q(iprop(($abortGoal ∧ $commitGoal) -∗ $Q)) := B
       | throwIPMError "the specialisation patterns must discharge the atomic precondition only, \
           leaving {B} instead of the abort and commit continuations"
     unless ← isDefEq Q goal do
       throwIPMError "internal error: {Q} is not the atomic accessor being proved"
-    -- `B` only definitionally has the shape required by `tac_aacc_intro`, so retype `pfSpec`
-    have pfSpec :
-      Q(($e' ∗ □?$pb iprop(($abortGoal ∧ $commitGoal) -∗ $goal) ⊢ $goal) → $e ∗ □?false $A ⊢ $goal) := pfSpec
+    have pfSpec : Q(($e' ∗ □?$pb iprop(($abortGoal ∧ $commitGoal) -∗ $goal) ⊢ $goal) →
+      $e ∗ □?false $A ⊢ $goal) := pfSpec
     let pfAbort ← addBIGoal hyps' abortGoal `abort
     let pfCommit ← addBIGoal hyps' commitGoal `commit
-    mvar.assign q(tac_aacc_intro $lem $pfSpec (and_intro $pfAbort $pfCommit))
+    mvar.assign q(tac_aacc_intro $lem $pfSpec $pfAbort $pfCommit)
 
 end
 

--- a/Iris/Iris/BI/Lib/Atomic.lean
+++ b/Iris/Iris/BI/Lib/Atomic.lean
@@ -479,11 +479,10 @@ theorem tac_aupd_intro {e eI eS : PROP} {Eo Ei : CoPset} {α : TA.Arg → PROP}
 
 omit [BIFUpdate PROP] in
 theorem tac_aacc_intro {pa pb : Bool} {e e' A R Q : PROP} (hlem : ⊢ □?pa A)
-    (hspec : (e' ∗ □?pb (R -∗ Q) ⊢ Q) → e ∗ □?pa A ⊢ Q) (hR : e' ⊢ R) : e ⊢ Q :=
-  have hA : emp ⊢ □?pa A := hlem
-  have hstep : e' ∗ □?pb (R -∗ Q) ⊢ Q :=
-    (sep_mono hR intuitionisticallyIf_elim).trans wand_elim_right
-  sep_emp.mpr.trans <| (sep_mono_right hA).trans <| hspec hstep
+    (hspec : (e' ∗ □?pb (R -∗ Q) ⊢ Q) → e ∗ □?pa A ⊢ Q) (hR : e' ⊢ R) : e ⊢ Q := calc
+  e ⊢ e ∗ emp    := sep_emp.mpr
+  _ ⊢ e ∗ □?pa A := sep_mono_right hlem
+  _ ⊢ Q          := hspec <| (sep_mono hR intuitionisticallyIf_elim).trans wand_elim_right
 
 theorem aacc_intro_wand (Eo Ei : CoPset) (α : TA.Arg → PROP) (P : PROP)
     (β Φ : TA.Arg → TB.Arg → PROP) (HEi : Ei ⊆ Eo) (x : TA.Arg) :
@@ -537,10 +536,10 @@ elab "iaaccintro" tele?:(" %" term:max)? spats:(colGt ppSpace specPat)+ : tactic
       throwIPMError "internal error: {Q} is not the atomic accessor being proved"
     -- `B` only definitionally has the shape required by `tac_aacc_intro`, so retype `pfSpec`
     have pfSpec :
-        Q(($e' ∗ □?$pb iprop(($abortGoal ∧ $commitGoal) -∗ $goal) ⊢ $goal) → $e ∗ □?false $A ⊢ $goal) := pfSpec
-    let mAb ← addBIGoal hyps' abortGoal `abort
-    let mCom ← addBIGoal hyps' commitGoal `commit
-    mvar.assign q(tac_aacc_intro $lem $pfSpec (and_intro $mAb $mCom))
+      Q(($e' ∗ □?$pb iprop(($abortGoal ∧ $commitGoal) -∗ $goal) ⊢ $goal) → $e ∗ □?false $A ⊢ $goal) := pfSpec
+    let pfAbort ← addBIGoal hyps' abortGoal `abort
+    let pfCommit ← addBIGoal hyps' commitGoal `commit
+    mvar.assign q(tac_aacc_intro $lem $pfSpec (and_intro $pfAbort $pfCommit))
 
 end
 

--- a/Iris/Iris/BI/Lib/Atomic.lean
+++ b/Iris/Iris/BI/Lib/Atomic.lean
@@ -462,4 +462,21 @@ theorem aacc_aupd_abort {TA' TB' : Tele} {E1 E1' E2 E3 : CoPset}
 
 end lemmas
 
+section ProofMode
+
+variable [BI PROP] [BIFUpdate PROP] {TA TB : Tele}
+
+@[rocq_alias tac_aupd_intro]
+theorem tac_aupd_intro {e eI eS : PROP} {Eo Ei : CoPset} {α : TA.Arg → PROP}
+    {β Φ : TA.Arg → TB.Arg → PROP} (hsplit : e ⊣⊢ eI ∗ eS) (hI : eI ⊢ □ eI)
+    (H : e ⊢ atomic_acc Eo Ei α eS β Φ) :
+    e ⊢ atomic_update Eo Ei α β Φ := by
+  have h : e ⊣⊢ <pers> eI ∧ eS := calc
+    _ ⊣⊢ eI ∗ eS        := hsplit.trans .rfl
+    _ ⊣⊢ □ eI ∗ eS      := sep_congr_left ⟨hI, intuitionistically_elim⟩
+    _ ⊣⊢ <pers> eI ∧ eS := persistently_and_intuitionistically_sep_left.symm
+  exact h.mp.trans <| aupd_intro (h.mpr.trans H)
+
+end ProofMode
+
 end Iris

--- a/Iris/Iris/ProofMode/Expr.lean
+++ b/Iris/Iris/ProofMode/Expr.lean
@@ -338,6 +338,45 @@ def Hyps.split {prop : Q(Type u)} (bi : Q(BI $prop)) (toRight : Name → IVarId 
   | .right => ⟨_, _, .mkEmp bi, hyps, q(emp_sep_rev)⟩
   | .split lhs rhs pf => ⟨_, _, lhs, rhs, pf⟩
 
+/--
+  Split `Hyps` into two parts, one with all spatial hypotheses representing `eS`
+  and another with all intuitionistic hypotheses representing `eI`.
+  A proof of `eI ⊢ □ eI` asserts that `eI` is indeed intuitionistic.
+-/
+def Hyps.splitIntuitionisticSpatial {prop : Q(Type u)} {bi : Q(BI $prop)} :
+    ∀ {e : Q($prop)}, Hyps bi e →
+      (eI : Q($prop)) × (eS : Q($prop)) × Q($e ⊣⊢ $eI ∗ $eS) × Q($eI ⊢ □ $eI)
+  | _, .emp _ =>
+    ⟨q(iprop(emp)), q(iprop(emp)), q(emp_sep_rev), q(intuitionistically_emp.mpr)⟩
+  | _, .hyp _ _ _ p ty _ =>
+    match matchBool p with
+    | .inl _ =>
+      ⟨q(iprop(□ $ty)), q(iprop(emp)), q(sep_emp_rev), q(intuitionistically_idem.mpr)⟩
+    | .inr _ =>
+      ⟨q(iprop(emp)), ty, q(emp_sep_rev), q(intuitionistically_emp.mpr)⟩
+  | _, .sep _ _ _ _ lhs rhs =>
+    let ⟨eIl, eSl, pfl, pIl⟩ := splitIntuitionisticSpatial lhs
+    let ⟨eIr, eSr, pfr, pIr⟩ := splitIntuitionisticSpatial rhs
+    let ⟨eI, hI, pI⟩ : (eI : Q($prop)) × Q(iprop($eIl ∗ $eIr) ⊣⊢ $eI) × Q($eI ⊢ □ $eI) :=
+      if eIl == q(iprop(emp)) then
+        let h : Q(iprop(emp) ∗ $eIr ⊣⊢ $eIr) := q(emp_sep)
+        ⟨eIr, h, pIr⟩
+      else if eIr == q(iprop(emp)) then
+        let h : Q($eIl ∗ iprop(emp) ⊣⊢ $eIl) := q(sep_emp)
+        ⟨eIl, h, pIl⟩
+      else
+        ⟨q(iprop($eIl ∗ $eIr)), q(.rfl),
+          q((sep_mono $pIl $pIr).trans intuitionistically_sep_mpr)⟩
+    let ⟨eS, hS⟩ : (eS : Q($prop)) × Q(iprop($eSl ∗ $eSr) ⊣⊢ $eS) :=
+      if eSl == q(iprop(emp)) then
+        let h : Q(iprop(emp) ∗ $eSr ⊣⊢ $eSr) := q(emp_sep)
+        ⟨eSr, h⟩
+      else if eSr == q(iprop(emp)) then
+        let h : Q($eSl ∗ iprop(emp) ⊣⊢ $eSl) := q(sep_emp)
+        ⟨eSl, h⟩
+      else ⟨q(iprop($eSl ∗ $eSr)), q(.rfl)⟩
+    ⟨eI, eS, q((split_ss $pfl $pfr).trans (sep_congr $hI $hS)), pI⟩
+
 end split
 
 section remove

--- a/Iris/Iris/ProofMode/Expr.lean
+++ b/Iris/Iris/ProofMode/Expr.lean
@@ -365,14 +365,13 @@ def Hyps.splitIntuitionisticSpatial {prop : Q(Type u)} {bi : Q(BI $prop)} :
         let h : Q($eIl ∗ iprop(emp) ⊣⊢ $eIl) := q(sep_emp)
         ⟨eIl, h, pIl⟩
       else
-        ⟨q(iprop($eIl ∗ $eIr)), q(.rfl),
-          q((sep_mono $pIl $pIr).trans intuitionistically_sep_mpr)⟩
+        ⟨q(iprop($eIl ∗ $eIr)), q(.rfl), q((sep_mono $pIl $pIr).trans intuitionistically_sep_mpr)⟩
     let ⟨eS, hS⟩ : (eS : Q($prop)) × Q(iprop($eSl ∗ $eSr) ⊣⊢ $eS) :=
       if eSl == q(iprop(emp)) then
-        let h : Q(iprop(emp) ∗ $eSr ⊣⊢ $eSr) := q(emp_sep)
+        let h : Q(emp ∗ $eSr ⊣⊢ $eSr) := q(emp_sep)
         ⟨eSr, h⟩
       else if eSr == q(iprop(emp)) then
-        let h : Q($eSl ∗ iprop(emp) ⊣⊢ $eSl) := q(sep_emp)
+        let h : Q($eSl ∗ emp ⊣⊢ $eSl) := q(sep_emp)
         ⟨eSl, h⟩
       else ⟨q(iprop($eSl ∗ $eSr)), q(.rfl)⟩
     ⟨eI, eS, q((split_ss $pfl $pfr).trans (sep_congr $hI $hS)), pI⟩

--- a/Iris/Iris/ProofMode/Porting.lean
+++ b/Iris/Iris/ProofMode/Porting.lean
@@ -63,6 +63,8 @@ import Iris.Init
 #rocq_concept proofmode "Tactics" "iInv" ported "iinv"
 #rocq_concept proofmode "Tactics" "iAccu" ported "iaccu"
 #rocq_concept proofmode "Tactics" "rules for trivial" ported "itrivial"
+#rocq_concept proofmode "Tactics" "iAuIntro" ported "iauintro"
+#rocq_concept proofmode "Tactics" "iAaccIntro" ported "iaaccintro"
 
 #rocq_concept proofmode "Intro Patterns" ported ""
 #rocq_concept proofmode "Intro Patterns" "IIdent (pattern: H)" ported "pattern: H"

--- a/Iris/IrisTest/Atomic.lean
+++ b/Iris/IrisTest/Atomic.lean
@@ -110,4 +110,57 @@ example : (AU <{ ∃∃ x, α x }> @ Eo, Ei <{ ∀∀ y, β x y, COMM Ψ x y }>)
   aupd_aacc
 
 end atomicNotation
+
+section ProofModeTactics
+
+variable {PROP : Type u} [instBI : BI PROP] [instBIFUpd : BIFUpdate PROP] {TA TB : Tele}
+variable {Eo Ei : CoPset} {α : TA.Arg → PROP} {β Φ : TA.Arg → TB.Arg → PROP}
+
+/-- trace:
+PROP : Type u
+instBI : BI PROP
+instBIFUpd : BIFUpdate PROP
+TA : Tele
+TB : Tele
+Eo Ei : CoPset
+α : TA.Arg → PROP
+β Φ : TA.Arg → TB.Arg → PROP
+HEi : Ei ⊆ Eo
+x : TA.Arg
+⊢
+∗Hα : α x
+⊢ atomic_acc Eo Ei α (α x) β β
+-/
+#guard_msgs (trace, drop all, whitespace := lax) in
+example (HEi : Ei ⊆ Eo) (x : TA.Arg) : α x ⊢ atomic_update Eo Ei α β β := by
+  iintro Hα
+  iauintro
+  trace_state
+
+/-- trace:
+PROP : Type u
+instBI : BI PROP
+instBIFUpd : BIFUpdate PROP
+TA : Tele
+TB : Tele
+Eo Ei : CoPset
+α : TA.Arg → PROP
+β Φ : TA.Arg → TB.Arg → PROP
+HEi : Ei ⊆ Eo
+x : TA.Arg
+Q : PROP
+⊢
+□HQ : Q
+∗Hα : α x
+⊢ atomic_acc Eo Ei α (α x) β β
+-/
+#guard_msgs (trace, drop all, whitespace := lax) in
+example (HEi : Ei ⊆ Eo) (x : TA.Arg) {Q : PROP} :
+    □ Q ∗ α x ⊢ atomic_update Eo Ei α β β := by
+  iintro ⟨#HQ, Hα⟩
+  iauintro
+  trace_state
+
+end ProofModeTactics
+
 end IrisTest

--- a/Iris/IrisTest/Atomic.lean
+++ b/Iris/IrisTest/Atomic.lean
@@ -116,18 +116,10 @@ section ProofModeTactics
 variable {PROP : Type u} [instBI : BI PROP] [instBIFUpd : BIFUpdate PROP] {TA TB : Tele}
 variable {Eo Ei : CoPset} {α : TA.Arg → PROP} {β Φ : TA.Arg → TB.Arg → PROP}
 
-example (HEi : Ei ⊆ Eo) (x : TA.Arg) : α x ⊢ atomic_acc Eo Ei α (α x) β β := by
-  iintro Hα
-  iaaccintro Hα
-  · iintro Hα !> //
-  · iintro %y Hβ !> //
-
-example (HEi : Ei ⊆ Eo) (x : TA.Arg) : α x ⊢ atomic_acc Eo Ei α (α x) β β := by
-  iintro Hα
-  iaaccintro %x Hα
-  · iintro Hα !> //
-  · iintro %y Hβ !> //
-
+/--
+  Tests `iauintro` for reducing `atomic_update Eo Ei α β β` to `atomic_acc Eo Ei α (α x) β β`.
+  Tests `iaaccintro` with `α x` for abort and `β x y` for commit.
+-/
 example (HEi : Ei ⊆ Eo) (x : TA.Arg) : α x ⊢ atomic_update Eo Ei α β β := by
   iintro Hα
   iauintro
@@ -135,11 +127,22 @@ example (HEi : Ei ⊆ Eo) (x : TA.Arg) : α x ⊢ atomic_update Eo Ei α β β :
   · iintro Hα !> //
   · iintro %y Hβ !> //
 
-example (HEi : Ei ⊆ Eo) (x : TA.Arg) {Q : PROP} :
-    □ Q ∗ α x ⊢ atomic_update Eo Ei α β β := by
-  iintro ⟨#HQ, Hα⟩
-  iauintro
-  iaaccintro Hα
+/--
+  Tests `iaaccintro` with `α x` for abort and `β x y` for commit.
+  The argument for the telescopic quantifier is supplied.
+-/
+example (HEi : Ei ⊆ Eo) (x : TA.Arg) : α x ⊢ atomic_acc Eo Ei α (α x) β β := by
+  iintro Hα
+  iaaccintro %x Hα
+  · iintro Hα !> //
+  · iintro %y Hβ !> //
+
+/-- Tests `iaaccintro` with the pre-condition `α x` obtained from several hypotheses. -/
+example (HEi : Ei ⊆ Eo) (x : TA.Arg) {Q R : PROP} (hα : α x = iprop(Q ∗ R)) :
+    Q ∗ R ⊢ atomic_acc Eo Ei α (α x) β β := by
+  iintro ⟨HQ, HR⟩
+  iaaccintro [HQ HR]
+  · rw [hα]; iframe
   · iintro Hα !> //
   · iintro %y Hβ !> //
 
@@ -154,6 +157,15 @@ example (Q : PROP) : Q ⊢ Q := by
 example {Q : PROP} : Q ⊢ Q := by
   iintro HQ
   iaaccintro HQ
+
+/-- error: iaaccintro:
+  the specialisation patterns must discharge the atomic precondition only,
+  leaving atomic_acc Eo Ei α (α x) β β
+-/
+#guard_msgs (whitespace := lax) in
+example (HEi : Ei ⊆ Eo) (x : TA.Arg) : α x ⊢ atomic_acc Eo Ei α (α x) β β := by
+  iintro Hα
+  iaaccintro %x Hα []
 
 end ProofModeTactics
 

--- a/Iris/IrisTest/Atomic.lean
+++ b/Iris/IrisTest/Atomic.lean
@@ -116,50 +116,44 @@ section ProofModeTactics
 variable {PROP : Type u} [instBI : BI PROP] [instBIFUpd : BIFUpdate PROP] {TA TB : Tele}
 variable {Eo Ei : CoPset} {α : TA.Arg → PROP} {β Φ : TA.Arg → TB.Arg → PROP}
 
-/-- trace:
-PROP : Type u
-instBI : BI PROP
-instBIFUpd : BIFUpdate PROP
-TA : Tele
-TB : Tele
-Eo Ei : CoPset
-α : TA.Arg → PROP
-β Φ : TA.Arg → TB.Arg → PROP
-HEi : Ei ⊆ Eo
-x : TA.Arg
-⊢
-∗Hα : α x
-⊢ atomic_acc Eo Ei α (α x) β β
--/
-#guard_msgs (trace, drop all, whitespace := lax) in
+example (HEi : Ei ⊆ Eo) (x : TA.Arg) : α x ⊢ atomic_acc Eo Ei α (α x) β β := by
+  iintro Hα
+  iaaccintro Hα
+  · iintro Hα !> //
+  · iintro %y Hβ !> //
+
+example (HEi : Ei ⊆ Eo) (x : TA.Arg) : α x ⊢ atomic_acc Eo Ei α (α x) β β := by
+  iintro Hα
+  iaaccintro %x Hα
+  · iintro Hα !> //
+  · iintro %y Hβ !> //
+
 example (HEi : Ei ⊆ Eo) (x : TA.Arg) : α x ⊢ atomic_update Eo Ei α β β := by
   iintro Hα
   iauintro
-  trace_state
+  iaaccintro Hα
+  · iintro Hα !> //
+  · iintro %y Hβ !> //
 
-/-- trace:
-PROP : Type u
-instBI : BI PROP
-instBIFUpd : BIFUpdate PROP
-TA : Tele
-TB : Tele
-Eo Ei : CoPset
-α : TA.Arg → PROP
-β Φ : TA.Arg → TB.Arg → PROP
-HEi : Ei ⊆ Eo
-x : TA.Arg
-Q : PROP
-⊢
-□HQ : Q
-∗Hα : α x
-⊢ atomic_acc Eo Ei α (α x) β β
--/
-#guard_msgs (trace, drop all, whitespace := lax) in
 example (HEi : Ei ⊆ Eo) (x : TA.Arg) {Q : PROP} :
     □ Q ∗ α x ⊢ atomic_update Eo Ei α β β := by
   iintro ⟨#HQ, Hα⟩
   iauintro
-  trace_state
+  iaaccintro Hα
+  · iintro Hα !> //
+  · iintro %y Hβ !> //
+
+/-- error: iauintro: the goal Q is not an atomic update -/
+#guard_msgs in
+example (Q : PROP) : Q ⊢ Q := by
+  iintro HQ
+  iauintro
+
+/-- error: iaaccintro: the goal Q is not an atomic accessor -/
+#guard_msgs in
+example {Q : PROP} : Q ⊢ Q := by
+  iintro HQ
+  iaaccintro HQ
 
 end ProofModeTactics
 

--- a/Iris/tactics.md
+++ b/Iris/tactics.md
@@ -56,7 +56,7 @@ The proof mode maintains three contexts: the *pure* (Lean) context, the *intuiti
 - `imodintro` *sel* — Like `imodintro`, but only succeed if the modality matches the selector term *sel*, e.g. `imodintro (<pers> _)` or `imodintro (□ _)`.
 - `inext` — Introduce one or more later modalities; equivalent to `imodintro (▷^[_] _)`.
 - `inext` *n* `credit:` *H* — given a later credit hypothesis *H*, reduce the later credits by *n* and strip *n* later modalities from all hypotheses while the goal remains unchanged. This tactic requires the goal to be a fancy update modality and `InvGS GF` to hold.
-- `inext credit:` *H* — equivalent to `inext 1 credit:` *H*.
+- `inext credit:` *H* — equivalent to `inext 1 credit:` *H*. This requires importing `Iris.Instances.Lib.FUpd`.
 - `imod` [*pmTerm*](#proof-mode-terms) `with` [*casesPat*](#cases-patterns) — Eliminate the modality at the top of [*pmTerm*](#proof-mode-terms) into the goal and destruct the result with [*casesPat*](#cases-patterns). Equivalent to `icases ... with >pat`.
 - `imod` [*pmTerm*](#proof-mode-terms) — Like above; if [*pmTerm*](#proof-mode-terms) is a hypothesis, its name is kept.
 
@@ -85,12 +85,13 @@ The proof mode maintains three contexts: the *pure* (Lean) context, the *intuiti
 - `iinv` *N* (`$$` [*specPat*](#specialization-patterns))? `with` [*casesPat*](#cases-patterns) ([*casesPat*](#cases-patterns))? — same as above, except that a namespace *N* is given. The last invariant hypothesis in the context of this namespace is chosen.
 - `iauintro` — turn a goal that is an atomic update into the corresponding atomic
   accessor, whose abort condition is the separating conjunction of the spatial
-  hypotheses. The context is left unchanged.
+  hypotheses. The context is left unchanged. This requires importing `Iris.BI.Lib.Atomic`.
 - `iaaccintro` [*specPat*](#specialization-patterns)+ — prove an atomic accessor
   by applying `aacc_intro`. The specialisation patterns discharge the atomic
   precondition. There are three subgoals: the mask side condition `Ei ⊆ Eo`, the abort goal
   and the commit goal. The mask side condition is discharged automatically, if possible.
-  The latter two subgoals keep the hypotheses left over by the specialisation patterns. 
+  The latter two subgoals keep the hypotheses left over by the specialisation patterns.
+  This requires importing `Iris.BI.Lib.Atomic`.
 
 ## Cases Patterns
 

--- a/Iris/tactics.md
+++ b/Iris/tactics.md
@@ -83,6 +83,14 @@ The proof mode maintains three contexts: the *pure* (Lean) context, the *intuiti
 
 - `iinv` *H* (`$$` [*specPat*](#specialization-patterns))? `with` [*casesPat*](#cases-patterns) ([*casesPat*](#cases-patterns))? — opens an invariant hypothesis *H* and uses the first cases pattern to destruct the result. The second cases pattern is used for destructing the hypothesis for closing the invariant. The specialisation pattern is used for resource consumption needed for opening the invariant. If the specialisation pattern is not given as part of the tactic, it is, by default, the auto-framing of spatial hypotheses.
 - `iinv` *N* (`$$` [*specPat*](#specialization-patterns))? `with` [*casesPat*](#cases-patterns) ([*casesPat*](#cases-patterns))? — same as above, except that a namespace *N* is given. The last invariant hypothesis in the context of this namespace is chosen.
+- `iauintro` — turn a goal that is an atomic update into the corresponding atomic
+  accessor, whose abort condition is the separating conjunction of the spatial
+  hypotheses. The context is left unchanged.
+- `iaaccintro` [*specPat*](#specialization-patterns)+ — prove an atomic accessor
+  by applying `aacc_intro`. The specialisation patterns discharge the atomic
+  precondition. There are three subgoals: the mask side condition `Ei ⊆ Eo`, the abort goal
+  and the commit goal. The mask side condition is discharged automatically, if possible.
+  The latter two subgoals keep the hypotheses left over by the specialisation patterns. 
 
 ## Cases Patterns
 

--- a/Iris/tactics.md
+++ b/Iris/tactics.md
@@ -83,15 +83,8 @@ The proof mode maintains three contexts: the *pure* (Lean) context, the *intuiti
 
 - `iinv` *H* (`$$` [*specPat*](#specialization-patterns))? `with` [*casesPat*](#cases-patterns) ([*casesPat*](#cases-patterns))? — opens an invariant hypothesis *H* and uses the first cases pattern to destruct the result. The second cases pattern is used for destructing the hypothesis for closing the invariant. The specialisation pattern is used for resource consumption needed for opening the invariant. If the specialisation pattern is not given as part of the tactic, it is, by default, the auto-framing of spatial hypotheses.
 - `iinv` *N* (`$$` [*specPat*](#specialization-patterns))? `with` [*casesPat*](#cases-patterns) ([*casesPat*](#cases-patterns))? — same as above, except that a namespace *N* is given. The last invariant hypothesis in the context of this namespace is chosen.
-- `iauintro` — turn a goal that is an atomic update into the corresponding atomic
-  accessor, whose abort condition is the separating conjunction of the spatial
-  hypotheses. The context is left unchanged. This requires importing `Iris.BI.Lib.Atomic`.
-- `iaaccintro` [*specPat*](#specialization-patterns)+ — prove an atomic accessor
-  by applying `aacc_intro`. The specialisation patterns discharge the atomic
-  precondition. There are three subgoals: the mask side condition `Ei ⊆ Eo`, the abort goal
-  and the commit goal. The mask side condition is discharged automatically, if possible.
-  The latter two subgoals keep the hypotheses left over by the specialisation patterns.
-  This requires importing `Iris.BI.Lib.Atomic`.
+- `iauintro` — turn a goal that is an atomic update into the corresponding atomic accessor, whose abort condition is the separating conjunction of the spatial hypotheses. The context is left unchanged. This requires importing `Iris.BI.Lib.Atomic`.
+- `iaaccintro` [*specPat*](#specialization-patterns)+ — prove an atomic accessor by applying `aacc_intro`. The specialisation patterns discharge the atomic precondition. There are three subgoals: the mask side condition `Ei ⊆ Eo`, the abort goal and the commit goal. The mask side condition is discharged automatically, if possible. The latter two subgoals keep the hypotheses left over by the specialisation patterns. This requires importing `Iris.BI.Lib.Atomic`.
 
 ## Cases Patterns
 


### PR DESCRIPTION
## Description

Ports `iAuIntro` and `iAaccIntro`.

Resolves #289 (i.e., the remaining items that are not included in #665).

These tactics can be used to simplify the proofs in `ProgramLogic/Atomic.lean` (#672).

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files
