### PR TITLE
fix: wrong pattern matching in `findECtxRev`

### DIFF
--- a/Iris/Iris/HeapLang/Tactic.lean
+++ b/Iris/Iris/HeapLang/Tactic.lean
@@ -146,5 +146,5 @@ where
   go (e' : Q(Exp)) (K : Q(List ECtxItem)) : ProofModeM (Option (ECtxResultOf ogE α)) := do
     if let some a ← observing? <| pred K e' then
       return some {result := a, K, e'}
-    let_expr List.cons Ki K := K | return none
+    let_expr List.cons _ Ki K := K | return none
     go (← fillItem e' Ki) K


### PR DESCRIPTION
## Description
`List.cons` takes 3 arguments, not 2, even if only 2 are explicit. This PR fixes a small bug in `findECtxRev`.

## Checklist
* [X] My code follows the mathlib [naming](https://leanprover-community.github.io/contribute/naming.html) and [code style](https://leanprover-community.github.io/contribute/style.html) conventions
* [X] I have added my name to the `authors` section of any appropriate files