### PR TITLE
feat: add findECtxRev

### DIFF
--- a/Iris/Iris/HeapLang/Tactic.lean
+++ b/Iris/Iris/HeapLang/Tactic.lean
@@ -57,6 +57,12 @@ where
   | e =>
     extractEctxItem e
 
+public meta partial
+def extractAllEctxItems (e : Q(Exp)) (acc : List Q(ECtxItem) := []) : MetaM (List Q(ECtxItem) × Q(Exp)) := do
+  match ← extractEctxItem e with
+  | (.some Ki, e') => extractAllEctxItems e' (Ki :: acc)
+  | (.none, e) => return (acc, e)
+
 open ECtxItem in
 meta partial
 def fillItem (e : Q(Exp)) : Q(ECtxItem) → MetaM Q(Exp)
@@ -112,6 +118,9 @@ structure ECtxResultOf (e : Q(Exp)) (α : Type) where unsafeMk ::
   e' : Q(Exp)
   heq : ProgramLogic.fill $K $e' =Q $e := ⟨⟩
 
+/-- Given an expression `ogE`, finds the *outermost* evaluation context `K` and
+    corresponding expression `e'` such that `K[e'] = e` and `pred K e'` does 
+    not fail -/
 public meta partial def findECtx {α : Type _} (ogE : Q(Exp))
     (pred : Q(List ECtxItem) → Q(Exp) → ProofModeM α) :
     ProofModeM (Option (ECtxResultOf ogE α)) :=
@@ -123,3 +132,19 @@ where
       return some {result := a, K, e' := e}
     let (some Ki, e') ← extractEctxItem e | return none
     go e' (Ki :: acc)
+
+/-- Given an expression `ogE`, finds the *innermost* evaluation context `K` and
+    corresponding expression `e'` such that `K[e'] = e` and `pred K e'` does 
+    not fail -/
+public meta partial def findECtxRev {α : Type _} (ogE : Q(Exp))
+    (pred : Q(List ECtxItem) → Q(Exp) → ProofModeM α) :
+    ProofModeM (Option (ECtxResultOf ogE α)) := do
+  let (Kis, inner) ← extractAllEctxItems ogE
+  go inner Kis
+where
+  go (e' : Q(Exp)) (Kis : List Q(ECtxItem)) : ProofModeM (Option (ECtxResultOf ogE α)) := do
+    let K := quoteList Kis
+    if let some a ← observing? <| pred K e' then
+      return some {result := a, K, e'}
+    let Ki :: Kis' := Kis | return none
+    go (← fillItem e' Ki) Kis'

--- a/Iris/Iris/HeapLang/Tactic.lean
+++ b/Iris/Iris/HeapLang/Tactic.lean
@@ -146,5 +146,5 @@ where
   go (e' : Q(Exp)) (K : Q(List ECtxItem)) : ProofModeM (Option (ECtxResultOf ogE α)) := do
     if let some a ← observing? <| pred K e' then
       return some {result := a, K, e'}
-    let mkApp2 (.const ``List.cons _) Ki K := K | return none
+    let_expr List.cons Ki K := K | return none
     go (← fillItem e' Ki) K

--- a/Iris/Iris/HeapLang/Tactic.lean
+++ b/Iris/Iris/HeapLang/Tactic.lean
@@ -120,7 +120,7 @@ structure ECtxResultOf (e : Q(Exp)) (α : Type) where unsafeMk ::
 
 /-- Given an expression `ogE`, finds the *outermost* evaluation context `K` and
     corresponding expression `e'` such that `K[e'] = e` and `pred K e'` does 
-    not fail -/
+    not fail. This corresponds to `reshape_expr` in Rocq. -/
 public meta partial def findECtx {α : Type _} (ogE : Q(Exp))
     (pred : Q(List ECtxItem) → Q(Exp) → ProofModeM α) :
     ProofModeM (Option (ECtxResultOf ogE α)) :=

--- a/Iris/Iris/HeapLang/Tactic.lean
+++ b/Iris/Iris/HeapLang/Tactic.lean
@@ -140,11 +140,11 @@ public meta partial def findECtxRev {α : Type _} (ogE : Q(Exp))
     (pred : Q(List ECtxItem) → Q(Exp) → ProofModeM α) :
     ProofModeM (Option (ECtxResultOf ogE α)) := do
   let (Kis, inner) ← extractAllEctxItems ogE
-  go inner Kis
+  let K : Q(List ECtxItem) := quoteList Kis
+  go inner K
 where
-  go (e' : Q(Exp)) (Kis : List Q(ECtxItem)) : ProofModeM (Option (ECtxResultOf ogE α)) := do
-    let K := quoteList Kis
+  go (e' : Q(Exp)) (K : Q(List ECtxItem)) : ProofModeM (Option (ECtxResultOf ogE α)) := do
     if let some a ← observing? <| pred K e' then
       return some {result := a, K, e'}
-    let Ki :: Kis' := Kis | return none
-    go (← fillItem e' Ki) Kis'
+    let mkApp2 (.const ``List.cons _) Ki K := K | return none
+    go (← fillItem e' Ki) K


### PR DESCRIPTION
## Description
Adds a `findECtxRev` function which works like `findECtx`, but explores the expression from the innermost context first. Also adds comments to distinguish `findECtx` and `findECtxRev`.

## Checklist
* [X] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [X] I have added my name to the `authors` section of any appropriate files