### PR TITLE
chore: Standardize the per-file copyright notices.

### DIFF
--- a/Iris/Iris.lean
+++ b/Iris/Iris.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/Iris.lean
+++ b/Iris/Iris.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public import Iris.Algebra

--- a/Iris/Iris/Algebra.lean
+++ b/Iris/Iris/Algebra.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/Iris/Algebra.lean
+++ b/Iris/Iris/Algebra.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public import Iris.Algebra.Agree

--- a/Iris/Iris/Algebra/Agree.lean
+++ b/Iris/Iris/Algebra/Agree.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Leo Stefanesco. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leo Stefanesco, Puming Liu, Sergei Stepanenko
 -/

--- a/Iris/Iris/Algebra/Auth.lean
+++ b/Iris/Iris/Algebra/Auth.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Alexander Bai. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alexander Bai
 -/

--- a/Iris/Iris/Algebra/BigOp.lean
+++ b/Iris/Iris/Algebra/BigOp.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Zongyuan Liu. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zongyuan Liu, Markus de Medeiros, Sergei Stepanenko
 -/

--- a/Iris/Iris/Algebra/CMRA.lean
+++ b/Iris/Iris/Algebra/CMRA.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Mario Carneiro. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Сухарик (@suhr), Markus de Medeiros, Puming Liu
 -/

--- a/Iris/Iris/Algebra/CMRABigOp.lean
+++ b/Iris/Iris/Algebra/CMRABigOp.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Zongyuan Liu. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zongyuan Liu
 -/

--- a/Iris/Iris/Algebra/COFESolver.lean
+++ b/Iris/Iris/Algebra/COFESolver.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Mario Carneiro. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Sebastian Graf
 -/

--- a/Iris/Iris/Algebra/Chain.lean
+++ b/Iris/Iris/Algebra/Chain.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Sergei Stepanenko. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sergei Stepanenko
 -/

--- a/Iris/Iris/Algebra/Csum.lean
+++ b/Iris/Iris/Algebra/Csum.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/Algebra/DFrac.lean
+++ b/Iris/Iris/Algebra/DFrac.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Markus de Medeiros. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros, Mario Carneiro
 -/

--- a/Iris/Iris/Algebra/DynReservationMap.lean
+++ b/Iris/Iris/Algebra/DynReservationMap.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Zongyuan Liu. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zongyuan Liu
 -/

--- a/Iris/Iris/Algebra/Excl.lean
+++ b/Iris/Iris/Algebra/Excl.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Oliver Soeser. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Oliver Soeser, Mario Carneiro
 -/

--- a/Iris/Iris/Algebra/Frac.lean
+++ b/Iris/Iris/Algebra/Frac.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Markus de Medeiros. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros, Shreyas Srinivas, Mario Carneiro
 -/

--- a/Iris/Iris/Algebra/Functions.lean
+++ b/Iris/Iris/Algebra/Functions.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Zongyuan Liu. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zongyuan Liu
 -/

--- a/Iris/Iris/Algebra/GenMap.lean
+++ b/Iris/Iris/Algebra/GenMap.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/Algebra/Heap.lean
+++ b/Iris/Iris/Algebra/Heap.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Markus de Medeiros. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros, Puming Liu
 -/

--- a/Iris/Iris/Algebra/HeapView.lean
+++ b/Iris/Iris/Algebra/HeapView.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Markus de Medeiros. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros, Puming Liu
 -/

--- a/Iris/Iris/Algebra/IProp.lean
+++ b/Iris/Iris/Algebra/IProp.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Markus de Medeiros. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/Algebra/IsOp.lean
+++ b/Iris/Iris/Algebra/IsOp.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Alvin Tang. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler, Alvin Tang
 -/

--- a/Iris/Iris/Algebra/LeibnizMultiSet.lean
+++ b/Iris/Iris/Algebra/LeibnizMultiSet.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/Algebra/LeibnizSet.lean
+++ b/Iris/Iris/Algebra/LeibnizSet.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Sergei Stepanenko. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sergei Stepanenko, Zongyuan Liu
 -/

--- a/Iris/Iris/Algebra/Lib.lean
+++ b/Iris/Iris/Algebra/Lib.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/Iris/Algebra/Lib.lean
+++ b/Iris/Iris/Algebra/Lib.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public import Iris.Algebra.Lib.DFracAgree

--- a/Iris/Iris/Algebra/Lib/DFracAgree.lean
+++ b/Iris/Iris/Algebra/Lib/DFracAgree.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Markus de Medeiros. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/Algebra/Lib/ExclAuth.lean
+++ b/Iris/Iris/Algebra/Lib/ExclAuth.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/Algebra/Lib/FracAuth.lean
+++ b/Iris/Iris/Algebra/Lib/FracAuth.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Iris contributors. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/Algebra/Lib/MonoList.lean
+++ b/Iris/Iris/Algebra/Lib/MonoList.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/Algebra/Lib/MonoNat.lean
+++ b/Iris/Iris/Algebra/Lib/MonoNat.lean
@@ -1,6 +1,7 @@
 /-
-Copyright (c) 2026 Sergei Stepanenko. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sergei Stepanenko
 -/
 module
 

--- a/Iris/Iris/Algebra/Lib/MonoZ.lean
+++ b/Iris/Iris/Algebra/Lib/MonoZ.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/Algebra/Lib/SetBij.lean
+++ b/Iris/Iris/Algebra/Lib/SetBij.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/Algebra/Lib/UFracAuth.lean
+++ b/Iris/Iris/Algebra/Lib/UFracAuth.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Zongyuan Liu. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zongyuan Liu, Markus de Medeiros
 -/

--- a/Iris/Iris/Algebra/List.lean
+++ b/Iris/Iris/Algebra/List.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/Algebra/LocalUpdates.lean
+++ b/Iris/Iris/Algebra/LocalUpdates.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Сухарик. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Сухарик (@suhr), Mario Carneiro
 -/

--- a/Iris/Iris/Algebra/MaxPrefixList.lean
+++ b/Iris/Iris/Algebra/MaxPrefixList.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/Algebra/Monoid.lean
+++ b/Iris/Iris/Algebra/Monoid.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Zongyuan Liu. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zongyuan Liu
 -/

--- a/Iris/Iris/Algebra/Mra.lean
+++ b/Iris/Iris/Algebra/Mra.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Zongyuan Liu. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zongyuan Liu
 -/

--- a/Iris/Iris/Algebra/Numbers.lean
+++ b/Iris/Iris/Algebra/Numbers.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Shreyas Srinivas. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Shreyas Srinivas, Markus de Medeiros, Fernando Leal
 -/

--- a/Iris/Iris/Algebra/OFE.lean
+++ b/Iris/Iris/Algebra/OFE.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2023 Mario Carneiro. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Sebastian Graf, Sergei Stepanenko, Markus de Medeiros
 -/

--- a/Iris/Iris/Algebra/Porting.lean
+++ b/Iris/Iris/Algebra/Porting.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/Algebra/ReservationMap.lean
+++ b/Iris/Iris/Algebra/ReservationMap.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 import Iris.Std.Positives

--- a/Iris/Iris/Algebra/ReservationMap.lean
+++ b/Iris/Iris/Algebra/ReservationMap.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/Iris/Algebra/StepIndex.lean
+++ b/Iris/Iris/Algebra/StepIndex.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Alvin Tang. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler, Alvin Tang
 -/

