### PR TITLE
feat: notations for telescope arguments

### DIFF
--- a/Iris/Iris/ProgramLogic/Atomic.lean
+++ b/Iris/Iris/ProgramLogic/Atomic.lean
@@ -206,12 +206,12 @@ theorem atomic_seq_wp_atomic [Atomic .WeaklyAtomic e] :
 
 /-- Sequential triples with a persistent precondition and no initial quantifier are atomic. -/
 @[rocq_alias persistent_seq_wp_atomic]
-theorem persistent_seq_wp_atomic {α : ([tele]) → IProp GF}
-    {β : ([tele]) → TB.Arg → IProp GF}
-    {POST : ([tele]) → TB.Arg → TP.Arg → Option (IProp GF)}
-    {f : ([tele]) → TB.Arg → TP.Arg → Val} [Persistent (α [tele_arg])] :
-    (∀ Φ, α [tele_arg] -∗
-      (∀.. y, β [tele_arg] y -∗ ∀.. z, POST [tele_arg] y z -∗? Φ (f [tele_arg] y z)) -∗ WP e {{ Φ }}) ⊢
+theorem persistent_seq_wp_atomic {α : ⟦tele⟧ → IProp GF}
+    {β : ⟦tele⟧ → TB.Arg → IProp GF}
+    {POST : ⟦tele⟧ → TB.Arg → TP.Arg → Option (IProp GF)}
+    {f : ⟦tele⟧ → TB.Arg → TP.Arg → Val} [Persistent (α ⟦tele_arg⟧)] :
+    (∀ Φ, α ⟦tele_arg⟧ -∗
+      (∀.. y, β ⟦tele_arg⟧ y -∗ ∀.. z, POST ⟦tele_arg⟧ y z -∗? Φ (f ⟦tele_arg⟧ y z)) -∗ WP e {{ Φ }}) ⊢
     atomic_wp e E α β POST f := by
   iunfold atomic_wp
   iintro Hwp %Φ HΦ

--- a/Iris/Iris/ProgramLogic/Atomic.lean
+++ b/Iris/Iris/ProgramLogic/Atomic.lean
@@ -206,12 +206,12 @@ theorem atomic_seq_wp_atomic [Atomic .WeaklyAtomic e] :
 
 /-- Sequential triples with a persistent precondition and no initial quantifier are atomic. -/
 @[rocq_alias persistent_seq_wp_atomic]
-theorem persistent_seq_wp_atomic {α : Tele.Arg .nil → IProp GF}
-    {β : Tele.Arg .nil → TB.Arg → IProp GF}
-    {POST : Tele.Arg .nil → TB.Arg → TP.Arg → Option (IProp GF)}
-    {f : Tele.Arg .nil → TB.Arg → TP.Arg → Val} [Persistent (α .nil)] :
-    (∀ Φ, α .nil -∗
-      (∀.. y, β .nil y -∗ ∀.. z, POST .nil y z -∗? Φ (f .nil y z)) -∗ WP e {{ Φ }}) ⊢
+theorem persistent_seq_wp_atomic {α : ([tele]) → IProp GF}
+    {β : ([tele]) → TB.Arg → IProp GF}
+    {POST : ([tele]) → TB.Arg → TP.Arg → Option (IProp GF)}
+    {f : ([tele]) → TB.Arg → TP.Arg → Val} [Persistent (α [tele_arg])] :
+    (∀ Φ, α [tele_arg] -∗
+      (∀.. y, β [tele_arg] y -∗ ∀.. z, POST [tele_arg] y z -∗? Φ (f [tele_arg] y z)) -∗ WP e {{ Φ }}) ⊢
     atomic_wp e E α β POST f := by
   iunfold atomic_wp
   iintro Hwp %Φ HΦ

--- a/Iris/Iris/Std/Telescopes.lean
+++ b/Iris/Iris/Std/Telescopes.lean
@@ -156,8 +156,8 @@ meta def delabLam : Delab :=
     (fun x rest body => `(λ.. $x:ident $[$rest:ident]*, $body))
     (fun | `(λ.. $y:ident $[$ys:ident]*, $body) => some (y, ys, body) | _ => none)
 
-syntax:max "⟦" &"tele" (ppSpace explicitBinders)? "⟧" : term
-syntax:max "⟦" &"tele_arg" (ppSpace term),* "⟧" : term
+syntax:max "⟦" &"tele" (explicitBinders)? "⟧" : term
+syntax:max "⟦" &"tele_arg" term,* "⟧" : term
 
 macro_rules
   | `(⟦tele $[$bs]?⟧) => return ← expandLiteral bs

--- a/Iris/Iris/Std/Telescopes.lean
+++ b/Iris/Iris/Std/Telescopes.lean
@@ -99,7 +99,7 @@ meta def expandFun (TT : Term) (binders? : Option (TSyntax ``Lean.explicitBinder
   `(Tele.app (TT := $TT) (fun $binders:funBinder* => ULift.up $body))
 
 /-- The number of fields in a literal telescope, or `none` if the expression is not one. -/
