### PR TITLE
fix: `rocq_alias` annotations for `AsEmpValid` instances

### DIFF
--- a/Iris/Iris/ProofMode/Instances.lean
+++ b/Iris/Iris/ProofMode/Instances.lean
@@ -21,10 +21,12 @@ open Iris.BI Iris.Std
 
 /-! ### AsEmpValid -/
 
+@[rocq_alias as_emp_valid_emp_valid]
 instance (priority := default + 10) asEmpValidEmpValid
     [bi : BI PROP] d (P : PROP) io ioP : AsEmpValid0 d (⊢ P) io PROP bi ioP P where
   as_emp_valid_0 := ⟨by simp⟩
 
+@[rocq_alias as_emp_valid_entails]
 instance asEmpValid_entails [bi : BI PROP] d io ioP (P Q : PROP) :
     AsEmpValid0 d (P ⊢ Q) io PROP bi ioP iprop(P -∗ Q) where
   as_emp_valid_0 := ⟨λ _ => entails_wand, λ _ => wand_entails⟩
@@ -33,10 +35,12 @@ instance asEmpValid_bientails [bi : BI PROP] d io ioP (P Q : PROP) :
     AsEmpValid0 d (P ⊣⊢ Q) io PROP bi ioP iprop(P ∗-∗ Q) where
   as_emp_valid_0 := ⟨λ _ => equiv_wandIff, λ _ => wandIff_equiv⟩
 
+@[rocq_alias as_emp_valid_equiv]
 instance asEmpValid_equiv [bi : BI PROP] d io ioP (P Q : PROP) :
     AsEmpValid0 d (P = Q) io PROP bi ioP iprop(P ∗-∗ Q) where
   as_emp_valid_0 := ⟨λ _ h => h ▸ wandIff_refl, λ _ h => equiv_iff.2 (wandIff_equiv h)⟩
 
+@[rocq_alias as_emp_valid_forall]
 instance asEmpValid_forall {α} [bi : BI PROP] (Φ : α → Prop) (P : α → PROP) d io
     [hP : ∀ x, AsEmpValid d (Φ x) io PROP bi iprop(P x)] :
     AsEmpValid d (∀ x, Φ x) io PROP bi iprop(∀ x, P x) where


### PR DESCRIPTION
## Description

These annotations were removed by mistake in #677.

## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files