--- a/Iris/Iris/Algebra/UFrac.lean
+++ b/Iris/Iris/Algebra/UFrac.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Markus de Medeiros. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/Algebra/UPred.lean
+++ b/Iris/Iris/Algebra/UPred.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Markus de Medeiros. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/Algebra/Updates.lean
+++ b/Iris/Iris/Algebra/Updates.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Сухарик. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Сухарик (@suhr)
 -/

--- a/Iris/Iris/Algebra/Vector.lean
+++ b/Iris/Iris/Algebra/Vector.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Markus de Medeiros. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/Algebra/View.lean
+++ b/Iris/Iris/Algebra/View.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Markus de Medeiros. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros, Puming Liu
 -/

--- a/Iris/Iris/BI.lean
+++ b/Iris/Iris/BI.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/Iris/BI.lean
+++ b/Iris/Iris/BI.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public import Iris.BI.Algebra

--- a/Iris/Iris/BI/Algebra.lean
+++ b/Iris/Iris/BI/Algebra.lean
@@ -1,6 +1,7 @@
 /-
-Copyright (c) 2026 Sergei Stepanenko. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sergei Stepanenko
 -/
 module
 

--- a/Iris/Iris/BI/BI.lean
+++ b/Iris/Iris/BI/BI.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro
 -/

--- a/Iris/Iris/BI/BIBase.lean
+++ b/Iris/Iris/BI/BIBase.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro
 -/

--- a/Iris/Iris/BI/BigOp.lean
+++ b/Iris/Iris/BI/BigOp.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/Iris/BI/BigOp.lean
+++ b/Iris/Iris/BI/BigOp.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public import Iris.BI.BigOp.BigAndList

--- a/Iris/Iris/BI/BigOp/BigAndList.lean
+++ b/Iris/Iris/BI/BigOp/BigAndList.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Zongyuan Liu. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zongyuan Liu
 -/

--- a/Iris/Iris/BI/BigOp/BigAndMap.lean
+++ b/Iris/Iris/BI/BigOp/BigAndMap.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Zongyuan Liu. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zongyuan Liu
 -/

--- a/Iris/Iris/BI/BigOp/BigOp.lean
+++ b/Iris/Iris/BI/BigOp/BigOp.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Zongyuan Liu. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zongyuan Liu
 -/

--- a/Iris/Iris/BI/BigOp/BigOrList.lean
+++ b/Iris/Iris/BI/BigOp/BigOrList.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Zongyuan Liu. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zongyuan Liu
 -/

--- a/Iris/Iris/BI/BigOp/BigSepList.lean
+++ b/Iris/Iris/BI/BigOp/BigSepList.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Zongyuan Liu. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zongyuan Liu
 -/

--- a/Iris/Iris/BI/BigOp/BigSepMSet.lean
+++ b/Iris/Iris/BI/BigOp/BigSepMSet.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Haokun Li. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Haokun Li
 -/

--- a/Iris/Iris/BI/BigOp/BigSepMap.lean
+++ b/Iris/Iris/BI/BigOp/BigSepMap.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Zongyuan Liu. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zongyuan Liu
 -/

--- a/Iris/Iris/BI/BigOp/BigSepMap2.lean
+++ b/Iris/Iris/BI/BigOp/BigSepMap2.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Zongyuan Liu. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zongyuan Liu
 -/

--- a/Iris/Iris/BI/BigOp/BigSepSet.lean
+++ b/Iris/Iris/BI/BigOp/BigSepSet.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Zongyuan Liu. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zongyuan Liu
 -/

--- a/Iris/Iris/BI/Classes.lean
+++ b/Iris/Iris/BI/Classes.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro
 -/

--- a/Iris/Iris/BI/Cmra.lean
+++ b/Iris/Iris/BI/Cmra.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Michael Sammler. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Markus de Medeiros
+Authors: Michael Sammler, Markus de Medeiros
 -/
 module
 

--- a/Iris/Iris/BI/DerivedLaws.lean
+++ b/Iris/Iris/BI/DerivedLaws.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro, Markus de Medeiros, Michael Sammler, Alvin Tang
 -/

--- a/Iris/Iris/BI/DerivedLawsLater.lean
+++ b/Iris/Iris/BI/DerivedLawsLater.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Michael Sammler. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler
 -/

--- a/Iris/Iris/BI/Embedding.lean
+++ b/Iris/Iris/BI/Embedding.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Haokun Li. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Haokun Li
 -/

--- a/Iris/Iris/BI/Extensions.lean
+++ b/Iris/Iris/BI/Extensions.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König
 -/

--- a/Iris/Iris/BI/Instances.lean
+++ b/Iris/Iris/BI/Instances.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro
 -/

--- a/Iris/Iris/BI/InternalEq.lean
+++ b/Iris/Iris/BI/InternalEq.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/BI/Lib.lean
+++ b/Iris/Iris/BI/Lib.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/Iris/BI/Lib.lean
+++ b/Iris/Iris/BI/Lib.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public import Iris.BI.Lib.Atomic

--- a/Iris/Iris/BI/Lib/Atomic.lean
+++ b/Iris/Iris/BI/Lib/Atomic.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros, Alvin Tang
 -/

--- a/Iris/Iris/BI/Lib/BUpdPlain.lean
+++ b/Iris/Iris/BI/Lib/BUpdPlain.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alex Bai, Markus de Medeiros
 -/

--- a/Iris/Iris/BI/Lib/Core.lean
+++ b/Iris/Iris/BI/Lib/Core.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Alvin Tang. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alvin Tang
 -/

--- a/Iris/Iris/BI/Lib/Counterexamples.lean
+++ b/Iris/Iris/BI/Lib/Counterexamples.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Alvin Tang. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alvin Tang
 -/

--- a/Iris/Iris/BI/Lib/Fixpoint.lean
+++ b/Iris/Iris/BI/Lib/Fixpoint.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Markus de Medeiros
+Authors: Lars König, Markus de Medeiros
 -/
 module
 

--- a/Iris/Iris/BI/Lib/FixpointBanach.lean
+++ b/Iris/Iris/BI/Lib/FixpointBanach.lean
@@ -1,6 +1,7 @@
 /-
-Copyright (c) 2026 Sergei Stepanenko. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sergei Stepanenko
 -/
 module
 

--- a/Iris/Iris/BI/Lib/Fractional.lean
+++ b/Iris/Iris/BI/Lib/Fractional.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Сухарик. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Сухарик (@suhr)
 -/

--- a/Iris/Iris/BI/Lib/GenHeap.lean
+++ b/Iris/Iris/BI/Lib/GenHeap.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 public import Iris.Algebra

--- a/Iris/Iris/BI/Lib/GenHeap.lean
+++ b/Iris/Iris/BI/Lib/GenHeap.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 public import Iris.Algebra
 public import Iris.Algebra.ReservationMap

--- a/Iris/Iris/BI/Lib/InvHeap.lean
+++ b/Iris/Iris/BI/Lib/InvHeap.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 . All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/BI/Lib/Laterable.lean
+++ b/Iris/Iris/BI/Lib/Laterable.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Alvin Tang. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alvin Tang
 -/

--- a/Iris/Iris/BI/Lib/MonoList.lean
+++ b/Iris/Iris/BI/Lib/MonoList.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/BI/Lib/MonoNat.lean
+++ b/Iris/Iris/BI/Lib/MonoNat.lean
@@ -1,6 +1,7 @@
 /-
-Copyright (c) 2026 Sergei Stepanenko. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sergei Stepanenko
 -/
 module
 