-partial def literalArity? (e : Expr) : Option Nat :=
+meta partial def literalArity? (e : Expr) : Option Nat :=
   if e.isConstOf ``Tele.nil then
     some 0
   else if e.isAppOfArity ``Tele.cons 2 then
@@ -156,12 +156,12 @@ meta def delabLam : Delab :=
     (fun x rest body => `(λ.. $x:ident $[$rest:ident]*, $body))
     (fun | `(λ.. $y:ident $[$ys:ident]*, $body) => some (y, ys, body) | _ => none)
 
-syntax:max "[" &"tele" (ppSpace explicitBinders)? "]" : term
-syntax:max "[" &"tele_arg" (ppSpace term),* "]" : term
+syntax:max "⟦" &"tele" (ppSpace explicitBinders)? "⟧" : term
+syntax:max "⟦" &"tele_arg" (ppSpace term),* "⟧" : term
 
 macro_rules
-  | `([tele $[$bs]?]) => return ← expandLiteral bs
-  | `([tele_arg $xs,*]) => do
+  | `(⟦tele $[$bs]?⟧) => return ← expandLiteral bs
+  | `(⟦tele_arg $xs,*⟧) => do
     let xs := xs.getElems
     if xs.isEmpty then
       `((Tele.Arg.nil : Tele.Arg (Tele.nil.{0})))

--- a/Iris/Iris/Std/Telescopes.lean
+++ b/Iris/Iris/Std/Telescopes.lean
@@ -168,6 +168,53 @@ macro_rules
     else
       xs.foldrM (fun x acc => `(Tele.Arg.cons $x $(⟨acc⟩))) (← `(Tele.Arg.nil))
 
+/-- The number of fields in a literal telescope argument, or `none` if the expression is not one. -/
+meta partial def Arg.literalLength? (e : Expr) : Option Nat :=
+  if e.isConstOf ``Tele.Arg.nil then
+    some 0
+  else if e.isAppOfArity ``Tele.Arg.cons 4 then
+    (Arg.literalLength? e.appArg!).map (· + 1)
+  else none
+
+/-- Walk a literal telescope, delaborating each field type under the preceding binders. -/
+private meta partial def delabTeleFields (acc : Array (Ident × Term)) :
+    DelabM (Array (Ident × Term)) := do
+  if (← getExpr).isConstOf ``Tele.nil then return acc
+  withNaryArg 1 do
+    let type ← withBindingDomain delab
+    withBindingBodyUnusedName fun x => delabTeleFields (acc.push (⟨x⟩, type))
+
+@[app_delab Iris.Std.Tele.cons]
+meta def delabTeleLiteral : Delab := whenPPOption getPPNotation do
+  guard (literalArity? (← getExpr)).isSome
+  let fields ← delabTeleFields #[]
+  if ← getPPOption getPPPiBinderTypes then
+    let xs := fields.map (·.1)
+    let types := fields.map (·.2)
+    `(⟦tele $[($xs:ident : $types)]*⟧)
+  else
+    let xs := fields.map (·.1)
+    `(⟦tele $[$xs:ident]*⟧)
+
+@[app_delab Iris.Std.Tele.nil]
+meta def delabTeleNilLiteral : Delab :=
+  whenPPOption getPPNotation <| whenNotPPOption getPPUniverses `(⟦tele⟧)
+
+private meta partial def delabTeleArgFields (acc : Array Term) : DelabM (Array Term) := do
+  if (← getExpr).isConstOf ``Tele.Arg.nil then return acc
+  let x ← withNaryArg 2 delab
+  withNaryArg 3 (delabTeleArgFields (acc.push x))
+
+@[app_delab Iris.Std.Tele.Arg.cons]
+meta def delabTeleArgLiteral : Delab := whenPPOption getPPNotation do
+  guard (Arg.literalLength? (← getExpr)).isSome
+  let xs ← delabTeleArgFields #[]
+  `(⟦tele_arg $xs,*⟧)
+
+@[app_delab Iris.Std.Tele.Arg.nil]
+meta def delabTeleArgNilLiteral : Delab :=
+  whenPPOption getPPNotation <| whenNotPPOption getPPUniverses `(⟦tele_arg⟧)
+
 /-- Collapse a non-dependent telescopic function into a single value, using `step` to introduce
 one binder at a time. -/
 def fold {B : Type v} (step : (A : Type u) → (A → B) → B) : {TT : Tele.{u}} → (TT -t> B) → B

--- a/Iris/Iris/Std/Telescopes.lean
+++ b/Iris/Iris/Std/Telescopes.lean
@@ -43,6 +43,8 @@ def Arg : Tele.{u} → Type u
 @[match_pattern] abbrev Arg.cons {b : X → Tele.{u}} (x : X) (xs : (b x).Arg) :
     (Tele.cons b).Arg := ⟨x, xs⟩
 
+instance : CoeSort Tele.{u} (Type u) := ⟨Tele.Arg⟩
+
 def Fun : (TT : Tele.{u}) → (TT.Arg → Type v) → Type (max u v)
   | .nil, T => ULift (T .nil)
   | .cons b, T => (x : _) → (b x).Fun fun xs => T (.cons x xs)
@@ -153,6 +155,18 @@ meta def delabLam : Delab :=
   delabQuant 3 pure
     (fun x rest body => `(λ.. $x:ident $[$rest:ident]*, $body))
     (fun | `(λ.. $y:ident $[$ys:ident]*, $body) => some (y, ys, body) | _ => none)
+
+syntax:max "[" &"tele" (ppSpace explicitBinders)? "]" : term
+syntax:max "[" &"tele_arg" (ppSpace term),* "]" : term
+
+macro_rules
+  | `([tele $[$bs]?]) => return ← expandLiteral bs
+  | `([tele_arg $xs,*]) => do
+    let xs := xs.getElems
+    if xs.isEmpty then
+      `((Tele.Arg.nil : Tele.Arg (Tele.nil.{0})))
+    else
+      xs.foldrM (fun x acc => `(Tele.Arg.cons $x $(⟨acc⟩))) (← `(Tele.Arg.nil))
 
 /-- Collapse a non-dependent telescopic function into a single value, using `step` to introduce
 one binder at a time. -/

--- a/Iris/IrisTest/Telescopes.lean
+++ b/Iris/IrisTest/Telescopes.lean
@@ -21,9 +21,20 @@ variable {PROP : Type} [inst : BI PROP] {TT : Tele.{0}}
 /-- info: ⟦tele⟧ : Tele -/
 #guard_msgs in #check ⟦tele⟧
 
-set_option linter.unusedVariables false in
 /-- info: ⟦tele  (n : Nat) (b : Bool) (s : String)⟧ : Tele -/
-#guard_msgs in #check ⟦tele (n : Nat) (b : Bool) (s : String)⟧
+#guard_msgs in
+set_option linter.unusedVariables false in
+#check ⟦tele (n : Nat) (b : Bool) (s : String)⟧
+
+/-- info: Tele.nil : Tele -/
+#guard_msgs in
+set_option pp.notation false in
+#check ⟦tele⟧
+
+/-- info: Tele.nil.{0} : Tele.{0} -/
+#guard_msgs in
+set_option pp.universes true in
+#check ⟦tele⟧
 
 set_option linter.unusedVariables false in
 /-- info: ⟦tele  (n : Nat) (f : Fin n)⟧ : Tele -/

--- a/Iris/IrisTest/Telescopes.lean
+++ b/Iris/IrisTest/Telescopes.lean
@@ -18,6 +18,25 @@ variable {PROP : Type} [inst : BI PROP] {TT : Tele.{0}}
   (Φ Ψ : TT.Arg → PROP) (φ : TT.Arg → Prop) (a : TT.Arg)
 
 /- Delaboration of the telescope-aware lambda. -/
+/-- info: ⟦tele⟧ : Tele -/
+#guard_msgs in #check ⟦tele⟧
+
+set_option linter.unusedVariables false in
+/-- info: ⟦tele  (n : Nat) (b : Bool) (s : String)⟧ : Tele -/
+#guard_msgs in #check ⟦tele (n : Nat) (b : Bool) (s : String)⟧
+
+set_option linter.unusedVariables false in
+/-- info: ⟦tele  (n : Nat) (f : Fin n)⟧ : Tele -/
+#guard_msgs in #check ⟦tele (n : Nat) (f : Fin n)⟧
+
+/-- info: ⟦tele_arg⟧ : ⟦tele⟧.Arg -/
+#guard_msgs in #check ⟦tele_arg⟧
+
+/-- info: ⟦tele_arg 3, true⟧ : ⟦tele  (x : Nat) (x : Bool)⟧.Arg -/
+#guard_msgs in
+#check (⟦tele_arg 3, true⟧ : Tele.Arg ⟦tele (_ : Nat) (_ : Bool)⟧)
+
+/- Delaboration of the telescope-aware lambda. -/
 /-- info: λ.. x, Φ x : TT.Arg → PROP -/
 #guard_msgs in #check (λ.. x, Φ x)
 

--- a/Iris/IrisTest/Telescopes.lean
+++ b/Iris/IrisTest/Telescopes.lean
@@ -17,33 +17,46 @@ open Iris BI ProofMode Std
 variable {PROP : Type} [inst : BI PROP] {TT : Tele.{0}}
   (Φ Ψ : TT.Arg → PROP) (φ : TT.Arg → Prop) (a : TT.Arg)
 
-/- Delaboration of the telescope-aware lambda. -/
+/- Delaboration of the empty telescope. -/
 /-- info: ⟦tele⟧ : Tele -/
 #guard_msgs in #check ⟦tele⟧
 
-/-- info: ⟦tele  (n : Nat) (b : Bool) (s : String)⟧ : Tele -/
+/- Delaboration of a telescope with multiple explicitly typed dependent binders. -/
+/-- info: ⟦tele (n : Nat) (b : Bool) (s : String)⟧ : Tele -/
 #guard_msgs in
 set_option linter.unusedVariables false in
 #check ⟦tele (n : Nat) (b : Bool) (s : String)⟧
 
+/- Same test but without type annotations. -/
+/-- info: ⟦tele n b s⟧ : Tele -/
+#guard_msgs in
+set_option pp.piBinderTypes false in
+set_option linter.unusedVariables false in
+#check ⟦tele (n : Nat) (b : Bool) (s : String)⟧
+
+/- No delaboration when `pp.notation` is set as `false`. -/
 /-- info: Tele.nil : Tele -/
 #guard_msgs in
 set_option pp.notation false in
 #check ⟦tele⟧
 
+/- No delaboration when `pp.notation` when the universe has to be printed. -/
 /-- info: Tele.nil.{0} : Tele.{0} -/
 #guard_msgs in
 set_option pp.universes true in
 #check ⟦tele⟧
 
+/- Delaboration of a telescope with dependent binders. -/
 set_option linter.unusedVariables false in
-/-- info: ⟦tele  (n : Nat) (f : Fin n)⟧ : Tele -/
+/-- info: ⟦tele (n : Nat) (f : Fin n)⟧ : Tele -/
 #guard_msgs in #check ⟦tele (n : Nat) (f : Fin n)⟧
 
+/- Delaboration of `Tele.Arg.nil` -/
 /-- info: ⟦tele_arg⟧ : ⟦tele⟧.Arg -/
 #guard_msgs in #check ⟦tele_arg⟧
 
-/-- info: ⟦tele_arg 3, true⟧ : ⟦tele  (x : Nat) (x : Bool)⟧.Arg -/
+/- Delaboration of `Tele.Arg.cons` -/
+/-- info: ⟦tele_arg 3, true⟧ : ⟦tele (x : Nat) (x : Bool)⟧.Arg -/
 #guard_msgs in
 #check (⟦tele_arg 3, true⟧ : Tele.Arg ⟦tele (_ : Nat) (_ : Bool)⟧)
 


### PR DESCRIPTION
## Description

Addresses https://github.com/leanprover-community/iris-lean/pull/672#pullrequestreview-5031335147.

Introduces the notations for `Tele.nil`, `Tele.cons`, `Tele.Arg.nil` and `Tele.Arg.cons`. The [coercion](https://gitlab.mpi-sws.org/iris/stdpp/-/blob/master/stdpp/telescopes.v#L47) is also ported.

The double bracket `⟦…⟧` is used instead of the single bracket `[…]` for two reasons.
- We cannot use it directly in the theorem's type signature like this:
  ```lean4
  theorem persistent_seq_wp_atomic {α : [tele] → IProp GF} {β : [tele] → TB.Arg → IProp GF} …
  ```
  This is because `[…]` is parsed as a type class hypothesis.
- A workaround would be to add parentheses:
  ```lean4
  theorem persistent_seq_wp_atomic {α : ([tele]) → IProp GF} {β : ([tele]) → TB.Arg → IProp GF} …
  ```
  The notations are elaborated correctly, so the theorem and its proof are accepted. Nonetheless, weird things happen as it conflates with the list notation, which results in `tele` and `tele_arg` being registered as implicit parameters.

  <img width="536" height="32" alt="Parsing problem with square brackets" src="https://github.com/user-attachments/assets/870b5317-ba61-40bf-b73b-dddc6e0eb8c4" />
  


## Checklist
* [x] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [x] I have added my name to the `authors` section of any appropriate files