--- a/Iris/Iris/BI/Lib/MonoZ.lean
+++ b/Iris/Iris/BI/Lib/MonoZ.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/BI/Lib/ProphMap.lean
+++ b/Iris/Iris/BI/Lib/ProphMap.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) Markus de Medeiros 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/BI/Lib/Relations.lean
+++ b/Iris/Iris/BI/Lib/Relations.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zongyuan Liu
 -/

--- a/Iris/Iris/BI/MonPred.lean
+++ b/Iris/Iris/BI/MonPred.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Haokun Li. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Haokun Li, Sergei Stepanenko
 -/

--- a/Iris/Iris/BI/Notation.lean
+++ b/Iris/Iris/BI/Notation.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Alex Keizer, Alvin Tang
 -/

--- a/Iris/Iris/BI/Plainly.lean
+++ b/Iris/Iris/BI/Plainly.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Markus de Medeiros. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros, Fernando Leal
 -/

--- a/Iris/Iris/BI/SIProp.lean
+++ b/Iris/Iris/BI/SIProp.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/BI/Sbi.lean
+++ b/Iris/Iris/BI/Sbi.lean
@@ -1,7 +1,6 @@
 /-
-Copyright (c) 2025. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/Iris/BI/SbiUnfold.lean
+++ b/Iris/Iris/BI/SbiUnfold.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/BI/Telescopes.lean
+++ b/Iris/Iris/BI/Telescopes.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/BI/Updates.lean
+++ b/Iris/Iris/BI/Updates.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Markus de Medeiros, Remy Seassau. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros, Remy Seassau, Yunsong Yang
 -/

--- a/Iris/Iris/BI/WeakestPre.lean
+++ b/Iris/Iris/BI/WeakestPre.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/Iris/BI/WeakestPre.lean
+++ b/Iris/Iris/BI/WeakestPre.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public import Iris.Std.CoPset

--- a/Iris/Iris/Examples.lean
+++ b/Iris/Iris/Examples.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public import Iris.Examples.ClosedProofs

--- a/Iris/Iris/Examples.lean
+++ b/Iris/Iris/Examples.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/Iris/Examples/ClosedProofs.lean
+++ b/Iris/Iris/Examples/ClosedProofs.lean
@@ -1,6 +1,7 @@
 /-
-Copyright (c) 2026 Sergei Stepanenko. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sergei Stepanenko
 -/
 module
 

--- a/Iris/Iris/Examples/Fix.lean
+++ b/Iris/Iris/Examples/Fix.lean
@@ -1,6 +1,7 @@
 /-
-Copyright (c) 2026 Sergei Stepanenko. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sergei Stepanenko
 -/
 module
 

--- a/Iris/Iris/Examples/HeapLang.lean
+++ b/Iris/Iris/Examples/HeapLang.lean
@@ -1,6 +1,7 @@
 /-
-Copyright (c) 2026 Sergei Stepanenko. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sergei Stepanenko
 -/
 module
 

--- a/Iris/Iris/Examples/IProp.lean
+++ b/Iris/Iris/Examples/IProp.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Markus de Medeiros. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/Examples/Namesets.lean
+++ b/Iris/Iris/Examples/Namesets.lean
@@ -1,6 +1,7 @@
 /-
-Copyright (c) 2026 Sergei Stepanenko. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sergei Stepanenko
 -/
 module
 

--- a/Iris/Iris/Examples/Proofs.lean
+++ b/Iris/Iris/Examples/Proofs.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König
 -/

--- a/Iris/Iris/Examples/Resources.lean
+++ b/Iris/Iris/Examples/Resources.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Markus de Medeiros. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/HeapLang.lean
+++ b/Iris/Iris/HeapLang.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/Iris/HeapLang.lean
+++ b/Iris/Iris/HeapLang.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public import Iris.HeapLang.Completeness

--- a/Iris/Iris/HeapLang/Completeness.lean
+++ b/Iris/Iris/HeapLang/Completeness.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Markus de Medeiros. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/HeapLang/DerivedLaws.lean
+++ b/Iris/Iris/HeapLang/DerivedLaws.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/HeapLang/Instances.lean
+++ b/Iris/Iris/HeapLang/Instances.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Sergei Stepanenko. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sergei Stepanenko, Markus de Medeiros
 -/

--- a/Iris/Iris/HeapLang/Lib.lean
+++ b/Iris/Iris/HeapLang/Lib.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public import Iris.HeapLang.Lib.Arith

--- a/Iris/Iris/HeapLang/Lib.lean
+++ b/Iris/Iris/HeapLang/Lib.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/Iris/HeapLang/Lib/Arith.lean
+++ b/Iris/Iris/HeapLang/Lib/Arith.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/HeapLang/Lib/Array.lean
+++ b/Iris/Iris/HeapLang/Lib/Array.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/HeapLang/Lib/Assert.lean
+++ b/Iris/Iris/HeapLang/Lib/Assert.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/HeapLang/Lib/ClairvoyantCoin.lean
+++ b/Iris/Iris/HeapLang/Lib/ClairvoyantCoin.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/HeapLang/Lib/Counter.lean
+++ b/Iris/Iris/HeapLang/Lib/Counter.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/HeapLang/Lib/Diverge.lean
+++ b/Iris/Iris/HeapLang/Lib/Diverge.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/HeapLang/Lib/LandinsKnot.lean
+++ b/Iris/Iris/HeapLang/Lib/LandinsKnot.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alex Bai, Klaus Kraßnitzer
 -/

--- a/Iris/Iris/HeapLang/Lib/LazyCoin.lean
+++ b/Iris/Iris/HeapLang/Lib/LazyCoin.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/Iris/HeapLang/Lib/LazyCoin.lean
+++ b/Iris/Iris/HeapLang/Lib/LazyCoin.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public import Iris.HeapLang

--- a/Iris/Iris/HeapLang/Lib/Lock.lean
+++ b/Iris/Iris/HeapLang/Lib/Lock.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/Iris/HeapLang/Lib/Lock.lean
+++ b/Iris/Iris/HeapLang/Lib/Lock.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public import Iris.ProgramLogic.WeakestPre

--- a/Iris/Iris/HeapLang/Lib/NondetBool.lean
+++ b/Iris/Iris/HeapLang/Lib/NondetBool.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/Iris/HeapLang/Lib/NondetBool.lean
+++ b/Iris/Iris/HeapLang/Lib/NondetBool.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public import Iris.ProgramLogic.WeakestPre

--- a/Iris/Iris/HeapLang/Lib/Par.lean
+++ b/Iris/Iris/HeapLang/Lib/Par.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zongyuan Liu
 -/

--- a/Iris/Iris/HeapLang/Lib/Quicksort.lean
+++ b/Iris/Iris/HeapLang/Lib/Quicksort.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros, Michael Sammler, Klaus Kraßnitzer
 -/

--- a/Iris/Iris/HeapLang/Lib/RwLock.lean
+++ b/Iris/Iris/HeapLang/Lib/RwLock.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/HeapLang/Lib/RwSpinLock.lean
+++ b/Iris/Iris/HeapLang/Lib/RwSpinLock.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/HeapLang/Lib/Spawn.lean
+++ b/Iris/Iris/HeapLang/Lib/Spawn.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zongyuan Liu, Klaus Kraßnitzer
 -/

--- a/Iris/Iris/HeapLang/Lib/SpinLock.lean
+++ b/Iris/Iris/HeapLang/Lib/SpinLock.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler, Fernando Leal, Klaus Kraßnitzer
 -/

--- a/Iris/Iris/HeapLang/Lib/TicketLock.lean
+++ b/Iris/Iris/HeapLang/Lib/TicketLock.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/HeapLang/Lib/Unwrap.lean
+++ b/Iris/Iris/HeapLang/Lib/Unwrap.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/HeapLang/Linter.lean
+++ b/Iris/Iris/HeapLang/Linter.lean
@@ -1,6 +1,7 @@
 /-
-Copyright (c) 2026 Markus de Medeiros. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Markus de Medeiros
 -/
 module
 

--- a/Iris/Iris/HeapLang/Metatheory.lean
+++ b/Iris/Iris/HeapLang/Metatheory.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/HeapLang/Notation.lean
+++ b/Iris/Iris/HeapLang/Notation.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Michael Sammler. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler
 -/

--- a/Iris/Iris/HeapLang/Porting.lean
+++ b/Iris/Iris/HeapLang/Porting.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/HeapLang/PrimitiveLaws.lean
+++ b/Iris/Iris/HeapLang/PrimitiveLaws.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public import Iris.HeapLang.Syntax

--- a/Iris/Iris/HeapLang/PrimitiveLaws.lean
+++ b/Iris/Iris/HeapLang/PrimitiveLaws.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/Iris/HeapLang/ProofMode.lean
+++ b/Iris/Iris/HeapLang/ProofMode.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Fernando Leal, Klaus Kraßnitzer. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Fernando Leal, Klaus Kraßnitzer
 -/

--- a/Iris/Iris/HeapLang/ProphErasure.lean
+++ b/Iris/Iris/HeapLang/ProphErasure.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Max Vistrup, Markus de Medeiros
 -/

--- a/Iris/Iris/HeapLang/Semantics.lean
+++ b/Iris/Iris/HeapLang/Semantics.lean
@@ -1,6 +1,7 @@
 /-
-Copyright (c) 2026 Sergei Stepanenko. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sergei Stepanenko
 -/
 module
 

--- a/Iris/Iris/HeapLang/Syntax.lean
+++ b/Iris/Iris/HeapLang/Syntax.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Michael Sammler. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler
 -/

--- a/Iris/Iris/HeapLang/Tactic.lean
+++ b/Iris/Iris/HeapLang/Tactic.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Fernando Leal. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Fernando Leal, Klaus Kraßnitzer
 -/

--- a/Iris/Iris/Init.lean
+++ b/Iris/Iris/Init.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/Iris/Init.lean
+++ b/Iris/Iris/Init.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public meta import Iris.Std.RocqPorting

--- a/Iris/Iris/Instances.lean
+++ b/Iris/Iris/Instances.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/Iris/Instances.lean
+++ b/Iris/Iris/Instances.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public import Iris.Instances.Classical

--- a/Iris/Iris/Instances/Classical.lean
+++ b/Iris/Iris/Instances/Classical.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public import Iris.Instances.Classical.Instance

--- a/Iris/Iris/Instances/Classical.lean
+++ b/Iris/Iris/Instances/Classical.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/Iris/Instances/Classical/Instance.lean
+++ b/Iris/Iris/Instances/Classical/Instance.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König
 -/

--- a/Iris/Iris/Instances/Classical/Notation.lean
+++ b/Iris/Iris/Instances/Classical/Notation.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König
 -/

--- a/Iris/Iris/Instances/Data.lean
+++ b/Iris/Iris/Instances/Data.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/Iris/Instances/Data.lean
+++ b/Iris/Iris/Instances/Data.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public import Iris.Instances.Data.SetNotation

--- a/Iris/Iris/Instances/Data/SetNotation.lean
+++ b/Iris/Iris/Instances/Data/SetNotation.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König
 -/

--- a/Iris/Iris/Instances/Data/State.lean
+++ b/Iris/Iris/Instances/Data/State.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König
 -/

--- a/Iris/Iris/Instances/IProp.lean
+++ b/Iris/Iris/Instances/IProp.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/Iris/Instances/IProp.lean
+++ b/Iris/Iris/Instances/IProp.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public import Iris.Instances.IProp.Instance

--- a/Iris/Iris/Instances/IProp/Instance.lean
+++ b/Iris/Iris/Instances/IProp/Instance.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Markus de Medeiros. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros, Zongyuan Liu, Remy Seassau
 -/

--- a/Iris/Iris/Instances/Lib.lean
+++ b/Iris/Iris/Instances/Lib.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public import Iris.Instances.Lib.Boxes

--- a/Iris/Iris/Instances/Lib.lean
+++ b/Iris/Iris/Instances/Lib.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/Iris/Instances/Lib/Boxes.lean
+++ b/Iris/Iris/Instances/Lib/Boxes.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Sergei Stepanenko. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sergei Stepanenko, Xiaoyang Lu, Zongyuan Liu
 -/

--- a/Iris/Iris/Instances/Lib/CInvariants.lean
+++ b/Iris/Iris/Instances/Lib/CInvariants.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/Instances/Lib/FUpd.lean
+++ b/Iris/Iris/Instances/Lib/FUpd.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Sergei Stepanenko. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sergei Stepanenko, Zongyuan Liu
 -/

--- a/Iris/Iris/Instances/Lib/FUpdFromViewShift.lean
+++ b/Iris/Iris/Instances/Lib/FUpdFromViewShift.lean
@@ -1,6 +1,7 @@
 /-
-Copyright (c) 2026 Zongyuan Liu. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Zongyuan Liu
 -/
 module
 

--- a/Iris/Iris/Instances/Lib/GhostMap.lean
+++ b/Iris/Iris/Instances/Lib/GhostMap.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Сухарик. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Сухарик (@suhr)
 -/

--- a/Iris/Iris/Instances/Lib/GhostVar.lean
+++ b/Iris/Iris/Instances/Lib/GhostVar.lean
@@ -1,7 +1,6 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/Iris/Instances/Lib/Invariants.lean
+++ b/Iris/Iris/Instances/Lib/Invariants.lean
@@ -1,6 +1,7 @@
 /-
-Copyright (c) 2026 Sergei Stepanenko. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sergei Stepanenko
 -/
 module
 

--- a/Iris/Iris/Instances/Lib/LaterCredits.lean
+++ b/Iris/Iris/Instances/Lib/LaterCredits.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Sergei Stepanenko. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sergei Stepanenko, Zongyuan Liu
 -/

--- a/Iris/Iris/Instances/Lib/NaInvariants.lean
+++ b/Iris/Iris/Instances/Lib/NaInvariants.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/Instances/Lib/SavedProp.lean
+++ b/Iris/Iris/Instances/Lib/SavedProp.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Markus de Medeiros. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/Instances/Lib/SetBij.lean
+++ b/Iris/Iris/Instances/Lib/SetBij.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/Instances/Lib/Token.lean
+++ b/Iris/Iris/Instances/Lib/Token.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Markus de Medeiros. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros, Sergei Stepanenko
 -/

--- a/Iris/Iris/Instances/Lib/WSat.lean
+++ b/Iris/Iris/Instances/Lib/WSat.lean
@@ -1,6 +1,7 @@
 /-
-Copyright (c) 2026 Sergei Stepanenko. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sergei Stepanenko
 -/
 module
 

--- a/Iris/Iris/Instances/UPred.lean
+++ b/Iris/Iris/Instances/UPred.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public import Iris.Instances.UPred.Instance

--- a/Iris/Iris/Instances/UPred.lean
+++ b/Iris/Iris/Instances/UPred.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/Iris/Instances/UPred/Instance.lean
+++ b/Iris/Iris/Instances/UPred/Instance.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Markus de Medeiros. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros, Mario Carneiro, Viet Anh Nguyen
 -/

--- a/Iris/Iris/Instances/UPred/ProofMode.lean
+++ b/Iris/Iris/Instances/UPred/ProofMode.lean
@@ -1,7 +1,6 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/Iris/ProgramLogic.lean
+++ b/Iris/Iris/ProgramLogic.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/Iris/ProgramLogic.lean
+++ b/Iris/Iris/ProgramLogic.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public import Iris.ProgramLogic.AbstractEctxLangCompleteness

--- a/Iris/Iris/ProgramLogic/AbstractEctxLangCompleteness.lean
+++ b/Iris/Iris/ProgramLogic/AbstractEctxLangCompleteness.lean
@@ -1,6 +1,7 @@
 /-
-Copyright (c) 2026 Markus de Medeiros. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Markus de Medeiros
 -/
 module
 

--- a/Iris/Iris/ProgramLogic/AbstractLangCompleteness.lean
+++ b/Iris/Iris/ProgramLogic/AbstractLangCompleteness.lean
@@ -1,6 +1,7 @@
 /-
-Copyright (c) 2026 Markus de Medeiros. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Markus de Medeiros
 -/
 module
 

--- a/Iris/Iris/ProgramLogic/AbstractWeakestPre.lean
+++ b/Iris/Iris/ProgramLogic/AbstractWeakestPre.lean
@@ -1,6 +1,7 @@
 /-
-Copyright (c) 2026 Markus de Medeiros. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Markus de Medeiros
 -/
 module
 

--- a/Iris/Iris/ProgramLogic/Adequacy.lean
+++ b/Iris/Iris/ProgramLogic/Adequacy.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Haokun Li. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Haokun Li, Sergei Stepanenko, Zongyuan Liu
 -/

--- a/Iris/Iris/ProgramLogic/Atomic.lean
+++ b/Iris/Iris/ProgramLogic/Atomic.lean
@@ -1,7 +1,6 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/Iris/ProgramLogic/EctxLanguage.lean
+++ b/Iris/Iris/ProgramLogic/EctxLanguage.lean
@@ -1,6 +1,7 @@
 /-
-Copyright (c) 2026 Fernando Leal. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Fernando Leal
 -/
 module
 

--- a/Iris/Iris/ProgramLogic/EctxLifting.lean
+++ b/Iris/Iris/ProgramLogic/EctxLifting.lean
@@ -1,6 +1,7 @@
 /-
-Copyright (c) 2026 Fernando Leal. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Fernando Leal
 -/
 module
 

--- a/Iris/Iris/ProgramLogic/EctxiLanguage.lean
+++ b/Iris/Iris/ProgramLogic/EctxiLanguage.lean
@@ -1,6 +1,7 @@
 /-
-Copyright (c) 2026 Fernando Leal. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Fernando Leal
 -/
 module
 

--- a/Iris/Iris/ProgramLogic/Language.lean
+++ b/Iris/Iris/ProgramLogic/Language.lean
@@ -1,6 +1,7 @@
 /-
-Copyright (c) 2026 Fernando Leal. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Fernando Leal
 -/
 module
 

--- a/Iris/Iris/ProgramLogic/Lifting.lean
+++ b/Iris/Iris/ProgramLogic/Lifting.lean
@@ -1,6 +1,7 @@
 /-
-Copyright (c) 2026 Fernando Leal. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Fernando Leal
 -/
 module
 

--- a/Iris/Iris/ProgramLogic/OwnP.lean
+++ b/Iris/Iris/ProgramLogic/OwnP.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/ProgramLogic/ThreadPool.lean
+++ b/Iris/Iris/ProgramLogic/ThreadPool.lean
@@ -1,6 +1,7 @@
 /-
-Copyright (c) 2026 Markus de Medeiros. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Markus de Medeiros
 -/
 module
 

--- a/Iris/Iris/ProgramLogic/TotalAdequacy.lean
+++ b/Iris/Iris/ProgramLogic/TotalAdequacy.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Marcelo Fornet. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Marcelo Fornet, Zongyuan Liu
 -/

--- a/Iris/Iris/ProgramLogic/TotalEctxLifting.lean
+++ b/Iris/Iris/ProgramLogic/TotalEctxLifting.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Marcelo Fornet. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Marcelo Fornet, Zongyuan Liu
 -/

--- a/Iris/Iris/ProgramLogic/TotalLifting.lean
+++ b/Iris/Iris/ProgramLogic/TotalLifting.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Marcelo Fornet. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Marcelo Fornet, Zongyuan Liu
 -/

--- a/Iris/Iris/ProgramLogic/TotalWeakestPre.lean
+++ b/Iris/Iris/ProgramLogic/TotalWeakestPre.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Marcelo Fornet. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Marcelo Fornet, Zongyuan Liu
 -/

--- a/Iris/Iris/ProgramLogic/WeakestPre.lean
+++ b/Iris/Iris/ProgramLogic/WeakestPre.lean
@@ -1,6 +1,7 @@
 /-
-Copyright (c) 2026 Fernando Leal. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Fernando Leal
 -/
 module
 

--- a/Iris/Iris/ProofMode.lean
+++ b/Iris/Iris/ProofMode.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/Iris/ProofMode.lean
+++ b/Iris/Iris/ProofMode.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public import Iris.ProofMode.Classes

--- a/Iris/Iris/ProofMode/Classes.lean
+++ b/Iris/Iris/ProofMode/Classes.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Michael Sammler, Yunsong Yang, Alvin Tang
 -/

--- a/Iris/Iris/ProofMode/ClassesMake.lean
+++ b/Iris/Iris/ProofMode/ClassesMake.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Michael Sammler. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler, Yunsong Yang
 -/

--- a/Iris/Iris/ProofMode/Display.lean
+++ b/Iris/Iris/ProofMode/Display.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro
 -/

--- a/Iris/Iris/ProofMode/Expr.lean
+++ b/Iris/Iris/ProofMode/Expr.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro, Michael Sammler, Yunsong Yang
 -/

--- a/Iris/Iris/ProofMode/Instances.lean
+++ b/Iris/Iris/ProofMode/Instances.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro, Michael Sammler, Alvin Tang
 -/

--- a/Iris/Iris/ProofMode/InstancesCmra.lean
+++ b/Iris/Iris/ProofMode/InstancesCmra.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Michael Sammler. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler
 -/

--- a/Iris/Iris/ProofMode/InstancesEmbedding.lean
+++ b/Iris/Iris/ProofMode/InstancesEmbedding.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Alvin Tang. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alvin Tang
 -/

--- a/Iris/Iris/ProofMode/InstancesFrame.lean
+++ b/Iris/Iris/ProofMode/InstancesFrame.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Michael Sammler. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler, Alvin Tang
 -/

--- a/Iris/Iris/ProofMode/InstancesInternalEq.lean
+++ b/Iris/Iris/ProofMode/InstancesInternalEq.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Sergei Stepanenko. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sergei Stepanenko, Michael Sammler
 -/

--- a/Iris/Iris/ProofMode/InstancesLater.lean
+++ b/Iris/Iris/ProofMode/InstancesLater.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Michael Sammler. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler, Alvin Tang
 -/

--- a/Iris/Iris/ProofMode/InstancesMake.lean
+++ b/Iris/Iris/ProofMode/InstancesMake.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Michael Sammler. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler, Yunsong Yang
 -/

--- a/Iris/Iris/ProofMode/InstancesPlainly.lean
+++ b/Iris/Iris/ProofMode/InstancesPlainly.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Michael Sammler. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler
 -/

--- a/Iris/Iris/ProofMode/InstancesUpdates.lean
+++ b/Iris/Iris/ProofMode/InstancesUpdates.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Michael Sammler. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler, Yunsong Yang, Alvin Tang
 -/

--- a/Iris/Iris/ProofMode/Modalities.lean
+++ b/Iris/Iris/ProofMode/Modalities.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Markus de Medeiros. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros, Michael Sammler
 -/

--- a/Iris/Iris/ProofMode/ModalityInstances.lean
+++ b/Iris/Iris/ProofMode/ModalityInstances.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Markus de Medeiros. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros, Michael Sammler
 -/

--- a/Iris/Iris/ProofMode/MonPred.lean
+++ b/Iris/Iris/ProofMode/MonPred.lean
@@ -1,7 +1,6 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/Iris/ProofMode/NatCancel.lean
+++ b/Iris/Iris/ProofMode/NatCancel.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Alvin Tang. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alvin Tang
 -/

--- a/Iris/Iris/ProofMode/Patterns.lean
+++ b/Iris/Iris/ProofMode/Patterns.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public import Iris.ProofMode.Patterns.CasesPattern

--- a/Iris/Iris/ProofMode/Patterns.lean
+++ b/Iris/Iris/ProofMode/Patterns.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/Iris/ProofMode/Patterns/CasesPattern.lean
+++ b/Iris/Iris/ProofMode/Patterns/CasesPattern.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Alvin Tang
 -/

--- a/Iris/Iris/ProofMode/Patterns/IntroPattern.lean
+++ b/Iris/Iris/ProofMode/Patterns/IntroPattern.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Michael Sammler. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler, Alvin Tang
 -/

--- a/Iris/Iris/ProofMode/Patterns/SelPattern.lean
+++ b/Iris/Iris/ProofMode/Patterns/SelPattern.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Yunsong Yang. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yunsong Yang
 -/

--- a/Iris/Iris/ProofMode/Patterns/SpecPattern.lean
+++ b/Iris/Iris/ProofMode/Patterns/SpecPattern.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Oliver Soeser. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Oliver Soeser, Zongyuan Liu, Yunsong Yang, Michael Sammler, Alvin Tang
 -/

--- a/Iris/Iris/ProofMode/Porting.lean
+++ b/Iris/Iris/ProofMode/Porting.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zongyuan Liu
 -/

--- a/Iris/Iris/ProofMode/ProofModeM.lean
+++ b/Iris/Iris/ProofMode/ProofModeM.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Michael Sammler. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler, Zongyuan Liu, Yunsong Yang, Alvin Tang
 -/

--- a/Iris/Iris/ProofMode/SolveSideCondition.lean
+++ b/Iris/Iris/ProofMode/SolveSideCondition.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Alvin Tang. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alvin Tang
 -/

--- a/Iris/Iris/ProofMode/SynthInstance.lean
+++ b/Iris/Iris/ProofMode/SynthInstance.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Michael Sammler. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler
 -/

--- a/Iris/Iris/ProofMode/SynthInstanceAttr.lean
+++ b/Iris/Iris/ProofMode/SynthInstanceAttr.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Michael Sammler. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler, Alvin Tang
 -/

--- a/Iris/Iris/ProofMode/Tactics.lean
+++ b/Iris/Iris/ProofMode/Tactics.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 /- A description of the tactics can be found in `tactics.md`. -/
 module
 

--- a/Iris/Iris/ProofMode/Tactics.lean
+++ b/Iris/Iris/ProofMode/Tactics.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 /- A description of the tactics can be found in `tactics.md`. -/
 module

--- a/Iris/Iris/ProofMode/Tactics/Accu.lean
+++ b/Iris/Iris/ProofMode/Tactics/Accu.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Alvin Tang. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler, Alvin Tang
 -/

--- a/Iris/Iris/ProofMode/Tactics/Apply.lean
+++ b/Iris/Iris/ProofMode/Tactics/Apply.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Oliver Soeser. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Oliver Soeser, Michael Sammler
 -/

--- a/Iris/Iris/ProofMode/Tactics/Assumption.lean
+++ b/Iris/Iris/ProofMode/Tactics/Assumption.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro, Michael Sammler
 -/

--- a/Iris/Iris/ProofMode/Tactics/Basic.lean
+++ b/Iris/Iris/ProofMode/Tactics/Basic.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro, Michael Sammler
 -/

--- a/Iris/Iris/ProofMode/Tactics/Cases.lean
+++ b/Iris/Iris/ProofMode/Tactics/Cases.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro, Michael Sammler, Yunsong Yang, Alvin Tang
 -/

--- a/Iris/Iris/ProofMode/Tactics/Clear.lean
+++ b/Iris/Iris/ProofMode/Tactics/Clear.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro, Michael Sammler, Yunsong Yang
 -/

--- a/Iris/Iris/ProofMode/Tactics/Combine.lean
+++ b/Iris/Iris/ProofMode/Tactics/Combine.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Alvin Tang. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alvin Tang, Michael Sammler
 -/

--- a/Iris/Iris/ProofMode/Tactics/Eval.lean
+++ b/Iris/Iris/ProofMode/Tactics/Eval.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Alvin Tang. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler, Alvin Tang
 -/

--- a/Iris/Iris/ProofMode/Tactics/ExFalso.lean
+++ b/Iris/Iris/ProofMode/Tactics/ExFalso.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro, Michael Sammler
 -/

--- a/Iris/Iris/ProofMode/Tactics/Exact.lean
+++ b/Iris/Iris/ProofMode/Tactics/Exact.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro, Michael Sammler
 -/

--- a/Iris/Iris/ProofMode/Tactics/Exists.lean
+++ b/Iris/Iris/ProofMode/Tactics/Exists.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro, Michael Sammler
 -/

--- a/Iris/Iris/ProofMode/Tactics/Frame.lean
+++ b/Iris/Iris/ProofMode/Tactics/Frame.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Michael Sammler. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler
 -/

--- a/Iris/Iris/ProofMode/Tactics/Have.lean
+++ b/Iris/Iris/ProofMode/Tactics/Have.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Michael Sammler. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler
 -/

--- a/Iris/Iris/ProofMode/Tactics/HaveCore.lean
+++ b/Iris/Iris/ProofMode/Tactics/HaveCore.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Michael Sammler. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler, Zongyuan Liu
 -/

--- a/Iris/Iris/ProofMode/Tactics/Induction.lean
+++ b/Iris/Iris/ProofMode/Tactics/Induction.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Yunsong Yang. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yunsong Yang, Michael Sammler, Alvin Tang
 -/

--- a/Iris/Iris/ProofMode/Tactics/Intro.lean
+++ b/Iris/Iris/ProofMode/Tactics/Intro.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro, Michael Sammler, Alvin Tang
 -/

--- a/Iris/Iris/ProofMode/Tactics/Inv.lean
+++ b/Iris/Iris/ProofMode/Tactics/Inv.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Alvin Tang. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler, Alvin Tang
 -/

--- a/Iris/Iris/ProofMode/Tactics/LeftRight.lean
+++ b/Iris/Iris/ProofMode/Tactics/LeftRight.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro, Michael Sammler
 -/

--- a/Iris/Iris/ProofMode/Tactics/Loeb.lean
+++ b/Iris/Iris/ProofMode/Tactics/Loeb.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Fernando Leal. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Fernando Leal
 -/

--- a/Iris/Iris/ProofMode/Tactics/Mod.lean
+++ b/Iris/Iris/ProofMode/Tactics/Mod.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Michael Sammler. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler
 -/

--- a/Iris/Iris/ProofMode/Tactics/ModIntro.lean
+++ b/Iris/Iris/ProofMode/Tactics/ModIntro.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Michael Sammler. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler
 -/

--- a/Iris/Iris/ProofMode/Tactics/Pure.lean
+++ b/Iris/Iris/ProofMode/Tactics/Pure.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro, Michael Sammler
 -/

--- a/Iris/Iris/ProofMode/Tactics/Rename.lean
+++ b/Iris/Iris/ProofMode/Tactics/Rename.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro, Michael Sammler
 -/

--- a/Iris/Iris/ProofMode/Tactics/Revert.lean
+++ b/Iris/Iris/ProofMode/Tactics/Revert.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Oliver Soeser. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Oliver Soeser, Yunsong Yang
 -/

--- a/Iris/Iris/ProofMode/Tactics/RevertIntro.lean
+++ b/Iris/Iris/ProofMode/Tactics/RevertIntro.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Fernando Leal. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Fernando Leal
 -/

--- a/Iris/Iris/ProofMode/Tactics/Rewrite.lean
+++ b/Iris/Iris/ProofMode/Tactics/Rewrite.lean
@@ -1,6 +1,7 @@
 /-
-Copyright (c) 2026 Sergei Stepanenko. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sergei Stepanenko
 -/
 module
 

--- a/Iris/Iris/ProofMode/Tactics/Specialize.lean
+++ b/Iris/Iris/ProofMode/Tactics/Specialize.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro, Michael Sammler, Alvin Tang
 -/

--- a/Iris/Iris/ProofMode/Tactics/Split.lean
+++ b/Iris/Iris/ProofMode/Tactics/Split.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro, Michael Sammler
 -/

--- a/Iris/Iris/ProofMode/Tactics/Trivial.lean
+++ b/Iris/Iris/ProofMode/Tactics/Trivial.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Michael Sammler. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler
 -/

--- a/Iris/Iris/ProofMode/UnifHints.lean
+++ b/Iris/Iris/ProofMode/UnifHints.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König
 -/

--- a/Iris/Iris/Std.lean
+++ b/Iris/Iris/Std.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/Iris/Std.lean
+++ b/Iris/Iris/Std.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public import Iris.Std.BigOp

--- a/Iris/Iris/Std/BigOp.lean
+++ b/Iris/Iris/Std/BigOp.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Mario Carneiro
 -/

--- a/Iris/Iris/Std/BitOp.lean
+++ b/Iris/Iris/Std/BitOp.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/Iris/Std/BitOp.lean
+++ b/Iris/Iris/Std/BitOp.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public import Batteries.Data.Int

--- a/Iris/Iris/Std/Classes.lean
+++ b/Iris/Iris/Std/Classes.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König
 -/

--- a/Iris/Iris/Std/CoPset.lean
+++ b/Iris/Iris/Std/CoPset.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Remy Seassau. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Remy Seassau, Markus de Medeiros, Sergei Stepanenko
 -/

--- a/Iris/Iris/Std/DelabRule.lean
+++ b/Iris/Iris/Std/DelabRule.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König
 -/

--- a/Iris/Iris/Std/Equivalence.lean
+++ b/Iris/Iris/Std/Equivalence.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2023 Mario Carneiro. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/

--- a/Iris/Iris/Std/Expr.lean
+++ b/Iris/Iris/Std/Expr.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König
 -/

--- a/Iris/Iris/Std/FromMathlib.lean
+++ b/Iris/Iris/Std/FromMathlib.lean
@@ -1,6 +1,7 @@
 /-
-Copyright (c) 2026 Zongyuan Liu, Markus de Medeiros. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Zongyuan Liu, Markus de Medeiros
 -/
 module
 

--- a/Iris/Iris/Std/GenMultiSets.lean
+++ b/Iris/Iris/Std/GenMultiSets.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Haokun Li. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Haokun Li, Markus de Medeiros
 -/

--- a/Iris/Iris/Std/GenMultiSetsInstances.lean
+++ b/Iris/Iris/Std/GenMultiSetsInstances.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Haokun Li. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Haokun Li
 -/

--- a/Iris/Iris/Std/GenSets.lean
+++ b/Iris/Iris/Std/GenSets.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Zongyuan Liu, Sergei Stepanenko. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zongyuan Liu, Sergei Stepanenko
 -/

--- a/Iris/Iris/Std/GenSetsInstances.lean
+++ b/Iris/Iris/Std/GenSetsInstances.lean
@@ -1,6 +1,7 @@
 /-
-Copyright (c) 2026 Sergei Stepanenko. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sergei Stepanenko
 -/
 
 module

--- a/Iris/Iris/Std/HeapInstances.lean
+++ b/Iris/Iris/Std/HeapInstances.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Alok Singh. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alok Singh, Markus de Medeiros
 -/

--- a/Iris/Iris/Std/Infinite.lean
+++ b/Iris/Iris/Std/Infinite.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2023 Mario Carneiro. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Markus de Medeiros
+Authors: Mario Carneiro, Markus de Medeiros
 -/
 module
 

--- a/Iris/Iris/Std/List.lean
+++ b/Iris/Iris/Std/List.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Zongyuan Liu. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zongyuan Liu, Markus de Medeiros
 -/

--- a/Iris/Iris/Std/Namespaces.lean
+++ b/Iris/Iris/Std/Namespaces.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Remy Seassau. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Remy Seassau, Markus de Medeiros, Sergei Stepanenko
 -/

--- a/Iris/Iris/Std/Nat.lean
+++ b/Iris/Iris/Std/Nat.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Markus de Medeiros. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/Std/Notation.lean
+++ b/Iris/Iris/Std/Notation.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Alvin Tang. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alvin Tang
 -/

--- a/Iris/Iris/Std/Option.lean
+++ b/Iris/Iris/Std/Option.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Markus de Medeiros. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/Std/PartialMap.lean
+++ b/Iris/Iris/Std/PartialMap.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Zongyuan Liu, Markus de Medeiros. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zongyuan Liu, Markus de Medeiros
 -/

--- a/Iris/Iris/Std/Positives.lean
+++ b/Iris/Iris/Std/Positives.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Remy Seassau. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Remy Seassau, Markus de Medeiros, Sergei Stepanenko
 -/

--- a/Iris/Iris/Std/Prod.lean
+++ b/Iris/Iris/Std/Prod.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König
 -/

--- a/Iris/Iris/Std/Qq.lean
+++ b/Iris/Iris/Std/Qq.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2023 Mario Carneiro. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/

--- a/Iris/Iris/Std/Relation.lean
+++ b/Iris/Iris/Std/Relation.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/Iris/Std/Relation.lean
+++ b/Iris/Iris/Std/Relation.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public import Iris.Std.FromMathlib

--- a/Iris/Iris/Std/Rewrite.lean
+++ b/Iris/Iris/Std/Rewrite.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König
 -/

--- a/Iris/Iris/Std/RocqPorting.lean
+++ b/Iris/Iris/Std/RocqPorting.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros, Zongyuan Liu
 -/

--- a/Iris/Iris/Std/Set.lean
+++ b/Iris/Iris/Std/Set.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2023 Mario Carneiro. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Markus de Medeiros
+Authors: Mario Carneiro, Markus de Medeiros
 -/
 module
 

--- a/Iris/Iris/Std/TC.lean
+++ b/Iris/Iris/Std/TC.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König
 -/

--- a/Iris/Iris/Std/Tactic.lean
+++ b/Iris/Iris/Std/Tactic.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König
 -/

--- a/Iris/Iris/Std/Telescopes.lean
+++ b/Iris/Iris/Std/Telescopes.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/Iris/Std/Try.lean
+++ b/Iris/Iris/Std/Try.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2023 Mario Carneiro. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/

--- a/Iris/Iris/Std/Vector.lean
+++ b/Iris/Iris/Std/Vector.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Markus de Medeiros. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/IrisTest/Atomic.lean
+++ b/Iris/IrisTest/Atomic.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus de Medeiros
 -/

--- a/Iris/IrisTest/BigOp.lean
+++ b/Iris/IrisTest/BigOp.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Alvin Tang. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alvin Tang
 -/

--- a/Iris/IrisTest/Display.lean
+++ b/Iris/IrisTest/Display.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Alvin Tang. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alvin Tang
 -/

--- a/Iris/IrisTest/Embedding.lean
+++ b/Iris/IrisTest/Embedding.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Alvin Tang. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alvin Tang
 -/

--- a/Iris/IrisTest/HeapLang.lean
+++ b/Iris/IrisTest/HeapLang.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/IrisTest/HeapLang.lean
+++ b/Iris/IrisTest/HeapLang.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public import IrisTest.HeapLang.Linter

--- a/Iris/IrisTest/HeapLang/Apply.lean
+++ b/Iris/IrisTest/HeapLang/Apply.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Klaus Kraßnitzer. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Klaus Kraßnitzer
 -/

--- a/Iris/IrisTest/HeapLang/HeapTactics.lean
+++ b/Iris/IrisTest/HeapLang/HeapTactics.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Klaus Kraßnitzer. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Klaus Kraßnitzer
 -/

--- a/Iris/IrisTest/HeapLang/Linter.lean
+++ b/Iris/IrisTest/HeapLang/Linter.lean
@@ -1,6 +1,7 @@
 /-
-Copyright (c) 2026 Markus de Medeiros. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Markus de Medeiros
 -/
 module
 

--- a/Iris/IrisTest/HeapLang/Notation.lean
+++ b/Iris/IrisTest/HeapLang/Notation.lean
@@ -1,6 +1,7 @@
 /-
-Copyright (c) 2026 Michael Sammler. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Michael Sammler
 -/
 module
 

--- a/Iris/IrisTest/HeapLang/Par.lean
+++ b/Iris/IrisTest/HeapLang/Par.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Klaus Kraßnitzer
 -/

--- a/Iris/IrisTest/HeapLang/Semantics.lean
+++ b/Iris/IrisTest/HeapLang/Semantics.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/IrisTest/HeapLang/Semantics.lean
+++ b/Iris/IrisTest/HeapLang/Semantics.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public import Iris.HeapLang.Instances

--- a/Iris/IrisTest/HeapLang/Tactics.lean
+++ b/Iris/IrisTest/HeapLang/Tactics.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Alvin Tang. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alvin Tang
 -/

--- a/Iris/IrisTest/HeapLang/WeakestPre.lean
+++ b/Iris/IrisTest/HeapLang/WeakestPre.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Fernando Leal, Klaus Kraßnitzer. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Fernando Leal, Klaus Kraßnitzer
 -/

--- a/Iris/IrisTest/Instances.lean
+++ b/Iris/IrisTest/Instances.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Michael Sammler. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler
 -/

--- a/Iris/IrisTest/InstancesImport.lean
+++ b/Iris/IrisTest/InstancesImport.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Michael Sammler. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Sammler
 -/

--- a/Iris/IrisTest/Language.lean
+++ b/Iris/IrisTest/Language.lean
@@ -1,6 +1,7 @@
 /-
-Copyright (c) 2026 Fernando Leal. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Fernando Leal
 -/
 module
 

--- a/Iris/IrisTest/MonPred.lean
+++ b/Iris/IrisTest/MonPred.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Alvin Tang. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alvin Tang
 -/

--- a/Iris/IrisTest/Notation.lean
+++ b/Iris/IrisTest/Notation.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Alex Keizer
 -/

--- a/Iris/IrisTest/SbiUnfold.lean
+++ b/Iris/IrisTest/SbiUnfold.lean
@@ -1,7 +1,6 @@
 /-
-Copyright (c) 2026. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/Iris/IrisTest/Tactics.lean
+++ b/Iris/IrisTest/Tactics.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 Lars König. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Lars König, Oliver Soeser, Michael Sammler, Yunsong Yang, Alvin Tang
 -/

--- a/Iris/IrisTest/Telescopes.lean
+++ b/Iris/IrisTest/Telescopes.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Alvin Tang. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alvin Tang
 -/

--- a/Iris/IrisTest/UPred.lean
+++ b/Iris/IrisTest/UPred.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Alvin Tang. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alvin Tang
 -/

--- a/Iris/IrisTest/Updates.lean
+++ b/Iris/IrisTest/Updates.lean
@@ -1,6 +1,7 @@
 /-
-Copyright (c) 2026 Fernando Leal. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Fernando Leal
 -/
 module
 

--- a/Iris/IrisTest/WeakestPre.lean
+++ b/Iris/IrisTest/WeakestPre.lean
@@ -1,6 +1,7 @@
 /-
-Copyright (c) 2026 Fernando Leal. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Fernando Leal
 -/
 module
 

--- a/IrisMath/IrisMath.lean
+++ b/IrisMath/IrisMath.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/IrisMath/IrisMath.lean
+++ b/IrisMath/IrisMath.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public import IrisMath.MeasureTheory

--- a/IrisMath/IrisMath/MeasureTheory.lean
+++ b/IrisMath/IrisMath/MeasureTheory.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public import Mathlib.Probability.Independence.Basic

--- a/IrisMath/IrisMath/MeasureTheory.lean
+++ b/IrisMath/IrisMath/MeasureTheory.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/IrisMath/IrisMath/Numbers.lean
+++ b/IrisMath/IrisMath/Numbers.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public import Mathlib.Data.Real.Basic

--- a/IrisMath/IrisMath/Numbers.lean
+++ b/IrisMath/IrisMath/Numbers.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/IrisMath/IrisMath/StepIndex.lean
+++ b/IrisMath/IrisMath/StepIndex.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Alvin Tang. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alvin Tang
 -/

--- a/IrisMath/IrisMathTest/Numbers.lean
+++ b/IrisMath/IrisMathTest/Numbers.lean
@@ -1,7 +1,6 @@
 /-
 Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors:
 -/
 module
 

--- a/IrisMath/IrisMathTest/Numbers.lean
+++ b/IrisMath/IrisMathTest/Numbers.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) The Iris-Lean Contributors
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors:
+-/
 module
 
 public import IrisMath.Numbers

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,2 @@
+Iris-Lean — Copyright (c) 2022–2026 The Iris-Lean Contributors.
+Prior per-file copyright notices are preserved in this repository's git history (tag `copyright-notices`).

--- a/scripts/CheckImports.lean
+++ b/scripts/CheckImports.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2026 Alvin Tang. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alvin Tang
 -/

--- a/scripts/DumpPortingData.lean
+++ b/scripts/DumpPortingData.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025. All rights reserved.
+Copyright (c) The Iris-Lean Contributors
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Zongyuan Liu
 -/


### PR DESCRIPTION
This is a minor thing that has bothered me for a while. This PR changes all of the headers to have a uniform copyright header. I preserved the `Authors` field, but it has no impact on copyright. 

As far as I can tell this is within the parameters of the Apache 2.0 license, as long as we make a git tag with the old headers before merging this (see the new file `NOTICE`). The license says they need to be preserved, but preserving a snapshot of them in the history should be fine. 