### PR TITLE
Implement ORAs

### DIFF
--- a/Iris/Iris/Algebra/Agree.lean
+++ b/Iris/Iris/Algebra/Agree.lean
@@ -420,7 +420,7 @@ theorem op_inv {x y : Agree α} : valid (op x y) → x = y :=
   ind₂ (fun _ _ h => OFE.eq_dist_2 (Raw.op_inv h)) x y
 
 @[rocq_alias agree_cmra_mixin]
-instance instCMRA : CMRA (Agree α) where
+instance instRABase : RABase (Agree α) where
   pcore := some
   op := op
   ValidN := validN
@@ -434,12 +434,16 @@ instance instCMRA : CMRA (Agree α) where
   comm := op_comm
   pcore_op_left := fun {x cx} h => by obtain rfl := Option.some.inj h; exact op_idemp
   pcore_idem := fun {x cx} h => by obtain rfl := Option.some.inj h; exact rfl
-  pcore_op_mono := fun {x cx} h y => by obtain rfl := Option.some.inj h; exact ⟨y, rfl⟩
   validN_op_left := validN_op_left
   extend {n x y₁ y₂ hval heq₁} := by
     have heq₂ := op_invN (validN_ne heq₁ hval)
     have heq₃ : op y₁ y₂ ≡{n}≡ y₁ := op_ne.ne heq₂.symm |>.trans op_idemp.dist
     exact ⟨x, x, op_idemp.symm, heq₁.trans heq₃, heq₁.trans heq₃ |>.trans heq₂⟩
+
+instance : RABase.ExtensionLaws (Agree α) where
+  pcore_op_mono := fun {x cx} h y => by obtain rfl := Option.some.inj h; exact ⟨y, rfl⟩
+
+instance instCMRA : CMRA (Agree α) := CMRA.withExtensionOrder
 
 #rocq_ignore agreeR "Use the plain Agree type with a typeclass instance instead."
 #rocq_ignore agree_op_instance "Use the CMRA instance instead."
@@ -466,13 +470,13 @@ theorem idemp {x : Agree α} : x • x = x := op_idemp
 #rocq_ignore to_agree_op_invN "Use the general Agree.op_invN theorem"
 #rocq_ignore to_agree_op_inv "Use the general Agree.op_inv theorem"
 
-@[rocq_alias agree_cmra_discrete]
-instance instCMRADiscrete [OFE.Discrete α] : CMRA.Discrete (Agree α) where
-  discrete_0 {x y} := ind₂ (fun _ _ h => OFE.eq_dist_2 (Raw.discrete_0 h)) x y
-  discrete_valid {x} := x.ind fun _ => Raw.discrete_valid
-
 instance instDiscrete [OFE.Discrete α] : OFE.Discrete (Agree α) where
   discrete_0 {x y} := ind₂ (fun _ _ h => OFE.eq_dist_2 (Raw.discrete_0 h)) x y
+
+@[rocq_alias agree_cmra_discrete]
+instance instCMRADiscrete [OFE.Discrete α] : CMRA.Discrete (Agree α) where
+  discrete_valid {x} := x.ind fun _ => Raw.discrete_valid
+  discrete_inc := RABase.incExt_of_incExt0
 
 @[rocq_alias agree_includedN]
 theorem includedN {x y : Agree α} : x ≼{n} y ↔ y ≡{n}≡ y • x := by
@@ -641,12 +645,10 @@ instance instNonExpansive_AgreeMap' : OFE.NonExpansive (Agree.map' f) where
 
 variable (f) in
 @[rocq_alias agree_map_morphism]
-def Agree.map : (Agree α) -C> (Agree β) where
-  f := map' f
-  ne := instNonExpansive_AgreeMap'
-  validN {_n x} := x.ind fun _ => Raw.map'_validN
-  pcore _ := rfl
-  op x y := ind₂ (fun _ _ => congrArg mk Raw.map'_op) x y
+def Agree.map : (Agree α) -C> (Agree β) :=
+  CMRA.Hom.withExtensionOrder ⟨map' f, instNonExpansive_AgreeMap'⟩
+    (fun {_ x} => x.ind fun _ => Raw.map'_validN) (fun _ => rfl)
+    fun x y => ind₂ (fun _ _ => congrArg mk Raw.map'_op) x y
 
 @[simp] theorem Agree.map_mk (f : α → β) [OFE.NonExpansive f] (x : Raw α) :
     Agree.map f (mk x) = mk (Raw.map' f x) := rfl
@@ -697,6 +699,9 @@ instance {F} [COFE.OFunctor F] : RFunctor (AgreeRF F) where
   map_comp f g f' g' x := by
     rw [← Agree.map_compose]
     exact Agree.agree_map_ext (fun a => COFE.OFunctor.map_comp f g f' g' a)
+
+instance {F} [COFE.OFunctor F] : RFunctorAffine (AgreeRF F) where
+  affine := inferInstance
 
 @[rocq_alias agreeRF_contractive]
 instance {F} [COFE.OFunctorContractive F] : RFunctorContractive (AgreeRF F) where

--- a/Iris/Iris/Algebra/Auth.lean
+++ b/Iris/Iris/Algebra/Auth.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 Alexander Bai. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Alexander Bai
+Authors: Alexander Bai, Janine Lohse
 -/
 module
 
@@ -25,23 +25,26 @@ open OFE CMRA UCMRA View
 /-!
 ## Definition of the view relation for the authoritative camera.
 -/
+/-- The authoritative view relation: the fragment is below the authority in the *order*
+(Amaryllis-style). Meaningful for affine algebras only — dropping a fragment summand must not
+break the bound, which is affineness. -/
 @[rocq_alias auth_view_rel_raw]
 def AuthViewRel [UCMRA A] : ViewRel A A := fun n a b => b ≼{n} a ∧ ✓{n} a
 
 namespace AuthViewRel
 
-variable [UCMRA A]
+variable [UCMRA A] [CMRA.Affine A]
 
 @[rocq_alias auth_view_rel]
-instance instViewRel_authViewRel : IsViewRel (AuthViewRel (A := A)) where
-  mono := by
-    intro _ a1 b1 n2 a2 b2 ⟨hinc, hv⟩ ha hb hn
-    refine ⟨?_, validN_ne ha (validN_of_le hn hv)⟩
-    calc b2 ≼{n2} b1 := hb
-         _  ≼{n2} a1 := incN_of_incN_le hn hinc
-         _  ≼{n2} a2 := ha.to_incN
-  rel_validN n a b := fun ⟨hinc, hv⟩ => validN_of_incN hinc hv
-  rel_unit n := ⟨unit, incN_refl unit, unit_valid.validN⟩
+instance instViewRel_authViewRel : IsViewRel (AuthViewRel (A := A)) :=
+  .ofMonoOrd
+    (fun ⟨hinc, hv⟩ ha hb hn =>
+      ⟨calc _ ≼{_} _ := hb
+            _ ≼{_} _ := CMRA.incN_of_incN_le hn hinc
+            _ ≼{_} _ := ha.to_incN,
+       validN_ne ha (validN_of_le hn hv)⟩)
+    (fun _ _ _ ⟨hinc, hv⟩ => validN_of_incN hinc hv)
+    (fun _ => ⟨unit, incN_refl unit, unit_valid.validN⟩)
 
 #rocq_ignore auth_view_rel_raw_mono "Use the IsViewRel typeclass"
 #rocq_ignore auth_view_rel_raw_valid "Use the IsViewRel typeclass"
@@ -49,7 +52,7 @@ instance instViewRel_authViewRel : IsViewRel (AuthViewRel (A := A)) where
 
 @[rocq_alias auth_view_rel_unit]
 theorem authViewRel_unit_iff {n : Nat} {a : A} : AuthViewRel n a unit ↔ ✓{n} a :=
-  ⟨(·.2), (⟨incN_unit, ·⟩)⟩
+  ⟨(·.2), (⟨CMRA.incN_unit, ·⟩)⟩
 
 @[rocq_alias auth_view_rel_exists]
 theorem authViewRel_exists_iff {n : Nat} {b : A} : (∃ a, AuthViewRel n a b) ↔ ✓{n} b :=
@@ -57,7 +60,8 @@ theorem authViewRel_exists_iff {n : Nat} {b : A} : (∃ a, AuthViewRel n a b) �
 
 @[rocq_alias auth_view_rel_discrete]
 instance [OFE.Discrete A] [CMRA.Discrete A] : IsViewRelDiscrete (AuthViewRel (A := A)) where
-  discrete _ _ _ h := ⟨incN_of_inc _ ((inc_iff_incN 0).mpr h.1), (discrete_valid h.2).validN⟩
+  discrete _ _ _ h :=
+    ⟨CMRA.incN_of_inc _ (CMRA.discrete_inc h.1), (discrete_valid h.2).validN⟩
 
 end AuthViewRel
 
@@ -68,11 +72,11 @@ abbrev Auth (A : Type _) [UCMRA A] :=
   View (AuthViewRel (A := A))
 
 namespace Auth
-variable [UCMRA A]
+variable [UCMRA A] [CMRA.Affine A]
 
 instance : OFE (Auth A) := View.instOFE
-instance : CMRA (Auth A) := View.instCMRA
-instance : UCMRA (Auth A) := View.instUCMRA
+instance instCMRA : CMRA (Auth A) := View.instCMRA
+instance instUCMRA : UCMRA (Auth A) := View.instUCMRA
 
 #rocq_ignore authO "Use the Auth type and View.instOFE typeclass"
 #rocq_ignore authR "Use the Auth type and View.instCMRA typeclass"
@@ -103,20 +107,24 @@ nonrec instance frag_ne : NonExpansive (frag : A → Auth A) :=
 
 #rocq_ignore auth_frag_proper "Derivable from frag_ne with NonExpansive.eqv"
 
+omit [CMRA.Affine A] in
 @[rocq_alias auth_auth_dist_inj]
 nonrec theorem auth_dist_inj {n : Nat} {dq1 dq2 : DFrac} {a1 a2 : A}
     (h : (●{dq1} a1) ≡{n}≡ ●{dq2} a2) : dq1 = dq2 ∧ a1 ≡{n}≡ a2 :=
   ⟨auth_inj_frac h, dist_of_auth_dist h⟩
 
+omit [CMRA.Affine A] in
 @[rocq_alias auth_auth_inj]
 theorem auth_inj {dq1 dq2 : DFrac} {a1 a2 : A} (h : (●{dq1} a1) = ●{dq2} a2) :
     dq1 = dq2 ∧ a1 = a2 :=
   ⟨auth_inj_frac (n := 0) h.dist, OFE.eq_dist_2 fun _ => dist_of_auth_dist h.dist⟩
 
+omit [CMRA.Affine A] in
 @[rocq_alias auth_frag_dist_inj]
 theorem frag_dist_inj {n : Nat} {b1 b2 : A} (h : (◯ b1 : Auth A) ≡{n}≡ ◯ b2) : b1 ≡{n}≡ b2 :=
   dist_of_frag_dist h
 
+omit [CMRA.Affine A] in
 @[rocq_alias auth_frag_inj]
 theorem frag_inj {b1 b2 : A} (h : (◯ b1 : Auth A) = ◯ b2) : b1 = b2 :=
   OFE.eq_dist_2 fun _ => dist_of_frag_dist h.dist
@@ -148,8 +156,8 @@ theorem frag_op {b1 b2 : A} : (◯ (b1 • b2) : Auth A) = ((◯ b1 : Auth A) �
   frag_op_eq
 
 @[rocq_alias auth_frag_mono]
-nonrec theorem frag_inc_of_inc {b1 b2 : A} (h : b1 ≼ b2) : (◯ b1 : Auth A) ≼ ◯ b2 :=
-  frag_inc_of_inc h
+nonrec theorem frag_incExt_of_incExt {b1 b2 : A} (h : b1 ≼ₑ b2) : (◯ b1 : Auth A) ≼ₑ ◯ b2 :=
+  frag_incExt_of_incExt h
 
 @[rocq_alias auth_frag_core]
 nonrec theorem frag_core {b : A} : core (◯ b : Auth A) = ◯ (core b) :=
@@ -210,7 +218,12 @@ theorem bigOpMS_frag [LawfulFiniteMultiSet MS' C] (g : C → A) (X : MS') :
 
 end BigOp
 
-/-! ## Validity -/
+/-! ## Validity
+
+The fragment–authority relation is stated with the primitive *order* `≼{n}`/`≼`, which for
+classical algebras — those built with `withExtensionOrder` — coincides definitionally with the
+extension inclusion of the Rocq originals. Likewise, `[IsTotal]` hypotheses that only provided
+reflexivity become `[IncRefl]`; total classical algebras satisfy it automatically. -/
 
 @[rocq_alias auth_auth_dfrac_op_invN]
 theorem auth_dfrac_op_invN {n : Nat} {dq1 dq2 : DFrac} {a b : A}
@@ -229,7 +242,7 @@ theorem auth_dfrac_op_inv {dq1 dq2 : DFrac} {a b : A}
 theorem auth_dfrac_validN {n : Nat} {dq : DFrac} {a : A} :
     (✓{n} (●{dq} a)) ↔ (✓ dq ∧ ✓{n} a) := by
   rw [auth_validN_iff]
-  exact ⟨fun ⟨hdq, _, hv⟩ => ⟨hdq, hv⟩, fun ⟨hdq, hv⟩ => ⟨hdq, incN_unit, hv⟩⟩
+  exact ⟨fun ⟨hdq, _, hv⟩ => ⟨hdq, hv⟩, fun ⟨hdq, hv⟩ => ⟨hdq, CMRA.incN_unit, hv⟩⟩
 
 @[rocq_alias auth_auth_validN]
 theorem auth_validN {n : Nat} {a : A} :
@@ -241,7 +254,7 @@ theorem auth_validN {n : Nat} {a : A} :
 theorem auth_dfrac_op_validN {n : Nat} {dq1 dq2 : DFrac} {a1 a2 : A} :
     (✓{n} ((●{dq1} a1) • ●{dq2} a2)) ↔ (✓ (dq1 • dq2) ∧ a1 ≡{n}≡ a2 ∧ ✓{n} a1) := by
   rw [View.auth_op_auth_validN_iff]
-  exact ⟨fun ⟨hdq, ha, ⟨_, hv⟩⟩ => ⟨hdq, ha, hv⟩, fun ⟨hdq, ha, hv⟩ => ⟨hdq, ha, incN_unit, hv⟩⟩
+  exact ⟨fun ⟨hdq, ha, ⟨_, hv⟩⟩ => ⟨hdq, ha, hv⟩, fun ⟨hdq, ha, hv⟩ => ⟨hdq, ha, CMRA.incN_unit, hv⟩⟩
 
 @[rocq_alias auth_auth_op_validN]
 theorem auth_op_validN {n : Nat} {a1 a2 : A} : (✓{n} ((● a1 : Auth A) • ● a2)) ↔ False :=
@@ -290,7 +303,7 @@ theorem auth_dfrac_op_valid {dq1 dq2 : DFrac} {a1 a2 : A} :
   rw [auth_op_auth_valid_iff]
   constructor
   · exact fun ⟨hdq, ha, hr⟩ => ⟨hdq, ha, valid_iff_validN.mpr (hr · |>.2)⟩
-  · exact fun ⟨hdq, ha, hv⟩ => ⟨hdq, ha, fun _ => ⟨incN_unit, hv.validN⟩⟩
+  · exact fun ⟨hdq, ha, hv⟩ => ⟨hdq, ha, fun _ => ⟨CMRA.incN_unit, hv.validN⟩⟩
 
 @[rocq_alias auth_auth_op_valid]
 theorem auth_op_valid {a1 a2 : A} : (✓ ((● a1 : Auth A) • ● a2)) ↔ False :=
@@ -333,7 +346,7 @@ theorem auth_both_valid {a b : A} :
 @[rocq_alias auth_both_dfrac_valid_2]
 theorem auth_both_dfrac_valid_2 {dq : DFrac} {a b : A} (hdq : ✓ dq) (ha : ✓ a)
     (hb : b ≼ a) : ✓ ((●{dq} a) • ◯ b) :=
-  both_dfrac_valid.mpr ⟨hdq, (incN_of_inc · hb), ha⟩
+  both_dfrac_valid.mpr ⟨hdq, (CMRA.incN_of_inc · hb), ha⟩
 
 @[rocq_alias auth_both_valid_2]
 theorem auth_both_valid_2 {a b : A} (ha : ✓ a) (hb : b ≼ a) :
@@ -346,7 +359,7 @@ theorem both_dfrac_valid_discrete [CMRA.Discrete A] {dq : DFrac} {a b : A} :
   constructor
   · intro h
     have ⟨hdq, hinc, hv⟩ := both_dfrac_valid.mp h
-    exact ⟨hdq, (inc_iff_incN 0).mpr (hinc 0), hv⟩
+    exact ⟨hdq, CMRA.discrete_inc (hinc 0), hv⟩
   · exact fun ⟨hdq, hinc, hv⟩ => auth_both_dfrac_valid_2 hdq hv hinc
 
 @[rocq_alias auth_both_valid_discrete]
@@ -360,86 +373,126 @@ theorem auth_both_valid_discrete [CMRA.Discrete A] {a b : A} :
 /-! ## Inclusion -/
 
 @[rocq_alias auth_auth_dfrac_includedN]
-theorem auth_dfrac_includedN {n : Nat} {dq1 dq2 : DFrac} {a1 a2 b : A} :
-    ((●{dq1} a1) ≼{n} ((●{dq2} a2) • ◯ b)) ↔ ((dq1 ≼ dq2 ∨ dq1 = dq2) ∧ a1 ≡{n}≡ a2) :=
-  auth_incN_auth_op_frag_iff
+theorem auth_dfrac_incExtN {n : Nat} {dq1 dq2 : DFrac} {a1 a2 b : A} :
+    ((●{dq1} a1) ≼ₑ{n} ((●{dq2} a2) • ◯ b)) ↔ ((dq1 ≼ dq2 ∨ dq1 = dq2) ∧ a1 ≡{n}≡ a2) :=
+  auth_incExtN_auth_op_frag_iff
 
 @[rocq_alias auth_auth_dfrac_included]
-theorem auth_dfrac_included {dq1 dq2 : DFrac} {a1 a2 b : A} :
-    ((●{dq1} a1) ≼ ((●{dq2} a2) • ◯ b)) ↔ ((dq1 ≼ dq2 ∨ dq1 = dq2) ∧ a1 = a2) :=
-  auth_inc_auth_op_frag_iff
+theorem auth_dfrac_incExt {dq1 dq2 : DFrac} {a1 a2 b : A} :
+    ((●{dq1} a1) ≼ₑ ((●{dq2} a2) • ◯ b)) ↔ ((dq1 ≼ dq2 ∨ dq1 = dq2) ∧ a1 = a2) :=
+  auth_incExt_auth_op_frag_iff
 
 @[rocq_alias auth_auth_includedN]
-theorem auth_includedN {n : Nat} {a1 a2 b : A} :
-    ((● a1 : Auth A) ≼{n} ((● a2) • ◯ b)) ↔ (a1 ≡{n}≡ a2) :=
-  auth_one_incN_auth_one_op_frag_iff
+theorem auth_incExtN {n : Nat} {a1 a2 b : A} :
+    ((● a1 : Auth A) ≼ₑ{n} ((● a2) • ◯ b)) ↔ (a1 ≡{n}≡ a2) :=
+  auth_one_incExtN_auth_one_op_frag_iff
 
 @[rocq_alias auth_auth_included]
-theorem auth_included {a1 a2 b : A} :
-    ((● a1 : Auth A) ≼ ((● a2) • ◯ b)) ↔ (a1 = a2) :=
-  auth_one_inc_auth_one_op_frag_iff
+theorem auth_incExt {a1 a2 b : A} :
+    ((● a1 : Auth A) ≼ₑ ((● a2) • ◯ b)) ↔ (a1 = a2) :=
+  auth_one_incExt_auth_one_op_frag_iff
 
 @[rocq_alias auth_frag_includedN]
-theorem frag_includedN {n : Nat} {dq : DFrac} {a b1 b2 : A} :
-    ((◯ b1) ≼{n} ((●{dq} a) • ◯ b2)) ↔ (b1 ≼{n} b2) :=
-  frag_incN_auth_op_frag_iff
+theorem frag_incExtN {n : Nat} {dq : DFrac} {a b1 b2 : A} :
+    ((◯ b1) ≼ₑ{n} ((●{dq} a) • ◯ b2)) ↔ (b1 ≼ₑ{n} b2) :=
+  frag_incExtN_auth_op_frag_iff
 
 @[rocq_alias auth_frag_included]
-theorem frag_included {dq : DFrac} {a b1 b2 : A} : ((◯ b1) ≼ ((●{dq} a) • ◯ b2)) ↔ (b1 ≼ b2) :=
-  frag_inc_auth_op_frag_iff
+theorem frag_incExt {dq : DFrac} {a b1 b2 : A} : ((◯ b1) ≼ₑ ((●{dq} a) • ◯ b2)) ↔ (b1 ≼ₑ b2) :=
+  frag_incExt_auth_op_frag_iff
 
 /-- The weaker `auth_both_included` lemmas below are a consequence of the
     `auth_included` and `frag_included` lemmas above. -/
 @[rocq_alias auth_both_dfrac_includedN]
-theorem auth_both_dfrac_includedN {n : Nat} {dq1 dq2 : DFrac} {a1 a2 b1 b2 : A} :
-    (((●{dq1} a1) • ◯ b1) ≼{n} ((●{dq2} a2) • ◯ b2)) ↔
-      ((dq1 ≼ dq2 ∨ dq1 = dq2) ∧ a1 ≡{n}≡ a2 ∧ b1 ≼{n} b2) :=
-  auth_op_frag_incN_auth_op_frag_iff
+theorem auth_both_dfrac_incExtN {n : Nat} {dq1 dq2 : DFrac} {a1 a2 b1 b2 : A} :
+    (((●{dq1} a1) • ◯ b1) ≼ₑ{n} ((●{dq2} a2) • ◯ b2)) ↔
+      ((dq1 ≼ dq2 ∨ dq1 = dq2) ∧ a1 ≡{n}≡ a2 ∧ b1 ≼ₑ{n} b2) :=
+  auth_op_frag_incExtN_auth_op_frag_iff
 
 @[rocq_alias auth_both_dfrac_included]
-theorem auth_both_dfrac_included {dq1 dq2 : DFrac} {a1 a2 b1 b2 : A} :
-    (((●{dq1} a1) • ◯ b1) ≼ ((●{dq2} a2) • ◯ b2)) ↔
-      ((dq1 ≼ dq2 ∨ dq1 = dq2) ∧ a1 = a2 ∧ b1 ≼ b2) :=
-  auth_op_frag_inc_auth_op_frag_iff
+theorem auth_both_dfrac_incExt {dq1 dq2 : DFrac} {a1 a2 b1 b2 : A} :
+    (((●{dq1} a1) • ◯ b1) ≼ₑ ((●{dq2} a2) • ◯ b2)) ↔
+      ((dq1 ≼ dq2 ∨ dq1 = dq2) ∧ a1 = a2 ∧ b1 ≼ₑ b2) :=
+  auth_op_frag_incExt_auth_op_frag_iff
 
 @[rocq_alias auth_both_includedN]
-theorem auth_both_includedN {n : Nat} {a1 a2 b1 b2 : A} :
-    (((● a1 : Auth A) • ◯ b1) ≼{n} ((● a2) • ◯ b2)) ↔ (a1 ≡{n}≡ a2 ∧ b1 ≼{n} b2) :=
-  auth_one_op_frag_incN_auth_one_op_frag_iff
+theorem auth_both_incExtN {n : Nat} {a1 a2 b1 b2 : A} :
+    (((● a1 : Auth A) • ◯ b1) ≼ₑ{n} ((● a2) • ◯ b2)) ↔ (a1 ≡{n}≡ a2 ∧ b1 ≼ₑ{n} b2) :=
+  auth_one_op_frag_incExtN_auth_one_op_frag_iff
 
 @[rocq_alias auth_both_included]
-theorem auth_both_included {a1 a2 b1 b2 : A} :
-    (((● a1 : Auth A) • ◯ b1) ≼ ((● a2) • ◯ b2)) ↔ (a1 = a2 ∧ b1 ≼ b2) :=
-  auth_one_op_frag_inc_auth_one_op_frag_iff
+theorem auth_both_incExt {a1 a2 b1 b2 : A} :
+    (((● a1 : Auth A) • ◯ b1) ≼ₑ ((● a2) • ◯ b2)) ↔ (a1 = a2 ∧ b1 ≼ₑ b2) :=
+  auth_one_op_frag_incExt_auth_one_op_frag_iff
 
 /-! ## Updates -/
 
+/-- The primitive authority update: transport the order bound of the fragment composite
+past the update, for every fragment frame `bf`. `auth_update_of_localUpdate` recovers the
+frame-based Rocq interface for classical fragment algebras. -/
+theorem auth_update {a b a' b' : A}
+    (hup : ∀ n (bf : A), b • bf ≼{n} a → ✓{n} a → b' • bf ≼{n} a' ∧ ✓{n} a') :
+    ((● a : Auth A) • ◯ b) ~~> (● a') • ◯ b' :=
+  auth_one_op_frag_update fun n bf ⟨hinc, hv⟩ => hup n bf hinc hv
+
+/-- `auth_update` in allocation form: the fragment starts empty. -/
+theorem auth_update_alloc {a a' b' : A}
+    (hup : ∀ n (bf : A), bf ≼{n} a → ✓{n} a → b' • bf ≼{n} a' ∧ ✓{n} a') :
+    (● a : Auth A) ~~> (● a') • ◯ b' :=
+  auth_one_alloc fun n bf ⟨hinc, hv⟩ => hup n bf hinc hv
+
+/-- `auth_update` in deallocation form: the fragment is given up. -/
+theorem auth_update_dealloc {a b a' : A}
+    (hup : ∀ n (bf : A), b • bf ≼{n} a → ✓{n} a → bf ≼{n} a' ∧ ✓{n} a') :
+    ((● a : Auth A) • ◯ b) ~~> ● a' :=
+  auth_one_op_frag_dealloc fun n bf ⟨hinc, hv⟩ => hup n bf hinc hv
+
+/-- `auth_update` for the authority alone: every fragment bound is preserved. -/
+theorem auth_update_auth {a a' : A}
+    (hup : ∀ n (bf : A), bf ≼{n} a → ✓{n} a → bf ≼{n} a' ∧ ✓{n} a') :
+    (● a : Auth A) ~~> ● a' :=
+  auth_one_update fun n bf ⟨hinc, hv⟩ => hup n bf hinc hv
+
+/-- On a classical algebra — one whose order coincides with the extension inclusion, witnessed
+by the plain hypothesis `hsub` — a frame-based local update drives the authority update. -/
 @[rocq_alias auth_update]
-theorem auth_update {a b a' b' : A} (hup : (a, b) ~l~> (a', b')) :
+theorem auth_update_of_localUpdate {a b a' b' : A}
+    (hsub : ∀ {n : Nat} {x y : A}, x ≼{n} y → x ≼ₑ{n} y)
+    (hup : (a, b) ~l~> (a', b')) :
     ((● a : Auth A) • ◯ b) ~~> (● a') • ◯ b' := by
-  refine auth_one_op_frag_update fun n bf ⟨⟨c, hinc⟩, hv⟩ => ?_
+  refine auth_update fun n bf hinc hv => ?_
+  obtain ⟨c, hc⟩ := hsub hinc
   have ha_eq : a ≡{n}≡ b •? some (bf • c) := by
-    simp only [CMRA.op?]; exact hinc.trans assoc.symm.dist
+    simp only [CMRA.op?]; exact hc.trans assoc.symm.dist
   have ⟨hv', ha'_eq⟩ := hup n (some (bf • c)) hv ha_eq
   simp only [CMRA.op?] at ha'_eq
-  exact ⟨⟨c, ha'_eq.trans assoc.dist⟩, hv'⟩
+  refine ⟨CMRA.incN_of_incExtN ⟨c, ha'_eq.trans assoc.dist⟩, hv'⟩
 
+/-- `auth_update_of_localUpdate` in allocation form. -/
 @[rocq_alias auth_update_alloc]
-theorem auth_update_alloc {a a' b' : A} (hup : (a, unit) ~l~> (a', b')) :
+theorem auth_update_alloc_of_localUpdate {a a' b' : A}
+    (hsub : ∀ {n : Nat} {x y : A}, x ≼{n} y → x ≼ₑ{n} y)
+    (hup : (a, unit) ~l~> (a', b')) :
     (● a : Auth A) ~~> (● a') • ◯ b' := by
   rw [← unit_right_id (x := (● a : Auth A))]
-  exact auth_update hup
+  exact auth_update_of_localUpdate hsub hup
 
+/-- `auth_update_of_localUpdate` in deallocation form. -/
 @[rocq_alias auth_update_dealloc]
-theorem auth_update_dealloc {a b a' : A} (hup : (a, b) ~l~> (a', unit)) :
+theorem auth_update_dealloc_of_localUpdate {a b a' : A}
+    (hsub : ∀ {n : Nat} {x y : A}, x ≼{n} y → x ≼ₑ{n} y)
+    (hup : (a, b) ~l~> (a', unit)) :
     ((● a : Auth A) • ◯ b) ~~> ● a' := by
   rw [← unit_right_id (x := (● a' : Auth A))]
-  exact auth_update hup
+  exact auth_update_of_localUpdate hsub hup
 
+/-- `auth_update_of_localUpdate` for the authority alone. -/
 @[rocq_alias auth_update_auth]
-theorem auth_update_auth {a a' b' : A} (hup : (a, unit) ~l~> (a', b')) :
+theorem auth_update_auth_of_localUpdate {a a' b' : A}
+    (hsub : ∀ {n : Nat} {x y : A}, x ≼{n} y → x ≼ₑ{n} y)
+    (hup : (a, unit) ~l~> (a', b')) :
     (● a : Auth A) ~~> ● a' :=
-  Update.trans (auth_update_alloc hup) Update.op_l
+  Update.trans (auth_update_alloc_of_localUpdate hsub hup) Update.op_l
 
 @[rocq_alias auth_update_auth_persist]
 theorem auth_update_auth_persist {dq : DFrac} {a : A} :
@@ -459,31 +512,32 @@ theorem auth_updateP_both_unpersist {a b : A} :
   auth_op_frag_acquire
 
 @[rocq_alias auth_update_dfrac_alloc]
-theorem auth_update_dfrac_alloc {dq : DFrac} {a b : A} [CoreId b] (hb : b ≼ a) :
+theorem auth_update_dfrac_alloc {dq : DFrac} {a b : A} [CoreId b] (hb : b ≼ₑ a) :
     (●{dq} a) ~~> (●{dq} a) • ◯ b := by
   refine auth_alloc fun n bf ⟨hinc, hv⟩ => ⟨?_, hv⟩
-  have hba : b • a = a := comm'.trans (op_core_left_of_inc hb)
-  exact (incN_iff_right hba.dist).mp (op_monoN_right b hinc)
+  have hba : b • a = a := comm'.trans (RABase.op_core_left_of_incExt hb)
+  exact (CMRA.incN_iff_right hba.dist).mp (CMRA.op_monoN_right b hinc)
 
 @[rocq_alias auth_local_update]
 theorem auth_local_update {a b0 b1 a' b0' b1' : A} (hup : (b0, b1) ~l~> (b0', b1'))
     (hinc : b0' ≼ a') (hv : ✓ a') :
     ((● a : Auth A) • ◯ b0, (● a) • ◯ b1) ~l~> ((● a' : Auth A) • ◯ b0', (● a') • ◯ b1') :=
-  view_local_update hup fun n _ => ⟨incN_of_inc n hinc, hv.validN⟩
+  view_local_update hup fun n _ => ⟨CMRA.incN_of_inc n hinc, hv.validN⟩
 
 /-! ## Functor -/
 
 /-- The AuthViewRel is preserved under CMRA homomorphisms. -/
-theorem authViewRel_map [UCMRA A'] [UCMRA B'] (g : A' -C> B') (n : Nat) (a : A')
+theorem authViewRel_map [UCMRA A'] [UCMRA B']
+    (g : A' -C> B') (n : Nat) (a : A')
     (b : A') : AuthViewRel n a b → AuthViewRel n (g a) (g b) :=
-  fun ⟨hinc, hv⟩ => ⟨CMRA.Hom.monoN g n hinc, CMRA.Hom.validN g hv⟩
+  fun ⟨hinc, hv⟩ => ⟨g.monoN hinc, CMRA.Hom.validN g hv⟩
 
 @[rocq_alias authURF]
 abbrev AuthURF (T : COFE.OFunctorPre) [URFunctor T] : COFE.OFunctorPre :=
   fun A B _ _ => Auth (T A B)
 
-instance instURFunctorAuthURF {T : COFE.OFunctorPre} [URFunctor T] :
-    URFunctor (AuthURF T) where
+instance instURFunctorAuthURF {T : COFE.OFunctorPre} [URFunctor T]
+    [RFunctorAffine T] : URFunctor (AuthURF T) where
   map {A A'} {B B'} _ _ _ _ f g :=
     mapC
       (URFunctor.map (F := T) f g).toHom
@@ -501,9 +555,13 @@ instance instURFunctorAuthURF {T : COFE.OFunctorPre} [URFunctor T] :
     refine congrArg (View.map _ · _ _) (funext fun _ => URFunctor.map_comp f g f' g' _) |>.trans
       (congrArg (View.map _ _ · _) (funext fun _ => URFunctor.map_comp f g f' g' _))
 
+instance {T : COFE.OFunctorPre} [URFunctor T] [RFunctorAffine T] :
+    RFunctorAffine (AuthURF T) where
+  affine := inferInstance
+
 @[rocq_alias authURF_contractive]
-instance instURFunctorContractiveAuthURF {T : COFE.OFunctorPre} [URFunctorContractive T] :
-    URFunctorContractive (AuthURF T) where
+instance instURFunctorContractiveAuthURF {T : COFE.OFunctorPre} [URFunctorContractive T]
+    [RFunctorAffine T] : URFunctorContractive (AuthURF T) where
   map_contractive.1 h x := by
     apply map_ne <;> apply URFunctorContractive.map_contractive.1 h
 
@@ -511,8 +569,8 @@ instance instURFunctorContractiveAuthURF {T : COFE.OFunctorPre} [URFunctorContra
 abbrev AuthRF (T : COFE.OFunctorPre) [URFunctor T] : COFE.OFunctorPre :=
   fun A B _ _ => Auth (T A B)
 
-instance instRFunctorAuthRF {T : COFE.OFunctorPre} [URFunctor T] :
-    RFunctor (AuthRF T) where
+instance instRFunctorAuthRF {T : COFE.OFunctorPre} [URFunctor T]
+    [RFunctorAffine T] : RFunctor (AuthRF T) where
   map {A A'} {B B'} _ _ _ _ f g :=
     mapC
       (URFunctor.map (F := T) f g).toHom
@@ -530,9 +588,13 @@ instance instRFunctorAuthRF {T : COFE.OFunctorPre} [URFunctor T] :
     refine congrArg (View.map _ · _ _) (funext fun _ => URFunctor.map_comp f g f' g' _) |>.trans
       (congrArg (View.map _ _ · _) (funext fun _ => URFunctor.map_comp f g f' g' _))
 
+instance {T : COFE.OFunctorPre} [URFunctor T] [RFunctorAffine T] :
+    RFunctorAffine (AuthRF T) where
+  affine := inferInstance
+
 @[rocq_alias authRF_contractive]
-instance instRFunctorContractiveAuthRF {T : COFE.OFunctorPre} [URFunctorContractive T] :
-    RFunctorContractive (AuthRF T) where
+instance instRFunctorContractiveAuthRF {T : COFE.OFunctorPre} [URFunctorContractive T]
+    [RFunctorAffine T] : RFunctorContractive (AuthRF T) where
   map_contractive.1 h x := by
     apply View.map_ne <;> apply URFunctorContractive.map_contractive.1 h
 

--- a/Iris/Iris/Algebra/CMRA.lean
+++ b/Iris/Iris/Algebra/CMRA.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Mario Carneiro, Сухарик (@suhr), Markus de Medeiros, Puming Liu
+Authors: Mario Carneiro, Сухарик (@suhr), Markus de Medeiros, Puming Liu, Janine Lohse
 -/
 module
 
@@ -13,76 +13,178 @@ public import Iris.Algebra.Monoid
 namespace Iris
 open OFE
 
-@[rocq_alias cmra]
-class CMRA (α : Type _) extends OFE α where
-  pcore : α → Option α
+/-! # Ordered resource algebras
+
+A `CMRA` is a resource algebra (`RABase`) equipped with a step-indexed order `≼{n}` and its
+limit `≼` (`OrderN`). The order need neither be reflexive nor contain the extension inclusion
+`x ≼ₑ{n} y := ∃ z, y ≡{n}≡ x • z` of frames: reflexivity is the law of unital algebras
+(`IncRefl`, part of `UCMRA`), and `≼ₑ ⊆ ≼` is affineness (`CMRA.Affine`). Every classical
+resource algebra is a `CMRA` under its extension inclusion, see `CMRA.withExtensionOrder`;
+constructions that reason about frames (local updates, views) are stated with `≼ₑ`. -/
+
+/-! ## The components of a resource algebra -/
+
+/-- The composition of a resource algebra, together with its own laws. -/
+@[rocq_alias Op]
+class Op (α : Type _) [OFE α] where
   op : α → α → α
-  ValidN : Nat → α → Prop
-  Valid : α → Prop
-
   op_ne : NonExpansive (op x)
-  pcore_ne : x ≡{n}≡ y → pcore x = some cx →
-    ∃ cy, pcore y = some cy ∧ cx ≡{n}≡ cy
-  validN_ne : x ≡{n}≡ y → ValidN n x → ValidN n y
-
-  valid_iff_validN : Valid x ↔ ∀ n, ValidN n x
-  validN_succ : ValidN n.succ x → ValidN n x
-  validN_op_left : ValidN n (op x y) → ValidN n x
-
   assoc : op x (op y z) = op (op x y) z
   comm : op x y = op y x
 
-  pcore_op_left : pcore x = some cx → op cx x = x
-  pcore_idem : pcore x = some cx → pcore cx = some cx
-  pcore_op_mono : pcore x = some cx → ∀ y, ∃ cy, pcore (op x y) = some (op cx cy)
+namespace Op
 
-  extend : ValidN n x → x ≡{n}≡ op y₁ y₂ →
-    Σ' z₁ z₂, x = op z₁ z₂ ∧ z₁ ≡{n}≡ y₁ ∧ z₂ ≡{n}≡ y₂
-
-#rocq_ignore Op "Use the CMRA.op field."
-#rocq_ignore PCore "Use the CMRA.pcore field."
-#rocq_ignore Valid "Use the CMRA.Valid field."
-#rocq_ignore ValidN "Use the CMRA.ValidN field."
-#rocq_ignore CmraMixin "Use the CMRA type class."
-#rocq_ignore cmra_mixin_of' "Not needed."
-#rocq_ignore cmra_ofeO "Not needed."
-
-/-- Reduction of `pcore_op_mono` to regular monotonicity -/
-theorem pcore_op_mono_of_core_op_mono (op : α → α → α) (pcore : α → Option α)
-    (h : (∀ x cx y : α, (∃ z, y = op x z) → pcore x = some cx →
-      ∃ cy, pcore y = some cy ∧ ∃ z, cy = op cx z))
-    (x cx) (e : pcore x = some cx) (y) : ∃ cy, pcore (op x y) = some (op cx cy) :=
-  have ⟨_, hcy, z, hz⟩ := h x cx (op x y) ⟨y, rfl⟩ e
-  ⟨z, hcy.trans (congrArg some hz)⟩
-
-namespace CMRA
-variable [CMRA α]
-
-/-- The CMRA composition operation. -/
+/-- The composition operation. -/
 infix:60 " • " => op
 
-/-- The inclusion order on a CMRA. -/
-@[rocq_alias included]
-def Included (x y : α) : Prop := ∃ z, y = x • z
-@[inherit_doc]
-infix:50 " ≼ " => Included
+variable [OFE α] [Op α]
 
-/-- The step-indexed inclusion order on a CMRA. -/
-@[rocq_alias includedN]
-def IncludedN (n : Nat) (x y : α) : Prop := ∃ z, y ≡{n}≡ x • z
-@[inherit_doc] notation:50 x " ≼{" n "} " y:51 => IncludedN n x y
-
-/-- The CMRA composition operation with an optional right argument. -/
+/-- The composition operation with an optional right argument. -/
 @[rocq_alias opM]
-def op? [CMRA α] (x : α) : Option α → α
+def op? (x : α) : Option α → α
   | some y => x • y
   | none => x
 @[inherit_doc] infix:60 " •? " => op?
 
-/-- The validity of a CMRA element. -/
-prefix:50 "✓ " => Valid
-/-- The step-indexed validity of a CMRA element. -/
-notation:50 "✓{" n "} " x:51 => ValidN n x
+end Op
+
+/-- The partial core of a resource algebra, together with its own laws. -/
+@[rocq_alias PCore]
+class PCore (α : Type _) [OFE α] where
+  pcore : α → Option α
+  pcore_ne : x ≡{n}≡ y → pcore x = some cx → ∃ cy, pcore y = some cy ∧ cx ≡{n}≡ cy
+  pcore_idem : pcore x = some cx → pcore cx = some cx
+
+namespace PCore
+variable [OFE α] [PCore α]
+
+/-- The total core, returning `x` itself where `pcore` is undefined. -/
+@[rocq_alias core]
+def core (x : α) := (pcore x).getD x
+
+end PCore
+
+/-- A resource algebra whose core is total. -/
+@[rocq_alias CmraTotal]
+class CMRA.IsTotal (α : Type _) [OFE α] [PCore α] : Prop where
+  total (x : α) : ∃ cx, PCore.pcore x = some cx
+#rocq_ignore cmra_total_mixin "Use CMRA + IsTotal"
+
+/-- The validity predicates of a resource algebra, together with their own laws. -/
+@[rocq_alias Valid]
+class Valid (α : Type _) [OFE α] where
+  ValidN : Nat → α → Prop
+  Valid : α → Prop
+  validN_ne : x ≡{n}≡ y → ValidN n x → ValidN n y
+  valid_iff_validN : Valid x ↔ ∀ n, ValidN n x
+  validN_succ : ValidN n.succ x → ValidN n x
+
+#rocq_ignore ValidN "Merged into the `Valid` type class"
+
+namespace Valid
+
+/-- Validity. -/
+prefix:50 "✓ " => Valid.Valid
+/-- Step-indexed validity. -/
+notation:50 "✓{" n "} " x:51 => Valid.ValidN n x
+
+end Valid
+
+/-- A step-indexed order `≼{n}` together with its limit `≼`: the step-indexed order is
+transitive, respects `≡{n}≡` and is downward closed in `n`; the limit is transitive and is
+contained in every `≼{n}`. Neither is required to be reflexive, see `IncRefl`. -/
+class OrderN (α : Type _) [OFE α] where
+  IncludedN : Nat → α → α → Prop
+  Included : α → α → Prop
+  incN_ne {n} {x x' y y' : α} :
+    x ≡{n}≡ x' → y ≡{n}≡ y' → IncludedN n x y → IncludedN n x' y'
+  incN_succ {n} {x y : α} : IncludedN n.succ x y → IncludedN n x y
+  incN_trans {n} {x y z : α} : IncludedN n x y → IncludedN n y z → IncludedN n x z
+  inc_trans {x y z : α} : Included x y → Included y z → Included x z
+  incN_of_inc {x y : α} (n) : Included x y → IncludedN n x y
+
+namespace OrderN
+
+/-- The step-indexed order. -/
+notation:50 x " ≼{" n "} " y:51 => IncludedN n x y
+/-- The order. -/
+infix:50 " ≼ " => Included
+
+variable [OFE α] [OrderN α]
+
+/-- The reflexive closure of the step-indexed order. -/
+def IncludedNR (n : Nat) (x y : α) : Prop := x ≡{n}≡ y ∨ x ≼{n} y
+@[inherit_doc] notation:50 x " ≼*{" n "} " y:51 => IncludedNR n x y
+
+/-- The reflexive closure of the order. -/
+def IncludedR (x y : α) : Prop := x = y ∨ x ≼ y
+@[inherit_doc] infix:50 " ≼* " => IncludedR
+
+theorem IncludedN.incNR {n} {x y : α} : x ≼{n} y → x ≼*{n} y := .inr
+theorem Included.incR {x y : α} : x ≼ y → x ≼* y := .inr
+
+@[refl] theorem IncludedNR.rfl {n} {x : α} : x ≼*{n} x := .inl .rfl
+@[refl] theorem IncludedR.rfl {x : α} : x ≼* x := .inl (Eq.refl x)
+
+theorem IncludedNR.ne {n} {x x' y y' : α} (ex : x ≡{n}≡ x') (ey : y ≡{n}≡ y') :
+    x ≼*{n} y → x' ≼*{n} y'
+  | .inl e => .inl (ex.symm.trans (e.trans ey))
+  | .inr h => .inr (incN_ne ex ey h)
+
+theorem IncludedNR.succ {n} {x y : α} : x ≼*{n.succ} y → x ≼*{n} y
+  | .inl e => .inl (e.le (Nat.le_succ n))
+  | .inr h => .inr (incN_succ h)
+
+theorem IncludedNR.trans {n} {x y z : α} : x ≼*{n} y → y ≼*{n} z → x ≼*{n} z
+  | .inl e₁, .inl e₂ => .inl (e₁.trans e₂)
+  | .inl e₁, .inr h₂ => .inr (incN_ne e₁.symm .rfl h₂)
+  | .inr h₁, .inl e₂ => .inr (incN_ne .rfl e₂ h₁)
+  | .inr h₁, .inr h₂ => .inr (incN_trans h₁ h₂)
+
+theorem IncludedR.trans {x y z : α} : x ≼* y → y ≼* z → x ≼* z
+  | .inl e₁, h₂ => e₁ ▸ h₂
+  | h₁, .inl e₂ => e₂ ▸ h₁
+  | .inr h₁, .inr h₂ => .inr (inc_trans h₁ h₂)
+
+theorem IncludedR.incNR (n) {x y : α} : x ≼* y → x ≼*{n} y
+  | .inl e => .inl (e ▸ .rfl)
+  | .inr h => .inr (incN_of_inc n h)
+
+end OrderN
+
+/-- Reflexivity of the order: the order law of unital algebras (`UCMRA`), also enjoyed by
+total algebras under their extension inclusion. -/
+class IncRefl (α : Type _) [OFE α] [OrderN α] : Prop where
+  inc_refl (x : α) : x ≼ x
+
+/-- An element `x` is increasing if composing with it never shrinks a resource. Cores and units
+are increasing; in an affine algebra every element is. -/
+class CMRA.Increasing {α : Type _} [OFE α] [Op α] [OrderN α] (x : α) : Prop where
+  increasing (y : α) : y ≼ x • y
+
+/-! ## Resource algebras -/
+
+/-- A resource algebra: composition, core and validity together with the laws relating them. -/
+class RABase (α : Type _) extends OFE α, Op α, PCore α, Valid α where
+  validN_op_left {n} {x y : α} : ✓{n} (x • y) → ✓{n} x
+  pcore_op_left {x cx : α} : pcore x = some cx → cx • x = x
+  extend {n} {x y₁ y₂ : α} : ✓{n} x → x ≡{n}≡ y₁ • y₂ →
+    Σ' z₁ z₂ : α, x = z₁ • z₂ ∧ z₁ ≡{n}≡ y₁ ∧ z₂ ≡{n}≡ y₂
+
+#rocq_ignore CmraMixin "Use the CMRA type class."
+#rocq_ignore cmra_mixin_of' "Not needed."
+#rocq_ignore cmra_ofeO "Not needed."
+#rocq_ignore RAMixin
+  "Bundled record of RA laws; Lean passes them as arguments to `RABase.ofDiscrete`."
+
+namespace CMRA
+variable [RABase α]
+
+export Op (op op? op_ne assoc comm)
+export PCore (pcore pcore_ne pcore_idem core)
+export Valid (Valid ValidN validN_ne valid_iff_validN validN_succ)
+export RABase (validN_op_left pcore_op_left extend)
+export IsTotal (total)
 
 @[rocq_alias CoreId]
 class CoreId (x : α) where
@@ -106,64 +208,18 @@ class IdFree (x : α) where
 export IdFree (id_free0_r)
 #rocq_ignore IdFree_proper "Derived from nonexpansivity"
 
-@[rocq_alias CmraTotal]
-class IsTotal (α : Type _) [CMRA α] where
-  total (x : α) : ∃ cx, pcore x = some cx
-export IsTotal (total)
-
-#rocq_ignore cmra_total_mixin "Use CMRA + IsTotal"
-
-@[rocq_alias core]
-def core (x : α) := (pcore x).getD x
-
-@[rocq_alias CmraDiscrete]
-class Discrete (α : Type _) [CMRA α] extends OFE.Discrete α where
-  discrete_valid {x : α} : ✓{0} x → ✓ x
-export Discrete (discrete_valid)
-#rocq_ignore RAMixin "Bundled record of RA laws; Lean passes them as arguments to `CMRA.ofDiscrete`."
-#rocq_ignore discrete_validN_instance "Use CMRA instance"
-
-end CMRA
-
-@[rocq_alias ucmra]
-class UCMRA (α : Type _) extends CMRA α where
-  unit : α
-  unit_valid : ✓ unit
-  unit_left_id : unit • x = x
-  pcore_unit : pcore unit = some unit
-
-#rocq_ignore Unit "Lean uses the UCMRA.unit field; no separate class needed."
-#rocq_ignore UcmraMixin "Lean uses the UCMRA type class directly; mixin/bundle separation is unnecessary."
-#rocq_ignore ucmra_cmraR "Folded into Lean's UCMRA extends CMRA."
-#rocq_ignore ucmra_ofeO "Folded into Lean's UCMRA → OFE."
-
-class IsUnit [CMRA α] (ε : α) : Prop where
-  unit_valid : ✓ ε
-  unit_left_id : ε • x = x
-  pcore_unit : CMRA.pcore ε = some ε
-
-instance [UCMRA α] : IsUnit (UCMRA.unit : α) where
-  unit_valid := UCMRA.unit_valid
-  unit_left_id := UCMRA.unit_left_id
-  pcore_unit := UCMRA.pcore_unit
-
-namespace CMRA
-variable [CMRA α]
-
-export UCMRA (unit unit_valid unit_left_id pcore_unit)
-
 @[rocq_alias cmra_assoc]
-theorem assoc' {x y z : α} : x • (y • z) = (x • y) • z := CMRA.assoc
+theorem assoc' {x y z : α} : x • (y • z) = (x • y) • z := assoc
 
 @[rocq_alias cmra_comm]
-theorem comm' {x y : α} : x • y = y • x := CMRA.comm
+theorem comm' {x y : α} : x • y = y • x := comm
 
 @[rocq_alias cmra_pcore_l]
-theorem pcore_l {x cx : α} (e : pcore x = some cx) : cx • x = x := CMRA.pcore_op_left e
+theorem pcore_l {x cx : α} (e : pcore x = some cx) : cx • x = x := pcore_op_left e
 
 @[rocq_alias cmra_pcore_idemp]
 theorem pcore_idemp {x cx : α} (e : pcore x = some cx) : pcore cx = some cx :=
-  CMRA.pcore_idem e
+  pcore_idem e
 
 @[rocq_alias cmra_extend]
 def extend' {n} {x y₁ y₂ : α} (v : ✓{n} x) (e : x ≡{n}≡ y₁ • y₂) :
@@ -172,34 +228,34 @@ def extend' {n} {x y₁ y₂ : α} (v : ✓{n} x) (e : x ≡{n}≡ y₁ • y₂
   ⟨z₁, z₂, hx, hz, hw⟩
 
 @[rocq_alias cmra_validN_op_l]
-theorem validN_op_l {n} {x y : α} : ✓{n} (x • y) → ✓{n} x := CMRA.validN_op_left
+theorem validN_op_l {n} {x y : α} : ✓{n} (x • y) → ✓{n} x := validN_op_left
 
 @[rocq_alias cmra_valid_validN]
-theorem valid_validN {x : α} : ✓ x ↔ ∀ n, ✓{n} x := CMRA.valid_iff_validN
+theorem valid_validN {x : α} : ✓ x ↔ ∀ n, ✓{n} x := valid_iff_validN
 
 @[rocq_alias cmra_op_ne]
-theorem op_ne' {x : α} : NonExpansive (x • ·) := CMRA.op_ne
+theorem op_ne' {x : α} : NonExpansive (x • ·) := op_ne
 
 @[rocq_alias cmra_pcore_ne]
 theorem pcore_ne' {n} {x y : α} {cx} (h : x ≡{n}≡ y) (e : pcore x = some cx) :
-    ∃ cy, pcore y = some cy ∧ cx ≡{n}≡ cy := CMRA.pcore_ne h e
+    ∃ cy, pcore y = some cy ∧ cx ≡{n}≡ cy := pcore_ne h e
 
 @[rocq_alias cmra_validN_ne]
-theorem validN_ne' {n} {x y : α} (h : x ≡{n}≡ y) : ✓{n} x → ✓{n} y := CMRA.validN_ne h
+theorem validN_ne' {n} {x y : α} (h : x ≡{n}≡ y) : ✓{n} x → ✓{n} y := validN_ne h
 
 theorem opM_ne_right {n} {x : α} {y₁ y₂ : Option α} (h : y₁ ≡{n}≡ y₂) : x •? y₁ ≡{n}≡ x •? y₂ :=
   match y₁, y₂, h with
   | none, none, _ => .rfl
-  | some _, some _, h => CMRA.op_ne.ne h
+  | some _, some _, h => op_ne.ne h
 
 @[rocq_alias cmra_opM_ne]
 instance : NonExpansive₂ (op? (α := α)) where
-  ne _ _ _ e₁ y₁ y₂ e₂ :=
+  ne _ x₁ _ e₁ y₁ y₂ e₂ :=
     match y₁, y₂, e₂ with
     | none, none, _ => e₁
-    | some _, some _, e₂ =>
-      (CMRA.op_ne.ne e₂).trans (Dist.of_eq comm |>.trans <|
-        (CMRA.op_ne.ne e₁).trans (Dist.of_eq comm))
+    | some _, some y₂, e₂ =>
+      ((op_ne (x := x₁)).ne e₂).trans (Dist.of_eq comm |>.trans <|
+        ((op_ne (x := y₂)).ne e₁).trans (Dist.of_eq comm))
 
 #rocq_ignore cmra_opM_proper "Derived from nonexpansivity"
 
@@ -263,10 +319,10 @@ theorem op_opM_assoc (x y : α) (mz : Option α) : (x • y) •? mz = x • (y 
 theorem op_opM_assoc_dist (x y : α) (mz : Option α) : (x • y) •? mz ≡{n}≡ x • (y •? mz) := by
   unfold op?; cases mz <;> simp [op_assocN, Dist.symm]
 
-
 /-! ## Validity -/
 
-theorem Valid.validN : ✓ (x : α) → ✓{n} x := (valid_iff_validN.1 · _)
+theorem _root_.Iris.Valid.Valid.validN : ✓ (x : α) → ✓{n} x := (valid_iff_validN.1 · _)
+protected theorem Valid.validN : ✓ (x : α) → ✓{n} x := Iris.Valid.Valid.validN
 
 theorem valid_mapN {x y : α} (f : ∀ n, ✓{n} x → ✓{n} y) (v : ✓ x) : ✓ y :=
   valid_iff_validN.mpr fun n => f n v.validN
@@ -363,6 +419,13 @@ theorem pcore_validN {n} {x : α} {cx} (e : pcore x = some cx) (v : ✓{n} x) : 
 theorem pcore_valid {x : α} {cx} (e : pcore x = some cx) : ✓ x → ✓ cx :=
   valid_mapN fun _ => pcore_validN e
 
+@[rocq_alias core_id_dup]
+theorem op_self (x : α) [CoreId x] : x • x = x := pcore_op_self' CoreId.core_id
+
+@[rocq_alias cmra_pcore_core_id]
+theorem CoreId.of_pcore_eq_some {x y : α} (e : pcore x = some y) : CoreId y where
+  core_id := pcore_idem e
+
 /-! ## Exclusive elements -/
 
 @[rocq_alias exclusiveN_l]
@@ -385,203 +448,9 @@ theorem not_excl_op_right {x : α} [Exclusive x] {y} : ¬✓ (y • x) :=
 theorem none_of_excl_valid_op {n} {x : α} [Exclusive x] {my} : ✓{n} (x •? my) → my = none := by
   cases my <;> simp [op?, not_valid_exclN_op_left]
 
-@[rocq_alias exclusive_includedN]
-theorem not_valid_of_exclN_inc {n} {x : α} [Exclusive x] {y} : x ≼{n} y → ¬✓{n} y
-  | ⟨_, hz⟩, v => not_valid_exclN_op_left (validN_ne hz v)
-
-@[rocq_alias exclusive_included]
-theorem not_valid_of_excl_inc {x : α} [Exclusive x] {y} : x ≼ y → ¬✓ y
-  | ⟨_, hz⟩, v => Exclusive.exclusive0_l _ <| hz ▸ v.validN
-
 #rocq_ignore Exclusive_proper "OFE is Leibniz; use equality"
 
-/-! ## Order -/
-
-theorem incN_of_incN_of_dist : (a : α) ≼{n} b → b ≡{n}≡ c → a ≼{n} c
-  | ⟨t, et⟩, e => ⟨t, e.symm.trans et⟩
-
-instance {n : Nat} : Trans (IncludedN (α := α) n) (Dist n) (IncludedN n) where
-  trans := incN_of_incN_of_dist
-
-theorem incN_of_dist_of_incN (e : (a : α) ≡{n}≡ b) : b ≼{n} c → a ≼{n} c
-  | ⟨t, et⟩ => ⟨t, et.trans e.symm.op_l⟩
-
-instance {n : Nat} : Trans (Dist (α := α) n) (IncludedN n) (IncludedN n) where
-  trans := incN_of_dist_of_incN
-
-@[rocq_alias cmra_included_includedN]
-theorem incN_of_inc (n) {x y : α} : x ≼ y → x ≼{n} y
-  | ⟨z, hz⟩ => ⟨z, hz.dist⟩
-theorem Included.incN {n} {x y : α} : x ≼ y → x ≼{n} y := incN_of_inc _
-
-#rocq_ignore cmra_included_proper "OFE is Leibniz; use equality"
-
-theorem incN_iff_left (e : (a : α) ≡{n}≡ b) : a ≼{n} c ↔ b ≼{n} c :=
-  ⟨incN_of_dist_of_incN e.symm, incN_of_dist_of_incN e⟩
-theorem _root_.Iris.OFE.Dist.incN_l : (a : α) ≡{n}≡ b → (a ≼{n} c ↔ b ≼{n} c) := incN_iff_left
-
-theorem incN_iff_right (e : (b : α) ≡{n}≡ c) : a ≼{n} b ↔ a ≼{n} c :=
-  ⟨(incN_of_incN_of_dist · e), (incN_of_incN_of_dist · e.symm)⟩
-theorem _root_.Iris.OFE.Dist.incN_r : (b : α) ≡{n}≡ c → (a ≼{n} b ↔ a ≼{n} c) := incN_iff_right
-
-@[rocq_alias cmra_includedN_ne]
-theorem incN_dist_iff (ea : (a : α) ≡{n}≡ a') (eb : (b : α) ≡{n}≡ b') : a ≼{n} b ↔ a' ≼{n} b' :=
-  (incN_iff_left ea).trans (incN_iff_right eb)
-theorem _root_.Iris.OFE.Dist.incN :
-    (a : α) ≡{n}≡ a' → b ≡{n}≡ b' → (a ≼{n} b ↔ a' ≼{n} b') := incN_dist_iff
-
-#rocq_ignore cmra_includedN_proper "OFE is Leibniz; use equality"
-
-@[rocq_alias cmra_included_trans]
-theorem inc_trans {x y z : α} : x ≼ y → y ≼ z → x ≼ z
-  | ⟨w, (hw : y = x • w)⟩, ⟨t, (ht : z = y • t)⟩ =>
-    suffices h : z = x • (w • t) from ⟨w • t, h⟩
-    calc
-      z = y • t := ht
-      _ = (x • w) • t := congrArg (· • t) hw
-      _ = x • (w • t) := assoc.symm
-theorem Included.trans : (x : α) ≼ y → y ≼ z → x ≼ z := inc_trans
-
-instance : Trans (Included (α := α)) Included Included where
-  trans := inc_trans
-
-@[rocq_alias cmra_includedN_trans]
-theorem incN_trans {x y z : α} : x ≼{n} y → y ≼{n} z → x ≼{n} z
-  | ⟨w, (hw : y ≡{n}≡ x • w)⟩, ⟨t, (ht : z ≡{n}≡ y • t)⟩ =>
-    suffices h : z ≡{n}≡ x • (w • t) from ⟨w • t, h⟩
-    calc
-      z ≡{n}≡ y • t := ht
-      _ ≡{n}≡ (x • w) • t := op_left_dist _ hw
-      _ ≡{n}≡ x • (w • t) := op_assocN.symm
-theorem IncludedN.trans : (x : α) ≼{n} y → y ≼{n} z → x ≼{n} z := incN_trans
-
-instance : Trans (IncludedN (α := α) n) (IncludedN n) (IncludedN n) where
-  trans := incN_trans
-
-@[rocq_alias cmra_valid_included]
-theorem valid_of_inc {x y : α} : x ≼ y → ✓ y → ✓ x
-  | ⟨_, hz⟩, v => valid_op_left (hz ▸ v)
-
-@[rocq_alias cmra_validN_includedN]
-theorem validN_of_incN {n} {x y : α} : x ≼{n} y → ✓{n} y → ✓{n} x
-  | ⟨_, hz⟩, v => validN_op_left (validN_ne hz v)
-theorem IncludedN.validN {n} {x y : α} : x ≼{n} y → ✓{n} y → ✓{n} x := validN_of_incN
-
-@[rocq_alias cmra_validN_included]
-theorem validN_of_inc {n} {x y : α} : x ≼ y → ✓{n} y → ✓{n} x
-  | ⟨_, hz⟩, v => validN_op_left (validN_ne hz.dist v)
-theorem Included.validN {n} {x y : α} : x ≼ y → ✓{n} y → ✓{n} x := validN_of_inc
-
-@[rocq_alias cmra_includedN_le]
-theorem incN_of_incN_le {n n'} {x y : α} (l1 : n' ≤ n) : x ≼{n} y → x ≼{n'} y
-  | ⟨z, hz⟩ => ⟨z, Dist.le hz l1⟩
-theorem inc0_of_incN {n} {x y : α} : x ≼{n} y → x ≼{0} y := incN_of_incN_le (Nat.zero_le n)
-theorem IncludedN.le {n n'} {x y : α} : n' ≤ n → x ≼{n} y → x ≼{n'} y := incN_of_incN_le
-
-@[rocq_alias cmra.cmra_includedN_S]
-theorem incN_of_incN_succ {n} {x y : α} : x ≼{n.succ} y → x ≼{n} y :=
-  incN_of_incN_le (Nat.le_succ n)
-theorem IncludedN.succ {n} {x y : α} : x ≼{n.succ} y → x ≼{n} y := incN_of_incN_succ
-
-@[rocq_alias cmra_includedN_l]
-theorem incN_op_left (n) (x y : α) : x ≼{n} x • y := ⟨y, Dist.rfl⟩
-
-@[rocq_alias cmra_included_l]
-theorem inc_op_left (x y : α) : x ≼ x • y := ⟨y, rfl⟩
-
-@[rocq_alias cmra_included_r]
-theorem inc_op_right (x y : α) : y ≼ x • y := ⟨x, comm⟩
-
-@[rocq_alias cmra_includedN_r]
-theorem incN_op_right (n) (x y : α) : y ≼{n} x • y :=
-  (inc_op_right x y).elim fun z hz => ⟨z, hz.dist⟩
-
-@[rocq_alias cmra_pcore_mono]
-theorem pcore_mono {x y : α} : x ≼ y → pcore x = some cx → ∃ cy, pcore y = some cy ∧ cx ≼ cy
-  | ⟨_, hw⟩, e =>
-    have ⟨z, hz⟩ := pcore_op_mono e _
-    let ⟨t, ht, et⟩ := OFE.equiv_some ((congrArg pcore hw).trans hz)
-    ⟨t, ht, z, et⟩
-
-@[rocq_alias cmra_pcore_mono']
-theorem pcore_mono' {x y : α} {cx} (le : x ≼ y) (e : pcore x = some cx) :
-    ∃ cy, pcore y = some cy ∧ cx ≼ cy :=
-  pcore_mono le e
-
-@[rocq_alias cmra_pcore_monoN']
-theorem pcore_monoN' {n} {x y : α} {cx} :
-    x ≼{n} y → pcore x ≡{n}≡ some cx → ∃ cy, pcore y = some cy ∧ cx ≼{n} cy
-  | ⟨z, hz⟩, e =>
-    let ⟨w, hw, ew⟩ := OFE.dist_some e
-    let ⟨t, ht, (et : w ≼ t)⟩ := pcore_mono (inc_op_left x z) hw
-    have : pcore y ≡{n}≡ some t :=
-      have : pcore y ≡{n}≡ pcore (x • z) := NonExpansive.ne hz
-      ht ▸ this
-    let ⟨r, hr, er⟩ := OFE.dist_some this
-    suffices h : cx ≼{n} r from ⟨r, hr, h⟩
-    calc
-      cx ≡{n}≡ w := ew
-      w  ≼{n}  t := incN_of_inc n et
-      t  ≡{n}≡ r := er
-
-@[rocq_alias cmra_included_pcore]
-theorem pcore_inc_self {x : α} {cx} (e : pcore x = some cx) : cx ≼ x :=
-  ⟨x, (pcore_op_left e).symm⟩
-
-@[rocq_alias cmra_mono_l]
-theorem op_mono_right {x y} (z : α) : x ≼ y → z • x ≼ z • y
-  | ⟨w, hw⟩ => ⟨w, (congrArg (z • ·) hw).trans assoc⟩
-
-@[rocq_alias cmra_monoN_l]
-theorem op_monoN_right {n x y} (z : α) : x ≼{n} y → z • x ≼{n} z • y
-  | ⟨w, hw⟩ => ⟨w, hw.op_r.trans op_assocN⟩
-
-@[rocq_alias cmra_monoN_r]
-theorem op_monoN_left {n x y} (z : α) (h : x ≼{n} y) : x • z ≼{n} y • z :=
-  (op_commN.incN op_commN).1 (op_monoN_right z h)
-
-@[rocq_alias cmra_mono_r]
-theorem op_mono_left {x y} (z : α) (h : x ≼ y) : x • z ≼ y • z := by
-  rw [comm' (x := x) (y := z), comm' (x := y) (y := z)]; exact op_mono_right z h
-
-@[rocq_alias cmra_monoN]
-theorem op_monoN {n} {x x' y y' : α} (hx : x ≼{n} x') (hy : y ≼{n} y') : x • y ≼{n} x' • y' :=
-  (op_monoN_left _ hx).trans (op_monoN_right _ hy)
-
-#rocq_ignore cmra_monoN' "Use cmra_monoN"
-
-@[rocq_alias cmra_mono]
-theorem op_mono {x x' y y' : α} (hx : x ≼ x') (hy : y ≼ y') : x • y ≼ x' • y' :=
-  (op_mono_left _ hx).trans (op_mono_right _ hy)
-
-#rocq_ignore cmra_mono' "Use cmra_mono"
-
-@[rocq_alias core_id_dup]
-theorem op_self (x : α) [CoreId x] : x • x = x := pcore_op_self' CoreId.core_id
-
-@[rocq_alias core_id_extract]
-theorem op_core_right_of_inc {x y : α} [CoreId x] : x ≼ y → x • y = y
-  | ⟨z, hz⟩ =>
-    calc x • y = x • (x • z) := congrArg (x • ·) hz
-    _ = (x • x) • z := assoc'
-    _ = x • z := congrArg (· • z) (op_self x)
-    _ = y := hz.symm
-
-@[rocq_alias cmra_included_dist_l]
-theorem included_dist_l {n} {x1 x2 x1' : α} :
-    x1 ≼ x2 → x1' ≡{n}≡ x1 → ∃ x2', x1' ≼ x2' ∧ x2' ≡{n}≡ x2
-  | ⟨y, hy⟩, e => ⟨x1' • y, inc_op_left x1' y, e.op_l.trans hy.symm.dist⟩
-
-theorem op_core_left_of_inc {x y : α} [CoreId x] (le : x ≼ y) : y • x = y :=
-  comm'.trans (op_core_right_of_inc le)
-
-@[rocq_alias cmra_pcore_core_id]
-theorem CoreId.of_pcore_eq_some {x y : α} (e : pcore x = some y) : CoreId y where
-  core_id := pcore_idem e
-
--- What's the best way to port these?
--- Global Instance cmra_includedN_preorder n : PreOrder (@includedN A _ _ n).
--- Global Instance cmra_included_preorder : PreOrder (@included A _ _).
+/-! ## Total cores -/
 
 section total
 variable [IsTotal α]
@@ -634,50 +503,9 @@ theorem coreId_iff_core_eqv_self : CoreId (x : α) ↔ core x = x :=
 @[rocq_alias cmra_core_idemp]
 theorem core_idem (x : α) : core (core x) = core x := core_eqv_self _
 
-theorem inc_refl (x : α) : x ≼ x := ⟨core x, (op_core x).symm⟩
-@[refl] theorem Included.rfl {x : α} : x ≼ x := inc_refl x
-
-theorem incN_refl (x : α) : x ≼{n} x := (inc_refl _).incN
-@[refl] theorem IncludedN.rfl {x : α} : x ≼{n} x := incN_refl x
-
-#rocq_ignore cmra_included_preorder "Reflexivity is inc_refl; transitivity is the Trans instance"
-#rocq_ignore cmra_includedN_preorder "Reflexivity is incN_refl; transitivity is the Trans instance"
-
-@[rocq_alias cmra_included_core]
-theorem core_inc_self {x : α} : core x ≼ x :=
-  ⟨x, (core_op x).symm⟩
-
-@[rocq_alias cmra_core_monoN]
-theorem core_incN_core {n} {x y : α} (inc : x ≼{n} y) : core x ≼{n} core y := by
-  let ⟨cy, hcy, icy⟩ := pcore_monoN' inc (Dist.of_eq (pcore_eq_core x))
-  cases (pcore_eq_core _).symm.trans hcy
-  exact icy
-
-theorem core_op_mono (x y : α) : core x ≼ core (x • y) := by
-  have ⟨cy, hcy⟩ := pcore_op_mono (pcore_eq_core x) y
-  simp [pcore_eq_core] at hcy
-  exact ⟨_, hcy⟩
-
-@[rocq_alias cmra_core_mono]
-theorem core_mono {x y : α} (Hinc : x ≼ y) : core x ≼ core y := by
-  have ⟨z, hz⟩ := Hinc
-  rw [hz]; exact core_op_mono x z
-
 end total
 
-section discreteElements
-
-variable {α : Type _} [CMRA α]
-
-@[rocq_alias cmra_discrete_included_l]
-theorem discrete_inc_l {x y : α} [HD : DiscreteE x] (Hv : ✓{0} y) (Hle : x ≼{0} y) : x ≼ y :=
-  have ⟨_, hz⟩ := Hle
-  let ⟨_, t, wt, wx, _⟩ := extend Hv hz
-  ⟨t, wt.trans (congrArg (· • t) (HD.discrete wx.symm).symm)⟩
-
-@[rocq_alias cmra_discrete_included_r]
-theorem discrete_inc_r {x y : α} [HD : DiscreteE y] : x ≼{0} y → x ≼ y
-  | ⟨z, hz⟩ => ⟨z, HD.discrete hz⟩
+/-! ## Discrete elements -/
 
 @[rocq_alias cmra_op_discrete]
 theorem discrete_op {x y : α} (Hv : ✓{0} x • y) [Hx : DiscreteE x] [Hy : DiscreteE y] :
@@ -686,11 +514,690 @@ theorem discrete_op {x y : α} (Hv : ✓{0} x • y) [Hx : DiscreteE x] [Hy : Di
     obtain ⟨_w, _t, wt, wx, ty⟩ := extend ((Dist.validN h).mp Hv) h.symm
     rw [Hx.discrete wx.symm, Hy.discrete ty.symm, wt]
 
-end discreteElements
+end CMRA
+
+/-! ## Ordered resource algebras -/
+
+/-- An ordered resource algebra: a resource algebra with a step-indexed order that is respected
+by composition, validity and the core. The order is neither required to be reflexive
+(`IncRefl`) nor to contain the extension inclusion (`CMRA.Affine`). -/
+@[rocq_alias cmra]
+class CMRA (α : Type _) extends RABase α, OrderN α where
+  op_monoN_left {n} {x y : α} (z : α) : x ≼{n} y → x • z ≼{n} y • z
+  op_mono_left {x y : α} (z : α) : x ≼ y → x • z ≼ y • z
+  validN_of_incN {n} {x y : α} : x ≼{n} y → ✓{n} y → ✓{n} x
+  pcore_monoN {n} {x y cx : α} : x ≼{n} y → pcore x = some cx →
+    ∃ cy, pcore y = some cy ∧ cx ≼{n} cy
+  pcore_mono {x y cx : α} : x ≼ y → pcore x = some cx →
+    ∃ cy, pcore y = some cy ∧ cx ≼ cy
+  pcore_order_op {x cx : α} : pcore x = some cx →
+    ∀ y, ∃ cxy, pcore (x • y) = some cxy ∧ cx ≼ cxy
+  pcore_increasing {x cx : α} : pcore x = some cx → CMRA.Increasing cx
+  increasing_closed {n} {x y : α} : CMRA.Increasing x → x ≼*{n} y → CMRA.Increasing y
+  incN_extend {n} {x y : α} : ✓{n} y → x ≼{n} y → ∃ z, z ≼{n.succ} y ∧ z ≡{n}≡ x
+
+namespace CMRA
+export OrderN (IncludedN Included incN_ne incN_succ incN_trans inc_trans incN_of_inc)
+export IncRefl (inc_refl)
+end CMRA
+
+/-! ## The extension inclusion -/
+
+namespace RABase
+open CMRA
+
+variable [RABase α]
+
+/-- The step-indexed extension inclusion: `y` is `x` composed with some frame. This is the
+inclusion of classical resource algebras (`CMRA.withExtensionOrder` makes it the order), and
+the relation frame-based constructions such as local updates and views are stated with. -/
+@[rocq_alias includedN]
+def IncExtN (n : Nat) (x y : α) : Prop := ∃ z : α, y ≡{n}≡ x • z
+@[inherit_doc] notation:50 x " ≼ₑ{" n "} " y:51 => IncExtN n x y
+
+/-- The extension inclusion: `y` is `x` composed with some frame. -/
+@[rocq_alias included]
+def IncExt (x y : α) : Prop := ∃ z : α, y = x • z
+@[inherit_doc] infix:50 " ≼ₑ " => IncExt
+
+theorem incExtN_ne {n} {x x' y y' : α} (ex : x ≡{n}≡ x') (ey : y ≡{n}≡ y') :
+    x ≼ₑ{n} y → x' ≼ₑ{n} y'
+  | ⟨z, hz⟩ => ⟨z, ey.symm.trans (hz.trans ex.op_l)⟩
+
+theorem incExtN_of_incExtN_of_dist (h : (a : α) ≼ₑ{n} b) (e : b ≡{n}≡ c) : a ≼ₑ{n} c :=
+  incExtN_ne .rfl e h
+
+instance {n : Nat} : Trans (IncExtN (α := α) n) (Dist n) (IncExtN n) where
+  trans := incExtN_of_incExtN_of_dist
+
+theorem incExtN_of_dist_of_incExtN (e : (a : α) ≡{n}≡ b) (h : b ≼ₑ{n} c) : a ≼ₑ{n} c :=
+  incExtN_ne e.symm .rfl h
+
+instance {n : Nat} : Trans (Dist (α := α) n) (IncExtN n) (IncExtN n) where
+  trans := incExtN_of_dist_of_incExtN
+
+@[rocq_alias cmra_included_includedN]
+theorem incExtN_of_incExt (n) {x y : α} : x ≼ₑ y → x ≼ₑ{n} y
+  | ⟨z, hz⟩ => ⟨z, hz.dist⟩
+theorem IncExt.incExtN {n} {x y : α} : x ≼ₑ y → x ≼ₑ{n} y := incExtN_of_incExt _
+
+#rocq_ignore cmra_included_proper "OFE is Leibniz; use equality"
+
+theorem incExtN_iff_left (e : (a : α) ≡{n}≡ b) : a ≼ₑ{n} c ↔ b ≼ₑ{n} c :=
+  ⟨incExtN_ne e .rfl, incExtN_ne e.symm .rfl⟩
+
+theorem incExtN_iff_right (e : (b : α) ≡{n}≡ c) : a ≼ₑ{n} b ↔ a ≼ₑ{n} c :=
+  ⟨incExtN_ne .rfl e, incExtN_ne .rfl e.symm⟩
+
+@[rocq_alias cmra_includedN_ne]
+theorem incExtN_dist_iff (ea : (a : α) ≡{n}≡ a') (eb : (b : α) ≡{n}≡ b') :
+    a ≼ₑ{n} b ↔ a' ≼ₑ{n} b' :=
+  ⟨incExtN_ne ea eb, incExtN_ne ea.symm eb.symm⟩
+theorem _root_.Iris.OFE.Dist.incExtN :
+    (a : α) ≡{n}≡ a' → b ≡{n}≡ b' → (a ≼ₑ{n} b ↔ a' ≼ₑ{n} b') :=
+  incExtN_dist_iff
+
+#rocq_ignore cmra_includedN_proper "OFE is Leibniz; use equality"
+
+@[rocq_alias cmra_included_trans]
+theorem incExt_trans {x y z : α} : x ≼ₑ y → y ≼ₑ z → x ≼ₑ z
+  | ⟨w, (hw : y = x • w)⟩, ⟨t, (ht : z = y • t)⟩ =>
+    suffices h : z = x • (w • t) from ⟨w • t, h⟩
+    calc
+      z = y • t := ht
+      _ = (x • w) • t := congrArg (· • t) hw
+      _ = x • (w • t) := assoc.symm
+theorem IncExt.trans : (x : α) ≼ₑ y → y ≼ₑ z → x ≼ₑ z := incExt_trans
+
+instance : Trans (IncExt (α := α)) IncExt IncExt where
+  trans := incExt_trans
+
+@[rocq_alias cmra_includedN_trans]
+theorem incExtN_trans {x y z : α} : x ≼ₑ{n} y → y ≼ₑ{n} z → x ≼ₑ{n} z
+  | ⟨w, (hw : y ≡{n}≡ x • w)⟩, ⟨t, (ht : z ≡{n}≡ y • t)⟩ =>
+    suffices h : z ≡{n}≡ x • (w • t) from ⟨w • t, h⟩
+    calc
+      z ≡{n}≡ y • t := ht
+      _ ≡{n}≡ (x • w) • t := op_left_dist _ hw
+      _ ≡{n}≡ x • (w • t) := op_assocN.symm
+theorem IncExtN.trans : (x : α) ≼ₑ{n} y → y ≼ₑ{n} z → x ≼ₑ{n} z := incExtN_trans
+
+instance : Trans (IncExtN (α := α) n) (IncExtN n) (IncExtN n) where
+  trans := incExtN_trans
+
+@[rocq_alias cmra_valid_included]
+theorem valid_of_incExt {x y : α} : x ≼ₑ y → ✓ y → ✓ x
+  | ⟨_, hz⟩, v => valid_op_left (hz ▸ v)
+
+@[rocq_alias cmra_validN_includedN]
+theorem validN_of_incExtN {n} {x y : α} : x ≼ₑ{n} y → ✓{n} y → ✓{n} x
+  | ⟨_, hz⟩, v => validN_op_left (validN_ne hz v)
+theorem IncExtN.validN {n} {x y : α} : x ≼ₑ{n} y → ✓{n} y → ✓{n} x := validN_of_incExtN
+
+@[rocq_alias cmra_validN_included]
+theorem validN_of_incExt {n} {x y : α} : x ≼ₑ y → ✓{n} y → ✓{n} x
+  | ⟨_, hz⟩, v => validN_op_left (validN_ne hz.dist v)
+theorem IncExt.validN {n} {x y : α} : x ≼ₑ y → ✓{n} y → ✓{n} x := validN_of_incExt
+
+@[rocq_alias cmra_includedN_le]
+theorem incExtN_le {n n'} {x y : α} (l1 : n' ≤ n) : x ≼ₑ{n} y → x ≼ₑ{n'} y
+  | ⟨z, hz⟩ => ⟨z, Dist.le hz l1⟩
+theorem incExt0_of_incExtN {n} {x y : α} : x ≼ₑ{n} y → x ≼ₑ{0} y :=
+  incExtN_le (Nat.zero_le n)
+theorem IncExtN.le {n n'} {x y : α} : n' ≤ n → x ≼ₑ{n} y → x ≼ₑ{n'} y := incExtN_le
+
+@[rocq_alias cmra.cmra_includedN_S]
+theorem incExtN_succ {n} {x y : α} : x ≼ₑ{n.succ} y → x ≼ₑ{n} y :=
+  incExtN_le (Nat.le_succ n)
+theorem IncExtN.succ {n} {x y : α} : x ≼ₑ{n.succ} y → x ≼ₑ{n} y := incExtN_succ
+
+@[rocq_alias cmra_includedN_l]
+theorem incExtN_op_left (n) (x y : α) : x ≼ₑ{n} x • y := ⟨y, Dist.rfl⟩
+
+@[rocq_alias cmra_included_l]
+theorem incExt_op_left (x y : α) : x ≼ₑ x • y := ⟨y, rfl⟩
+
+@[rocq_alias cmra_included_r]
+theorem incExt_op_right (x y : α) : y ≼ₑ x • y := ⟨x, comm⟩
+
+@[rocq_alias cmra_includedN_r]
+theorem incExtN_op_right (n) (x y : α) : y ≼ₑ{n} x • y := ⟨x, op_commN⟩
+
+@[rocq_alias cmra_included_pcore]
+theorem pcore_incExt_self {x : α} {cx} (e : pcore x = some cx) : cx ≼ₑ x :=
+  ⟨x, (pcore_op_left e).symm⟩
+
+@[rocq_alias cmra_mono_l]
+theorem op_mono_right_ext {x y} (z : α) : x ≼ₑ y → z • x ≼ₑ z • y
+  | ⟨w, hw⟩ => ⟨w, (congrArg (z • ·) hw).trans assoc⟩
+
+@[rocq_alias cmra_monoN_l]
+theorem op_monoN_right_ext {n x y} (z : α) : x ≼ₑ{n} y → z • x ≼ₑ{n} z • y
+  | ⟨w, hw⟩ => ⟨w, hw.op_r.trans op_assocN⟩
+
+@[rocq_alias cmra_monoN_r]
+theorem op_monoN_left_ext {n x y} (z : α) (h : x ≼ₑ{n} y) : x • z ≼ₑ{n} y • z :=
+  (op_commN.incExtN op_commN).1 (op_monoN_right_ext z h)
+
+@[rocq_alias cmra_mono_r]
+theorem op_mono_left_ext {x y} (z : α) (h : x ≼ₑ y) : x • z ≼ₑ y • z := by
+  rw [comm' (x := x) (y := z), comm' (x := y) (y := z)]; exact op_mono_right_ext z h
+
+@[rocq_alias cmra_monoN]
+theorem op_monoN_ext {n} {x x' y y' : α} (hx : x ≼ₑ{n} x') (hy : y ≼ₑ{n} y') :
+    x • y ≼ₑ{n} x' • y' :=
+  (op_monoN_left_ext _ hx).trans (op_monoN_right_ext _ hy)
+
+#rocq_ignore cmra_monoN' "Use cmra_monoN"
+
+@[rocq_alias cmra_mono]
+theorem op_mono_ext {x x' y y' : α} (hx : x ≼ₑ x') (hy : y ≼ₑ y') :
+    x • y ≼ₑ x' • y' :=
+  (op_mono_left_ext _ hx).trans (op_mono_right_ext _ hy)
+
+#rocq_ignore cmra_mono' "Use cmra_mono"
+
+@[rocq_alias core_id_extract]
+theorem op_core_right_of_incExt {x y : α} [CoreId x] : x ≼ₑ y → x • y = y
+  | ⟨z, hz⟩ =>
+    calc x • y = x • (x • z) := congrArg (x • ·) hz
+    _ = (x • x) • z := assoc'
+    _ = x • z := congrArg (· • z) (op_self x)
+    _ = y := hz.symm
+
+theorem op_core_left_of_incExt {x y : α} [CoreId x] (le : x ≼ₑ y) : y • x = y :=
+  comm'.trans (op_core_right_of_incExt le)
+
+@[rocq_alias cmra_included_dist_l]
+theorem incExt_dist_l {n} {x1 x2 x1' : α} :
+    x1 ≼ₑ x2 → x1' ≡{n}≡ x1 → ∃ x2', x1' ≼ₑ x2' ∧ x2' ≡{n}≡ x2
+  | ⟨y, hy⟩, e => ⟨x1' • y, incExt_op_left x1' y, e.op_l.trans hy.symm.dist⟩
+
+@[rocq_alias exclusive_includedN]
+theorem not_valid_of_exclN_incExt {n} {x : α} [Exclusive x] {y} : x ≼ₑ{n} y → ¬✓{n} y
+  | ⟨_, hz⟩, v => not_valid_exclN_op_left (validN_ne hz v)
+
+@[rocq_alias exclusive_included]
+theorem not_valid_of_excl_incExt {x : α} [Exclusive x] {y} : x ≼ₑ y → ¬✓ y
+  | ⟨_, hz⟩, v => Exclusive.exclusive0_l _ <| hz ▸ v.validN
+
+/-- Extension along the step index: `CMRA.incN_extend` for the extension inclusion. -/
+theorem incExtN_extend {n} {x y : α} (v : ✓{n} y) :
+    x ≼ₑ{n} y → ∃ z, z ≼ₑ{n.succ} y ∧ z ≡{n}≡ x
+  | ⟨_, hw⟩ =>
+    let ⟨z₁, z₂, hy, hz₁, _⟩ := extend v hw
+    ⟨z₁, ⟨z₂, hy.dist⟩, hz₁⟩
+
+/-- A non-expansive function commuting with composition preserves the extension inclusion. -/
+theorem incExtN_map {β : Type _} [RABase β] (f : α → β) [NonExpansive f]
+    (hop : ∀ x y, f (x • y) = f x • f y) {n} {x y : α} : x ≼ₑ{n} y → f x ≼ₑ{n} f y
+  | ⟨z, hz⟩ => ⟨f z, (NonExpansive.ne hz).trans (hop x z).dist⟩
+
+theorem incExt_map {β : Type _} [RABase β] (f : α → β)
+    (hop : ∀ x y, f (x • y) = f x • f y) {x y : α} : x ≼ₑ y → f x ≼ₑ f y
+  | ⟨z, hz⟩ => ⟨f z, (congrArg f hz).trans (hop x z)⟩
+
+section total
+variable [IsTotal α]
+
+theorem incExt_refl (x : α) : x ≼ₑ x := ⟨core x, (op_core x).symm⟩
+@[refl] theorem IncExt.rfl {x : α} : x ≼ₑ x := incExt_refl x
+
+theorem incExtN_refl (x : α) : x ≼ₑ{n} x := (incExt_refl _).incExtN
+@[refl] theorem IncExtN.rfl {x : α} : x ≼ₑ{n} x := incExtN_refl x
+
+#rocq_ignore cmra_included_preorder
+  "Reflexivity is incExt_refl; transitivity is the Trans instance"
+#rocq_ignore cmra_includedN_preorder
+  "Reflexivity is incExtN_refl; transitivity is the Trans instance"
+
+theorem incExtN_of_dist {n} {x y : α} (h : x ≡{n}≡ y) : x ≼ₑ{n} y :=
+  incExtN_ne .rfl h (incExtN_refl x)
+theorem _root_.Iris.OFE.Dist.to_incExtN {n} {x y : α} : x ≡{n}≡ y → x ≼ₑ{n} y :=
+  incExtN_of_dist
+
+@[rocq_alias cmra_included_core]
+theorem core_incExt_self {x : α} : core x ≼ₑ x := ⟨x, (core_op x).symm⟩
+
+end total
+
+section discrete
+
+@[rocq_alias cmra_discrete_included_iff]
+theorem incExt_iff_incExtN [OFE.Discrete α] (n) {x y : α} : x ≼ₑ y ↔ x ≼ₑ{n} y :=
+  ⟨incExtN_of_incExt _, fun ⟨z, hz⟩ => ⟨z, discrete hz⟩⟩
+
+@[rocq_alias cmra_discrete_included_iff_0]
+theorem incExt_0_iff_incExtN [OFE.Discrete α] (n) {x y : α} : x ≼ₑ{0} y ↔ x ≼ₑ{n} y :=
+  ⟨fun ⟨z, hz⟩ => ⟨z, (discrete hz).dist⟩, incExt0_of_incExtN⟩
+
+/-- The `discrete_inc` law of `CMRA.Discrete` for a discrete algebra with the extension order. -/
+theorem incExt_of_incExt0 [OFE.Discrete α] {x y : α} : x ≼ₑ{0} y → x ≼ₑ y :=
+  (incExt_iff_incExtN 0).mpr
+
+@[rocq_alias cmra_discrete_included_l]
+theorem discrete_incExt_l {x y : α} [HD : DiscreteE x] (Hv : ✓{0} y) (Hle : x ≼ₑ{0} y) :
+    x ≼ₑ y :=
+  have ⟨_, hz⟩ := Hle
+  let ⟨_, t, wt, wx, _⟩ := extend Hv hz
+  ⟨t, wt.trans (congrArg (· • t) (HD.discrete wx.symm).symm)⟩
+
+@[rocq_alias cmra_discrete_included_r]
+theorem discrete_incExt_r {x y : α} [HD : DiscreteE y] : x ≼ₑ{0} y → x ≼ₑ y
+  | ⟨z, hz⟩ => ⟨z, HD.discrete hz⟩
+
+end discrete
+
+/-- The extension inclusion as a step-indexed order. -/
+@[reducible] def extOrderN : OrderN α where
+  IncludedN := IncExtN
+  Included := IncExt
+  incN_ne := incExtN_ne
+  incN_succ := incExtN_succ
+  incN_trans := incExtN_trans
+  inc_trans := incExt_trans
+  incN_of_inc n h := incExtN_of_incExt n h
+
+/-- The one law of a classical resource algebra that is specific to the extension inclusion:
+the partial core is monotone along frames. Instantiated by such algebras only; it is the input
+of the smart constructors `CMRA.withExtensionOrder` and `UCMRA.withExtensionOrder`, and only
+the monotonicity of the core along `≼ₑ` (`pcore_mono_ext` and its relatives) is stated over
+it. -/
+class ExtensionLaws (α : Type _) [RABase α] : Prop where
+  pcore_op_mono {x cx : α} :
+    pcore x = some cx → ∀ y, ∃ cy : α, pcore (x • y) = some (cx • cy)
+export ExtensionLaws (pcore_op_mono)
+
+/-- The extension laws follow from monotonicity of the partial core along the extension
+inclusion, the form of the law in Iris-Rocq (`cmra_pcore_mono`). -/
+theorem ExtensionLaws.ofPCoreMono
+    (h : ∀ {x y cx : α}, x ≼ₑ y → pcore x = some cx → ∃ cy, pcore y = some cy ∧ cx ≼ₑ cy) :
+    ExtensionLaws α where
+  pcore_op_mono e y :=
+    let ⟨_, hcy, z, hz⟩ := h (incExt_op_left _ y) e
+    ⟨z, hcy.trans (congrArg some hz)⟩
+
+/-- For a total core, monotonicity of `core` along the extension inclusion suffices. -/
+theorem ExtensionLaws.ofCoreMono [IsTotal α] (h : ∀ x y : α, x ≼ₑ y → core x ≼ₑ core y) :
+    ExtensionLaws α :=
+  .ofPCoreMono fun {x y cx} hxy e =>
+    have hcx : cx = core x := Option.some.inj (e.symm.trans (pcore_eq_core x))
+    ⟨core y, pcore_eq_core y, hcx ▸ h x y hxy⟩
+
+section extensionLaws
+variable [ExtensionLaws α]
+
+@[rocq_alias cmra_pcore_mono]
+theorem pcore_mono_ext {x y : α} :
+    x ≼ₑ y → pcore x = some cx → ∃ cy, pcore y = some cy ∧ cx ≼ₑ cy
+  | ⟨_, hw⟩, e =>
+    have ⟨z, hz⟩ := pcore_op_mono e _
+    let ⟨t, ht, et⟩ := OFE.equiv_some ((congrArg pcore hw).trans hz)
+    ⟨t, ht, z, et⟩
+
+@[rocq_alias cmra_pcore_mono']
+theorem pcore_mono_ext' {x y : α} {cx} (le : x ≼ₑ y) (e : pcore x = some cx) :
+    ∃ cy, pcore y = some cy ∧ cx ≼ₑ cy :=
+  pcore_mono_ext le e
+
+@[rocq_alias cmra_pcore_monoN']
+theorem pcore_monoN_ext' {n} {x y : α} {cx} :
+    x ≼ₑ{n} y → pcore x ≡{n}≡ some cx → ∃ cy, pcore y = some cy ∧ cx ≼ₑ{n} cy
+  | ⟨z, hz⟩, e =>
+    let ⟨w, hw, ew⟩ := OFE.dist_some e
+    let ⟨t, ht, (et : w ≼ₑ t)⟩ := pcore_mono_ext (incExt_op_left x z) hw
+    have : pcore y ≡{n}≡ some t :=
+      have : pcore y ≡{n}≡ pcore (x • z) := NonExpansive.ne hz
+      ht ▸ this
+    let ⟨r, hr, er⟩ := OFE.dist_some this
+    suffices h : cx ≼ₑ{n} r from ⟨r, hr, h⟩
+    calc
+      cx ≡{n}≡ w := ew
+      w  ≼ₑ{n}  t := incExtN_of_incExt n et
+      t  ≡{n}≡ r := er
+
+theorem pcore_monoN_ext {n} {x y : α} {cx} (h : x ≼ₑ{n} y) (e : pcore x = some cx) :
+    ∃ cy, pcore y = some cy ∧ cx ≼ₑ{n} cy :=
+  pcore_monoN_ext' h (Dist.of_eq e)
+
+section total
+variable [IsTotal α]
+
+@[rocq_alias cmra_core_monoN]
+theorem core_incExtN_core {n} {x y : α} (inc : x ≼ₑ{n} y) : core x ≼ₑ{n} core y := by
+  let ⟨cy, hcy, icy⟩ := pcore_monoN_ext' inc (Dist.of_eq (pcore_eq_core x))
+  cases (pcore_eq_core _).symm.trans hcy
+  exact icy
+
+theorem core_op_mono_ext (x y : α) : core x ≼ₑ core (x • y) := by
+  have ⟨cy, hcy⟩ := pcore_op_mono (pcore_eq_core x) y
+  simp [pcore_eq_core] at hcy
+  exact ⟨_, hcy⟩
+
+@[rocq_alias cmra_core_mono]
+theorem core_mono_ext {x y : α} (Hinc : x ≼ₑ y) : core x ≼ₑ core y := by
+  have ⟨z, hz⟩ := Hinc
+  rw [hz]; exact core_op_mono_ext x z
+
+end total
+end extensionLaws
+
+section extOrder
+attribute [local instance] extOrderN
+
+/-- Under the extension order, the order is the extension inclusion. -/
+theorem incExt_iff_inc {x y : α} : x ≼ₑ y ↔ x ≼ y := .rfl
+
+/-- Under the extension order, the step-indexed order is the extension inclusion. -/
+theorem incExtN_iff_incN {n} {x y : α} : x ≼ₑ{n} y ↔ x ≼{n} y := .rfl
+
+/-- Every element is increasing for the extension inclusion. -/
+theorem increasing_ext (x : α) : Increasing x where
+  increasing y := incExt_op_right x y
+
+instance [IsTotal α] : IncRefl α where
+  inc_refl := incExt_refl
+
+variable [ExtensionLaws α]
+
+/-- Every classical resource algebra is an ordered resource algebra under its extension
+inclusion. -/
+@[reducible] def _root_.Iris.CMRA.withExtensionOrder : CMRA α where
+  toOrderN := extOrderN
+  op_monoN_left := op_monoN_left_ext
+  op_mono_left := op_mono_left_ext
+  validN_of_incN := validN_of_incExtN
+  pcore_monoN := pcore_monoN_ext
+  pcore_mono := pcore_mono_ext
+  pcore_order_op {_ cx} e y :=
+    let ⟨cy, hcy⟩ := pcore_op_mono e y
+    ⟨cx • cy, hcy, incExt_op_left cx cy⟩
+  pcore_increasing _ := increasing_ext _
+  increasing_closed _ _ := increasing_ext _
+  incN_extend := incExtN_extend
+
+end extOrder
+end RABase
+
+/-! ## Discrete and affine algebras -/
+
+namespace CMRA
+variable [CMRA α]
+
+@[rocq_alias CmraDiscrete]
+class Discrete (α : Type _) [CMRA α] extends OFE.Discrete α where
+  discrete_valid {x : α} : ✓{0} x → ✓ x
+  discrete_inc {x y : α} : x ≼{0} y → x ≼ y
+export Discrete (discrete_valid discrete_inc)
+#rocq_ignore discrete_validN_instance "Use CMRA instance"
+
+/-- An affine algebra: every element is increasing, i.e. the extension inclusion is contained
+in the order. Classical resource algebras are affine (`RABase.affine_withExtensionOrder`), and
+`UPred M` is a `BIAffine` exactly when `M` is affine. -/
+class Affine (α : Type _) [CMRA α] : Prop where
+  increasing (x : α) : Increasing x
+
+instance [Affine α] (x : α) : Increasing x := Affine.increasing x
+
+end CMRA
+
+instance RABase.affine_withExtensionOrder [RABase α] [RABase.ExtensionLaws α] :
+    @CMRA.Affine α CMRA.withExtensionOrder :=
+  letI := CMRA.withExtensionOrder (α := α)
+  { increasing := RABase.increasing_ext }
+
+/-! ## Unital algebras -/
+
+/-- The unit of a classical unital resource algebra; the input of `UCMRA.withExtensionOrder`. -/
+class Unital (α : Type _) extends RABase α where
+  unit : α
+  unit_valid : ✓ unit
+  unit_left_id : unit • x = x
+  pcore_unit : pcore unit = some unit
+
+/-- A unital ordered resource algebra: an ordered resource algebra with a unit, whose order is
+reflexive. -/
+@[rocq_alias ucmra]
+class UCMRA (α : Type _) extends CMRA α, Unital α, IncRefl α
+
+#rocq_ignore Unit "Lean uses the UCMRA.unit field; no separate class needed."
+#rocq_ignore UcmraMixin "Lean uses the UCMRA type class directly; mixin/bundle separation is unnecessary."
+#rocq_ignore ucmra_cmraR "Folded into Lean's UCMRA extends CMRA."
+#rocq_ignore ucmra_ofeO "Folded into Lean's UCMRA → OFE."
+
+/-- Every classical unital resource algebra is a unital ordered resource algebra under its
+extension inclusion. -/
+@[reducible] def UCMRA.withExtensionOrder [Unital α] [RABase.ExtensionLaws α] : UCMRA α where
+  toCMRA := CMRA.withExtensionOrder
+  unit := Unital.unit
+  unit_valid := Unital.unit_valid
+  unit_left_id := Unital.unit_left_id
+  pcore_unit := Unital.pcore_unit
+  inc_refl _ := ⟨Unital.unit, (Op.comm.trans Unital.unit_left_id).symm⟩
+
+/-- An element that behaves as a unit: valid, a left identity, and its own core. The
+element-level counterpart of `Unital`; `UCMRA.unit` satisfies it. -/
+class IsUnit [RABase α] (ε : α) : Prop where
+  unit_valid : ✓ ε
+  unit_left_id : ε • x = x
+  pcore_unit : CMRA.pcore ε = some ε
+
+instance [UCMRA α] : IsUnit (UCMRA.unit : α) where
+  unit_valid := UCMRA.unit_valid
+  unit_left_id := UCMRA.unit_left_id
+  pcore_unit := UCMRA.pcore_unit
+
+namespace CMRA
+variable [CMRA α]
+
+export UCMRA (unit unit_valid unit_left_id pcore_unit)
+
+/-! ## Order -/
+
+section orderN
+omit [CMRA α]
+variable [OFE α] [OrderN α]
+
+theorem incN_of_incN_of_dist (h : (a : α) ≼{n} b) (e : b ≡{n}≡ c) : a ≼{n} c :=
+  incN_ne .rfl e h
+
+instance {n : Nat} : Trans (IncludedN (α := α) n) (Dist n) (IncludedN n) where
+  trans := incN_of_incN_of_dist
+
+theorem incN_of_dist_of_incN (e : (a : α) ≡{n}≡ b) (h : b ≼{n} c) : a ≼{n} c :=
+  incN_ne e.symm .rfl h
+
+instance {n : Nat} : Trans (Dist (α := α) n) (IncludedN n) (IncludedN n) where
+  trans := incN_of_dist_of_incN
+
+theorem _root_.Iris.OrderN.Included.incN {n} {x y : α} : x ≼ y → x ≼{n} y := incN_of_inc _
+
+theorem incN_iff_left (e : (a : α) ≡{n}≡ b) : a ≼{n} c ↔ b ≼{n} c :=
+  ⟨incN_ne e .rfl, incN_ne e.symm .rfl⟩
+theorem _root_.Iris.OFE.Dist.incN_l : (a : α) ≡{n}≡ b → (a ≼{n} c ↔ b ≼{n} c) := incN_iff_left
+
+theorem incN_iff_right (e : (b : α) ≡{n}≡ c) : a ≼{n} b ↔ a ≼{n} c :=
+  ⟨incN_ne .rfl e, incN_ne .rfl e.symm⟩
+theorem _root_.Iris.OFE.Dist.incN_r : (b : α) ≡{n}≡ c → (a ≼{n} b ↔ a ≼{n} c) := incN_iff_right
+
+theorem incN_dist_iff (ea : (a : α) ≡{n}≡ a') (eb : (b : α) ≡{n}≡ b') : a ≼{n} b ↔ a' ≼{n} b' :=
+  ⟨incN_ne ea eb, incN_ne ea.symm eb.symm⟩
+theorem _root_.Iris.OFE.Dist.incN :
+    (a : α) ≡{n}≡ a' → b ≡{n}≡ b' → (a ≼{n} b ↔ a' ≼{n} b') := incN_dist_iff
+
+theorem _root_.Iris.OrderN.Included.trans : (x : α) ≼ y → y ≼ z → x ≼ z := inc_trans
+
+instance : Trans (Included (α := α)) Included Included where
+  trans := inc_trans
+
+theorem _root_.Iris.OrderN.IncludedN.trans : (x : α) ≼{n} y → y ≼{n} z → x ≼{n} z :=
+  incN_trans
+
+instance : Trans (IncludedN (α := α) n) (IncludedN n) (IncludedN n) where
+  trans := incN_trans
+
+theorem incN_of_incN_le {n n'} {x y : α} (l1 : n' ≤ n) : x ≼{n} y → x ≼{n'} y :=
+  l1.recOn id fun _ ih h => ih (incN_succ h)
+theorem inc0_of_incN {n} {x y : α} : x ≼{n} y → x ≼{0} y := incN_of_incN_le (Nat.zero_le n)
+theorem _root_.Iris.OrderN.IncludedN.le {n n'} {x y : α} :
+    n' ≤ n → x ≼{n} y → x ≼{n'} y := incN_of_incN_le
+
+theorem incN_of_incN_succ {n} {x y : α} : x ≼{n.succ} y → x ≼{n} y := incN_succ
+theorem _root_.Iris.OrderN.IncludedN.succ {n} {x y : α} : x ≼{n.succ} y → x ≼{n} y :=
+  incN_succ
+
+section incRefl
+variable [IncRefl α]
+
+theorem incN_refl (x : α) : x ≼{n} x := (inc_refl x).incN
+@[refl] theorem _root_.Iris.OrderN.Included.rfl {x : α} : x ≼ x := inc_refl x
+@[refl] theorem _root_.Iris.OrderN.IncludedN.rfl {x : α} : x ≼{n} x := incN_refl x
+
+theorem incN_of_dist {n} {x y : α} (h : x ≡{n}≡ y) : x ≼{n} y := incN_ne .rfl h (incN_refl x)
+theorem _root_.Iris.OFE.Dist.to_incN {n} {x y : α} : x ≡{n}≡ y → x ≼{n} y := incN_of_dist
+
+end incRefl
+
+end orderN
+
+theorem valid_of_inc {x y : α} (h : x ≼ y) : ✓ y → ✓ x :=
+  valid_mapN fun n => validN_of_incN (incN_of_inc n h)
+
+theorem _root_.Iris.OrderN.IncludedN.validN {n} {x y : α} : x ≼{n} y → ✓{n} y → ✓{n} x :=
+  validN_of_incN
+
+theorem validN_of_inc {n} {x y : α} (h : x ≼ y) : ✓{n} y → ✓{n} x :=
+  validN_of_incN (incN_of_inc n h)
+theorem _root_.Iris.OrderN.Included.validN {n} {x y : α} : x ≼ y → ✓{n} y → ✓{n} x :=
+  validN_of_inc
+
+theorem pcore_mono' {x y : α} {cx} (le : x ≼ y) (e : pcore x = some cx) :
+    ∃ cy, pcore y = some cy ∧ cx ≼ cy :=
+  pcore_mono le e
+
+theorem pcore_monoN' {n} {x y : α} {cx} (h : x ≼{n} y) (e : pcore x ≡{n}≡ some cx) :
+    ∃ cy, pcore y = some cy ∧ cx ≼{n} cy :=
+  let ⟨_, hw, ew⟩ := OFE.dist_some e
+  let ⟨cy, hcy, hi⟩ := pcore_monoN h hw
+  ⟨cy, hcy, incN_of_dist_of_incN ew hi⟩
+
+theorem op_monoN_right {n x y} (z : α) (h : x ≼{n} y) : z • x ≼{n} z • y :=
+  (op_commN.incN op_commN).1 (op_monoN_left z h)
+
+theorem op_mono_right {x y} (z : α) (h : x ≼ y) : z • x ≼ z • y := by
+  rw [comm' (x := z) (y := x), comm' (x := z) (y := y)]; exact op_mono_left z h
+
+theorem op_monoN {n} {x x' y y' : α} (hx : x ≼{n} x') (hy : y ≼{n} y') : x • y ≼{n} x' • y' :=
+  (op_monoN_left _ hx).trans (op_monoN_right _ hy)
+
+theorem op_mono {x x' y y' : α} (hx : x ≼ x') (hy : y ≼ y') : x • y ≼ x' • y' :=
+  (op_mono_left _ hx).trans (op_mono_right _ hy)
+
+theorem op?_monoN_left {n} {x y : α} (mz : Option α) (h : x ≼{n} y) : x •? mz ≼{n} y •? mz :=
+  match mz with
+  | none => h
+  | some z => op_monoN_left z h
+
+theorem op?_mono_left {x y : α} (mz : Option α) (h : x ≼ y) : x •? mz ≼ y •? mz :=
+  match mz with
+  | none => h
+  | some z => op_mono_left z h
+
+theorem _root_.Iris.OrderN.IncludedNR.op_left {n} {x y : α} (z : α) :
+    x ≼*{n} y → x • z ≼*{n} y • z
+  | .inl e => .inl e.op_l
+  | .inr h => .inr (op_monoN_left z h)
+
+theorem _root_.Iris.OrderN.IncludedR.op_left {x y : α} (z : α) : x ≼* y → x • z ≼* y • z
+  | .inl e => .inl (e ▸ rfl)
+  | .inr h => .inr (op_mono_left z h)
+
+theorem _root_.Iris.OrderN.IncludedNR.validN {n} {x y : α} : x ≼*{n} y → ✓{n} y → ✓{n} x
+  | .inl e, v => validN_ne e.symm v
+  | .inr h, v => validN_of_incN h v
+
+theorem _root_.Iris.OrderN.IncludedR.validN {n} {x y : α} : x ≼* y → ✓{n} y → ✓{n} x
+  | .inl e, v => e ▸ v
+  | .inr h, v => validN_of_inc h v
+
+/-- Extension of a composition along the step index. -/
+theorem op_extend {n} {x y₁ y₂ : α} (v : ✓{n} x) (h : y₁ • y₂ ≼{n} x) :
+    ∃ z₁ z₂ : α, z₁ • z₂ ≼{n.succ} x ∧
+      z₁ ≡{n}≡ y₁ ∧ z₂ ≡{n}≡ y₂ :=
+  let ⟨_, hx', e⟩ := incN_extend v h
+  let ⟨z₁, z₂, hz, hz₁, hz₂⟩ := extend (validN_of_incN (incN_succ hx') v) e
+  ⟨z₁, z₂, hz ▸ hx', hz₁, hz₂⟩
+
+/-! ## Increasing elements -/
+
+theorem Increasing.of_incNR {n} {x y : α} (h : Increasing x) (hxy : x ≼*{n} y) : Increasing y :=
+  increasing_closed h hxy
+theorem Increasing.of_dist {n} {x y : α} (h : Increasing x) (e : x ≡{n}≡ y) : Increasing y :=
+  h.of_incNR (.inl e)
+theorem Increasing.of_incN {n} {x y : α} (h : Increasing x) (hxy : x ≼{n} y) : Increasing y :=
+  h.of_incNR (.inr hxy)
+theorem Increasing.of_inc {x y : α} (h : Increasing x) (hxy : x ≼ y) : Increasing y :=
+  h.of_incN (incN_of_inc 0 hxy)
+theorem Increasing.of_incR {x y : α} (h : Increasing x) : x ≼* y → Increasing y
+  | .inl e => e ▸ h
+  | .inr hxy => h.of_inc hxy
+
+theorem Increasing.incN {n} {x : α} (h : Increasing x) (y : α) : y ≼{n} x • y :=
+  incN_of_inc n (h.increasing y)
+
+instance (x : α) [CoreId x] : Increasing x := pcore_increasing core_id
+
+instance Increasing.op (x y : α) [Increasing x] [Increasing y] : Increasing (x • y) where
+  increasing z := calc
+    z ≼ y • z := Increasing.increasing z
+    _ ≼ x • (y • z) := Increasing.increasing _
+    _ = (x • y) • z := assoc'
+
+section total
+variable [IsTotal α]
+
+theorem core_incN_core {n} {x y : α} (inc : x ≼{n} y) : core x ≼{n} core y := by
+  let ⟨cy, hcy, icy⟩ := pcore_monoN inc (pcore_eq_core x)
+  cases (pcore_eq_core _).symm.trans hcy
+  exact icy
+
+theorem core_mono {x y : α} (inc : x ≼ y) : core x ≼ core y := by
+  let ⟨cy, hcy, icy⟩ := pcore_mono inc (pcore_eq_core x)
+  cases (pcore_eq_core _).symm.trans hcy
+  exact icy
+
+theorem core_op_mono (x y : α) : core x ≼ core (x • y) :=
+  let ⟨_, hcxy, h⟩ := pcore_order_op (pcore_eq_core x) y
+  Option.some.inj (hcxy.symm.trans (pcore_eq_core _)) ▸ h
+
+instance increasing_core (x : α) : Increasing (core x) := pcore_increasing (pcore_eq_core x)
+
+end total
+
+/-! ## Affine algebras -/
+
+section affine
+variable [Affine α]
+
+theorem inc_op_right (x y : α) : y ≼ x • y := (Affine.increasing x).increasing y
+theorem inc_op_left (x y : α) : x ≼ x • y := comm' (x := y) (y := x) ▸ inc_op_right y x
+theorem incN_op_left (n) (x y : α) : x ≼{n} x • y := (inc_op_left x y).incN
+theorem incN_op_right (n) (x y : α) : y ≼{n} x • y := (inc_op_right x y).incN
+
+/-- In an affine algebra the extension inclusion is contained in the order. -/
+theorem incN_of_incExtN {n} {x y : α} : x ≼ₑ{n} y → x ≼{n} y
+  | ⟨z, hz⟩ => incN_ne .rfl hz.symm (incN_op_left n x z)
+theorem inc_of_incExt {x y : α} : x ≼ₑ y → x ≼ y
+  | ⟨z, hz⟩ => hz ▸ inc_op_left x z
+
+theorem pcore_inc_self {x : α} {cx} (e : pcore x = some cx) : cx ≼ x :=
+  pcore_op_left e ▸ inc_op_left cx x
+
+theorem core_inc_self [IsTotal α] {x : α} : core x ≼ x := pcore_inc_self (pcore_eq_core x)
+
+end affine
 
 section discreteCMRA
-
-variable {α : Type _} [CMRA α]
 
 @[rocq_alias cmra_discrete_valid_iff]
 theorem valid_iff_validN' [Discrete α] (n) {x : α} : ✓ x ↔ ✓{n} x :=
@@ -700,20 +1207,15 @@ theorem valid_iff_validN' [Discrete α] (n) {x : α} : ✓ x ↔ ✓{n} x :=
 theorem valid_0_iff_validN [Discrete α] (n) {x : α} : ✓{0} x ↔ ✓{n} x :=
   ⟨Valid.validN ∘ discrete_valid, validN_of_le (Nat.zero_le n)⟩
 
-@[rocq_alias cmra_discrete_included_iff]
-theorem inc_iff_incN [OFE.Discrete α] (n) {x y : α} : x ≼ y ↔ x ≼{n} y :=
-  ⟨incN_of_inc _, fun ⟨z, hz⟩ => ⟨z, discrete hz⟩⟩
+theorem inc_iff_incN [Discrete α] (n) {x y : α} : x ≼ y ↔ x ≼{n} y :=
+  ⟨incN_of_inc _, fun h => discrete_inc (inc0_of_incN h)⟩
 
-@[rocq_alias cmra_discrete_included_iff_0]
-theorem inc_0_iff_incN [OFE.Discrete α] (n) {x y : α} : x ≼{0} y ↔ x ≼{n} y :=
-  ⟨fun ⟨z, hz⟩ => ⟨z, (discrete hz).dist⟩,
-   fun a => incN_of_incN_le (Nat.zero_le n) a⟩
+theorem inc_0_iff_incN [Discrete α] (n) {x y : α} : x ≼{0} y ↔ x ≼{n} y :=
+  ⟨fun h => incN_of_inc n (discrete_inc h), inc0_of_incN⟩
 
 end discreteCMRA
 
 section cancelableElements
-
-variable {α : Type _} [CMRA α]
 
 @[rocq_alias cancelable]
 theorem cancelable {x y z : α} [Cancelable x] (v : ✓(x • y)) (e : x • y = x • z) : y = z :=
@@ -746,8 +1248,6 @@ theorem op_opM_cancel_dist {x y z : α} [Cancelable x]
 end cancelableElements
 
 section idFreeElements
-
-variable {α : Type _} [CMRA α]
 
 theorem IdFree.of_dist {x₁ x₂ : α} {n} (e : x₁ ≡{n}≡ x₂) (h : IdFree x₁) : IdFree x₂ where
   id_free0_r z v := fun h₂ =>
@@ -799,19 +1299,12 @@ instance exclusive_idFree {x : α} [Exclusive x] : IdFree x where
 
 end idFreeElements
 
-
 section ucmra
 
 variable {α : Type _} [UCMRA α]
 
 @[rocq_alias ucmra_unit_validN]
 theorem unit_validN {n} : ✓{n} (unit : α) := valid_iff_validN.mp (unit_valid) n
-
-@[rocq_alias ucmra_unit_leastN]
-theorem incN_unit {n} {x : α} : unit ≼{n} x := ⟨x, unit_left_id.symm.dist⟩
-
-@[rocq_alias ucmra_unit_least]
-theorem inc_unit {x : α} : unit ≼ x := ⟨x, unit_left_id.symm⟩
 
 theorem unit_left_id_dist {n} (x : α) : unit • x ≡{n}≡ x := unit_left_id.dist
 
@@ -820,15 +1313,22 @@ theorem unit_right_id {x : α} : x • unit = x := comm'.trans unit_left_id
 
 theorem unit_right_id_dist (x : α) : x • unit ≡{n}≡ x := comm'.dist.trans (unit_left_id_dist x)
 
+@[rocq_alias ucmra_unit_leastN]
+theorem _root_.Iris.RABase.incExtN_unit {n} {x : α} : unit ≼ₑ{n} x :=
+  ⟨x, unit_left_id.symm.dist⟩
+
+@[rocq_alias ucmra_unit_least]
+theorem _root_.Iris.RABase.incExt_unit {x : α} : unit ≼ₑ x := ⟨x, unit_left_id.symm⟩
+
 @[rocq_alias ucmra_unit_core_id]
 instance unit_CoreId : CoreId (unit : α) where
   core_id := pcore_unit
 
 @[rocq_alias cmra_unit_cmra_total]
 instance unit_total : IsTotal α where
-  total _ :=
-    have ⟨y, hy, _⟩ := pcore_mono' inc_unit pcore_unit
-    ⟨y, hy⟩
+  total x :=
+    let ⟨cx, hcx, _⟩ := pcore_order_op (pcore_unit (α := α)) x
+    ⟨cx, unit_left_id (x := x) ▸ hcx⟩
 
 @[rocq_alias empty_cancelable]
 instance empty_cancelable : Cancelable (unit : α) where
@@ -837,8 +1337,30 @@ instance empty_cancelable : Cancelable (unit : α) where
     _ ≡{n}≡ unit • t := e
     _ ≡{n}≡ t := unit_left_id.dist
 
-theorem _root_.Iris.OFE.Dist.to_incN {n} {x y : α} (H : x ≡{n}≡ y) : x ≼{n} y :=
-  ⟨unit, (unit_right_id.dist.trans H).symm⟩
+/-- In a unital algebra, an element is increasing exactly when it lies above the unit. -/
+theorem increasing_iff_unit_inc {x : α} : Increasing x ↔ unit ≼ x :=
+  ⟨fun h => unit_right_id (x := x) ▸ h.increasing unit,
+   fun h => ⟨fun y => calc
+    y = unit • y := unit_left_id.symm
+    _ ≼ x • y := op_mono_left y h⟩⟩
+
+/-- The step-indexed form of `increasing_iff_unit_inc`: elements above the unit are increasing. -/
+theorem incN_op_right_of_unit_incN {n} {x : α} (y : α) (h : unit ≼{n} x) : y ≼{n} x • y :=
+  calc y ≡{n}≡ unit • y := (unit_left_id_dist y).symm
+    _ ≼{n} x • y := op_monoN_left y h
+
+theorem unit_inc_core (x : α) : unit ≼ core x := increasing_iff_unit_inc.mp (increasing_core x)
+
+theorem unit_incN_core {n} (x : α) : unit ≼{n} core x := (unit_inc_core x).incN
+
+section affine
+variable [Affine α]
+
+theorem incN_unit {n} {x : α} : unit ≼{n} x := unit_left_id (x := x) ▸ incN_op_left n unit x
+
+theorem inc_unit {x : α} : unit ≼ x := unit_left_id (x := x) ▸ inc_op_left unit x
+
+end affine
 
 @[rocq_alias cmra_monoid]
 instance ucmraMonoidOps {α : Type _} [UCMRA α] : Algebra.MonoidOps (CMRA.op (α := α)) UCMRA.unit where
@@ -932,12 +1454,15 @@ end UCMRA
 section Hom
 
 /-- A morphism between CMRAs, written `α -C> β`, is defined to be a non-expansive function which
-preserves `validN`, `pcore` and `op`. -/
+preserves `validN`, `pcore`, `op`, the order and increasing elements. -/
 @[ext, rocq_alias CmraMorphism]
 structure Hom (α β : Type _) [CMRA α] [CMRA β] extends OFE.Hom α β where
   protected validN {n x} : ✓{n} x → ✓{n} (f x)
   protected pcore x : (pcore x).map f = pcore (f x)
   protected op x y : f (x • y) = f x • f y
+  protected monoN {n x₁ x₂} : x₁ ≼{n} x₂ → f x₁ ≼{n} f x₂
+  protected mono {x₁ x₂} : x₁ ≼ x₂ → f x₁ ≼ f x₂
+  protected increasing {x} : Increasing x → Increasing (f x)
 
 @[inherit_doc]
 infixr:25 " -C> " => Hom
@@ -960,6 +1485,9 @@ protected def Hom.id [CMRA α] : α -C> α where
   validN := id
   pcore x := by dsimp; cases pcore x <;> rfl
   op _ _ := rfl
+  monoN := id
+  mono := id
+  increasing := id
 
 @[rocq_alias cmra_morphism_compose]
 protected def Hom.comp [CMRA β] [CMRA γ] (g : β -C> γ) (f : α -C> β) : α -C> γ where
@@ -967,6 +1495,9 @@ protected def Hom.comp [CMRA β] [CMRA γ] (g : β -C> γ) (f : α -C> β) : α 
   validN v := g.validN (f.validN v)
   pcore x := ((Option.map_map ..).symm.trans (congrArg _ (f.pcore x))).trans (g.pcore (f x))
   op x y := (congrArg g.f (f.op x y)).trans (g.op ..)
+  monoN h := g.monoN (f.monoN h)
+  mono h := g.mono (f.mono h)
+  increasing h := g.increasing (f.increasing h)
 
 #rocq_ignore cmra_morphism_proper "OFE is Leibniz; use equality"
 
@@ -977,11 +1508,13 @@ protected theorem Hom.core [CMRA β] (f : α -C> β) {x : α} : core (f x) = f (
   cases hx : pcore x <;> rw [hx] at h <;> simp only [Option.map] at h <;> simp [← h]
 
 @[rocq_alias cmra_morphism_mono]
-protected theorem Hom.mono [CMRA β] (f : α -C> β) {x₁ x₂ : α} : x₁ ≼ x₂ → f x₁ ≼ f x₂
+protected theorem Hom.mono_ext [CMRA β] (f : α -C> β) {x₁ x₂ : α} :
+    x₁ ≼ₑ x₂ → f x₁ ≼ₑ f x₂
   | ⟨z, hz⟩ => ⟨f.f z, (congrArg f.f hz).trans (f.op _ _)⟩
 
 @[rocq_alias cmra_morphism_monoN]
-protected theorem Hom.monoN [CMRA β] (f : α -C> β) n {x₁ x₂ : α} : x₁ ≼{n} x₂ → f x₁ ≼{n} f x₂
+protected theorem Hom.monoN_ext [CMRA β] (f : α -C> β) n {x₁ x₂ : α} :
+    x₁ ≼ₑ{n} x₂ → f x₁ ≼ₑ{n} f x₂
   | ⟨z, hz⟩ => ⟨f.f z, (f.ne.ne hz).trans (f.op _ _).dist⟩
 
 @[rocq_alias cmra_morphism_valid]
@@ -991,6 +1524,26 @@ protected theorem Hom.valid [CMRA β] (f : α -C> β) {x : α} (H : ✓ x) : ✓
 end Hom
 end CMRA
 
+section HomExt
+open RABase
+variable [RABase α] [ExtensionLaws α] [RABase β] [ExtensionLaws β]
+attribute [local instance] RABase.extOrderN CMRA.withExtensionOrder
+
+/-- A morphism between classical resource algebras needs only the classical fields: under the
+extension order, `monoN`, `mono` and `increasing` follow from `op`. -/
+@[reducible] def CMRA.Hom.withExtensionOrder (f : α -n> β)
+    (validN : ∀ {n} {x : α}, ✓{n} x → ✓{n} (f x))
+    (pcore : ∀ x, (CMRA.pcore x).map f = CMRA.pcore (f x))
+    (op : ∀ x y, f (x • y) = f x • f y) : α -C> β where
+  toHom := f
+  validN := validN
+  pcore := pcore
+  op := op
+  monoN | ⟨z, hz⟩ => ⟨f z, (f.ne.ne hz).trans (op _ _).dist⟩
+  mono | ⟨z, hz⟩ => ⟨f z, (congrArg f hz).trans (op _ _)⟩
+  increasing _ := increasing_ext _
+
+end HomExt
 
 section rFunctor
 
@@ -1052,6 +1605,13 @@ class URFunctorContractive (F : COFE.OFunctorPre) extends URFunctor F where
 attribute [reducible, instance] URFunctor.cmra
 
 #rocq_ignore urFunctor_apply "Just apply the underlying `OFunctorPre`"
+
+/-- A resource functor all of whose algebras are affine. The global ghost state of `IProp` is
+affine — so that `IProp` is an affine logic — exactly when every functor of its bundle is. -/
+class RFunctorAffine (F : COFE.OFunctorPre) [RFunctor F] : Prop where
+  affine [COFE α] [COFE β] : CMRA.Affine (F α β)
+
+attribute [instance] RFunctorAffine.affine
 
 @[rocq_alias urFunctor_to_rFunctor]
 instance URFunctor.toRFunctor [UF : URFunctor F] : RFunctor F where
@@ -1116,6 +1676,9 @@ instance urFunctorComposeOF [URFunctor F₁] : URFunctor (ComposeOF F₁ F₂) w
     simp only [map_comp_eq]
     exact URFunctor.map_comp (F := F₁) _ _ _ _ _
 
+instance [RFunctor F₁] [RFunctorAffine F₁] : RFunctorAffine (ComposeOF F₁ F₂) where
+  affine := RFunctorAffine.affine (F := F₁)
+
 open OFunctor in
 @[rocq_alias rFunctor_oFunctor_compose_contractive_1]
 instance rFunctorComposeOF_contractive_left [RFunctorContractive F₁] :
@@ -1171,6 +1734,10 @@ instance COFE.OFunctor.constOF_RFunctor [CMRA B] : RFunctor (constOF B) where
   map_id _ := rfl
   map_comp _ _ _ _ _ := rfl
 
+instance COFE.OFunctor.constOF_RFunctorAffine [CMRA B] [CMRA.Affine B] :
+    RFunctorAffine (constOF B) where
+  affine := inferInstance
+
 @[rocq_alias constRF_contractive]
 instance OFunctor.constOF_RFunctorContractive [CMRA B] :
     RFunctorContractive (constOF B) where
@@ -1220,9 +1787,32 @@ open CMRA
 #rocq_ignore discrete_fun_validN_instance "Use CMRA instance"
 #rocq_ignore discrete_fun_cmra_mixin "Use CMRA instance"
 
-@[rocq_alias discrete_funR]
-instance cmraDiscreteFunO {α : Type _} (β : α → Type _)
-    [∀ x, CMRA (β x)] [∀ x, IsTotal (β x)] : CMRA (∀ x, β x) where
+namespace DiscreteFun
+
+variable {α : Type _} {β : α → Type _}
+
+section
+variable [∀ x, CMRA (β x)]
+
+/-- The pointwise order on functions. -/
+@[reducible] def orderN : OrderN (∀ x, β x) where
+  IncludedN n f g := ∀ x, f x ≼{n} g x
+  Included f g := ∀ x, f x ≼ g x
+  incN_ne ef eg h x := incN_ne (ef x) (eg x) (h x)
+  incN_succ h x := incN_succ (h x)
+  incN_trans h₁ h₂ x := incN_trans (h₁ x) (h₂ x)
+  inc_trans h₁ h₂ x := inc_trans (h₁ x) (h₂ x)
+  incN_of_inc n h x := incN_of_inc n (h x)
+
+attribute [local instance] orderN
+
+theorem incNR_apply {n} {f g : ∀ x, β x} (h : f ≼*{n} g) (x : α) : f x ≼*{n} g x :=
+  h.imp (· x) (· x)
+
+variable [∀ x, IsTotal (β x)]
+
+/-- The pointwise resource algebra on functions. -/
+@[reducible] def raBase : RABase (∀ x, β x) where
   pcore f := some fun x => core (f x)
   op f g x := f x • g x
   ValidN n f := ∀ x, ✓{n} f x
@@ -1238,28 +1828,55 @@ instance cmraDiscreteFunO {α : Type _} (β : α → Type _)
   pcore_op_left := by rintro f _ ⟨⟩; exact funext fun x => core_op (f x)
   pcore_idem := by
     rintro f _ ⟨⟩; exact congrArg some (funext fun x => core_idem (f x))
-  pcore_op_mono := by
-    rintro f _ ⟨⟩ g
-    exact ⟨fun x => core (f x • g x), congrArg some (funext fun x =>
-      (op_core_right_of_inc (core_op_mono (f x) (g x))).symm)⟩
   extend {n f f1 f2} Hv He := by
     let F x := extend (Hv x) (He x)
     exact ⟨fun x => (F x).1, fun x => (F x).2.1,
       funext fun x => (F x).2.2.1, fun x => (F x).2.2.2.1, fun x => (F x).2.2.2.2⟩
 
+attribute [local instance] raBase
+
+open Classical in
+theorem increasing_apply {f : ∀ x, β x} (h : Increasing f) (x : α) : Increasing (f x) where
+  increasing y := by
+    let g : ∀ x', β x' := fun x' => if e : x' = x then e ▸ y else f x'
+    have hg : g x = y := dif_pos rfl
+    rw [← hg]
+    exact h.increasing g x
+
+theorem increasing_iff {f : ∀ x, β x} : Increasing f ↔ ∀ x, Increasing (f x) :=
+  ⟨increasing_apply, fun h => { increasing := fun g x => (h x).increasing (g x) }⟩
+
+variable (β) in
+@[rocq_alias discrete_funR]
+instance _root_.Iris.cmraDiscreteFunO : CMRA (∀ x, β x) where
+  toRABase := raBase
+  toOrderN := orderN
+  op_monoN_left h H x := op_monoN_left (h x) (H x)
+  op_mono_left h H x := op_mono_left (h x) (H x)
+  validN_of_incN H V x := validN_of_incN (H x) (V x)
+  pcore_monoN := by rintro n f g _ H ⟨⟩; exact ⟨_, rfl, fun x => core_incN_core (H x)⟩
+  pcore_mono := by rintro f g _ H ⟨⟩; exact ⟨_, rfl, fun x => core_mono (H x)⟩
+  pcore_order_op := by rintro f _ ⟨⟩ g; exact ⟨_, rfl, fun x => core_op_mono (f x) (g x)⟩
+  pcore_increasing := by rintro f _ ⟨⟩; exact increasing_iff.mpr fun x => inferInstance
+  increasing_closed H₁ H₂ :=
+    increasing_iff.mpr fun x => increasing_closed (increasing_apply H₁ x) (incNR_apply H₂ x)
+  incN_extend V H :=
+    let ⟨z, hz⟩ := Classical.skolem.mp fun x => incN_extend (V x) (H x)
+    ⟨z, fun x => (hz x).1, fun x => (hz x).2⟩
+
+end
+
 #rocq_ignore discrete_fun_unit_instance "Use UCMRA instance"
 #rocq_ignore discrete_fun_ucmra_mixin "Use UCMRA instance"
 
+variable (β) in
 @[rocq_alias discrete_funUR]
-instance ucmraDiscreteFunO {α : Type _} (β : α → Type _) [∀ x, UCMRA (β x)] : UCMRA (∀ x, β x) where
+instance _root_.Iris.ucmraDiscreteFunO [∀ x, UCMRA (β x)] : UCMRA (∀ x, β x) where
   unit _ := unit
   unit_valid _ := unit_valid
   unit_left_id := funext fun _ => unit_left_id
   pcore_unit := congrArg some (funext fun _ => core_eqv_self _)
-
-namespace DiscreteFun
-
-variable {α : Type _} {β : α → Type _}
+  inc_refl f x := inc_refl (f x)
 
 @[rocq_alias discrete_fun_lookup_op]
 theorem op_apply [∀ x, CMRA (β x)] [∀ x, IsTotal (β x)] (f g : ∀ x, β x) (x : α) :
@@ -1279,16 +1896,37 @@ instance [∀ x, UCMRA (β x)] [∀ x, OFE.DiscreteE (unit : β x)] :
 
 variable [∀ x, CMRA (β x)] [∀ x, IsTotal (β x)]
 
+theorem inc_apply {f g : ∀ x, β x} (h : f ≼ g) (x : α) : f x ≼ g x := h x
+
+theorem inc_iff {f g : ∀ x, β x} : f ≼ g ↔ ∀ x, f x ≼ g x := .rfl
+
+theorem incN_iff {n} {f g : ∀ x, β x} : f ≼{n} g ↔ ∀ x, f x ≼{n} g x := .rfl
+
 @[rocq_alias discrete_fun_included_spec_1]
-theorem inc_apply {f g : ∀ x, β x} : f ≼ g → ∀ x, f x ≼ g x
+theorem incExt_apply {f g : ∀ x, β x} : f ≼ₑ g → ∀ x, f x ≼ₑ g x
   | ⟨h, hh⟩, x => ⟨h x, congrFun hh x⟩
 
 /-- Note: The finiteness assumption from Iris-Rocq is removed using choice. -/
 @[rocq_alias discrete_fun_included_spec]
-theorem inc_iff {f g : ∀ x, β x} : f ≼ g ↔ ∀ x, f x ≼ g x := by
-  refine ⟨inc_apply, fun h => ?_⟩
+theorem incExt_iff {f g : ∀ x, β x} : f ≼ₑ g ↔ ∀ x, f x ≼ₑ g x := by
+  refine ⟨incExt_apply, fun h => ?_⟩
   obtain ⟨z, hz⟩ := Classical.skolem.mp h
   exact ⟨z, funext hz⟩
+
+theorem incExtN_apply {n} {f g : ∀ x, β x} : f ≼ₑ{n} g → ∀ x, f x ≼ₑ{n} g x
+  | ⟨h, hh⟩, x => ⟨h x, hh x⟩
+
+/-- Note: The finiteness assumption from Iris-Rocq is removed using choice. -/
+theorem incExtN_iff {n} {f g : ∀ x, β x} : f ≼ₑ{n} g ↔ ∀ x, f x ≼ₑ{n} g x := by
+  refine ⟨incExtN_apply, fun h => ?_⟩
+  obtain ⟨z, hz⟩ := Classical.skolem.mp h
+  exact ⟨z, hz⟩
+
+instance [∀ x, IncRefl (β x)] : IncRefl (∀ x, β x) where
+  inc_refl f x := inc_refl (f x)
+
+instance [∀ x, Affine (β x)] : Affine (∀ x, β x) where
+  increasing f := increasing_iff.mpr fun x => Affine.increasing (f x)
 
 end DiscreteFun
 
@@ -1300,6 +1938,10 @@ def mapCodHomC {α : Type _} {β₁ β₂ : α → Type _}
   validN h x := (F x).validN (h x)
   pcore _ := congrArg some (funext fun x => (F x).core.symm)
   op f g := funext fun x => (F x).op (f x) (g x)
+  monoN h x := (F x).monoN (h x)
+  mono h x := (F x).mono (h x)
+  increasing h := DiscreteFun.increasing_iff.mpr fun x =>
+    (F x).increasing (DiscreteFun.increasing_apply h x)
 
 end DiscreteFunO
 
@@ -1315,10 +1957,18 @@ instance urFunctorDiscreteFunOF {C} (F : C → COFE.OFunctorPre) [∀ c, URFunct
       simp only [CMRA.pcore, Option.map]
       exact congrArg some (funext fun c => ((URFunctor.map f g).core).symm)
     op x y := funext fun c => (URFunctor.map f g).op (x c) (y c)
+    monoN h c := (URFunctor.map f g).monoN (h c)
+    mono h c := (URFunctor.map f g).mono (h c)
+    increasing h := DiscreteFun.increasing_iff.mpr fun c =>
+      (URFunctor.map f g).increasing (DiscreteFun.increasing_apply h c)
   }
   map_ne.ne := COFE.OFunctor.map_ne.ne
   map_id x := COFE.OFunctor.map_id x
   map_comp f g f' g' x := COFE.OFunctor.map_comp f g f' g' x
+
+instance {C} (F : C → COFE.OFunctorPre) [∀ c, URFunctor (F c)] [∀ c, RFunctorAffine (F c)] :
+    RFunctorAffine (DiscreteFunOF F) where
+  affine := inferInstance
 
 @[rocq_alias discrete_funURF_contractive]
 instance DiscreteFunOF_URFC {C} (F : C → COFE.OFunctorPre) [HURF : ∀ c, URFunctorContractive (F c)] :
@@ -1329,7 +1979,7 @@ end DiscreteFunURF
 
 section option
 
-open CMRA Option
+open CMRA RABase Option
 
 variable [CMRA α]
 
@@ -1353,13 +2003,32 @@ def optionValid : Option α → Prop
   | some x => ✓ x
   | none => True
 
+/-- The step-indexed order on `Option α`: `none` lies below `none` and below every increasing
+element, `some` is monotone up to `n`-equivalence, and nothing but `none` lies below `none`. -/
+@[simp]
+def optionIncludedN (n : Nat) : Option α → Option α → Prop
+  | none, none => True
+  | none, some y => Increasing y
+  | some x, some y => x ≼*{n} y
+  | some _, none => False
+
+/-- The order on `Option α`; see `optionIncludedN`. -/
+@[simp]
+def optionIncluded : Option α → Option α → Prop
+  | none, none => True
+  | none, some y => Increasing y
+  | some x, some y => x ≼* y
+  | some _, none => False
+
 #rocq_ignore option_op_instance "Use CMRA instance"
 #rocq_ignore option_pcore_instance "Use CMRA instance"
 #rocq_ignore option_valid_instance "Use CMRA instance"
 #rocq_ignore option_validN_instance "Use CMRA instance"
 
-@[rocq_alias optionR, rocq_alias option_cmra_mixin]
-instance cmraOption : CMRA (Option α) where
+namespace Option
+
+/-- The resource algebra on `Option α`. -/
+@[reducible] def raBase : RABase (Option α) where
   pcore x := some (optionCore x)
   op := optionOp
   ValidN := optionValidN
@@ -1396,14 +2065,6 @@ instance cmraOption : CMRA (Option α) where
     rintro (_|x) <;> simp
     rcases H : pcore x with _|y <;> simp
     exact pcore_idem H
-  pcore_op_mono := by
-    rintro (_|x) _ ⟨⟩ y <;> simp
-    cases H : pcore x
-    · simp only []; exact ⟨_, rfl⟩
-    obtain _|y := y <;> simp
-    · exact ⟨none, H⟩
-    obtain ⟨cy, H⟩ := pcore_op_mono H y
-    exact ⟨some cy, H⟩
   extend {n} := by
     rintro (_|x) (_|mb1) (_|mb2) Hx Hx' <;> simp at Hx' ⊢
     · exists none, none
@@ -1412,17 +2073,178 @@ instance cmraOption : CMRA (Option α) where
     · rcases extend Hx Hx' with ⟨mc1, mc2, hx, h1, h2⟩
       exact ⟨some mc1, some mc2, congrArg some hx, h1, h2⟩
 
+/-- The order on `Option α`. -/
+@[reducible] def orderN : OrderN (Option α) where
+  IncludedN := optionIncludedN
+  Included := optionIncluded
+  incN_ne {n x x' y y'} ex ey h := by
+    rcases x, x', y, y' with ⟨_|x, _|x', _|y, _|y'⟩ <;> simp_all [Dist, Option.Forall₂]
+    · exact h.of_dist ey
+    · exact OrderN.IncludedNR.ne ex ey h
+  incN_succ {n x y} h := by
+    rcases x, y with ⟨_|x, _|y⟩ <;> simp_all
+    exact OrderN.IncludedNR.succ h
+  incN_trans {n x y z} h₁ h₂ := by
+    rcases x, y, z with ⟨_|x, _|y, _|z⟩ <;> simp_all
+    · exact h₁.of_incNR h₂
+    · exact OrderN.IncludedNR.trans h₁ h₂
+  inc_trans {x y z} h₁ h₂ := by
+    rcases x, y, z with ⟨_|x, _|y, _|z⟩ <;> simp_all
+    · exact h₁.of_incR h₂
+    · exact OrderN.IncludedR.trans h₁ h₂
+  incN_of_inc {x y} n h := by
+    rcases x, y with ⟨_|x, _|y⟩ <;> simp_all
+    exact OrderN.IncludedR.incNR n h
+
+section
+attribute [local instance] raBase orderN
+
+theorem some_incN_some_iff {n} {a b : α} : some a ≼{n} some b ↔ a ≡{n}≡ b ∨ a ≼{n} b :=
+  .rfl
+theorem some_inc_some_iff {a b : α} : some a ≼ some b ↔ a = b ∨ a ≼ b := .rfl
+theorem none_incN_some_iff {n} {b : α} : none ≼{n} some b ↔ Increasing b := .rfl
+theorem none_inc_some_iff {b : α} : none ≼ some b ↔ Increasing b := .rfl
+theorem not_some_incN_none {n} {a : α} : ¬some a ≼{n} none := id
+theorem not_some_inc_none {a : α} : ¬some a ≼ none := id
+
+instance : IncRefl (Option α) where
+  inc_refl | none => trivial | some _ => Or.inl rfl
+
+theorem increasing_some_iff {a : α} : Increasing (some a) ↔ Increasing a where
+  mp h := h.increasing none
+  mpr h := ⟨fun | none => h | some b => Or.inr (h.increasing b)⟩
+
+instance : Increasing (none : Option α) := ⟨fun | none => trivial | some _ => Or.inl rfl⟩
+
+theorem increasing_pcore (x : α) : Increasing (pcore x : Option α) :=
+  match h : pcore x with
+  | none => inferInstance
+  | some _ => increasing_some_iff.mpr (pcore_increasing h)
+
+theorem none_incN_pcore {n} (x : α) : none ≼{n} pcore x :=
+  match h : pcore x with
+  | none => trivial
+  | some _ => pcore_increasing h
+
+theorem none_inc_pcore (x : α) : none ≼ pcore x :=
+  match h : pcore x with
+  | none => trivial
+  | some _ => pcore_increasing h
+
+theorem pcore_incN_pcore {n} {x y : α} (h : x ≼*{n} y) : pcore x ≼{n} pcore y := by
+  cases hx : pcore x with
+  | none => exact none_incN_pcore y
+  | some cx =>
+    rcases h with e | i
+    · obtain ⟨cy, hcy, ecy⟩ := pcore_ne e hx
+      rw [hcy]; exact Or.inl ecy
+    · obtain ⟨cy, hcy, icy⟩ := pcore_monoN i hx
+      rw [hcy]; exact Or.inr icy
+
+theorem pcore_inc_pcore {x y : α} (h : x ≼* y) : pcore x ≼ pcore y := by
+  cases hx : pcore x with
+  | none => exact none_inc_pcore y
+  | some cx =>
+    rcases h with rfl | i
+    · rw [hx]
+    · obtain ⟨cy, hcy, icy⟩ := pcore_mono i hx
+      rw [hcy]; exact Or.inr icy
+
+theorem pcore_inc_pcore_op (x y : α) : (pcore x : Option α) ≼ pcore (x • y) := by
+  cases hx : pcore x with
+  | none => exact none_inc_pcore _
+  | some cx =>
+    obtain ⟨cxy, hcxy, i⟩ := pcore_order_op hx y
+    rw [hcxy]; exact Or.inr i
+
+@[rocq_alias optionR, rocq_alias option_cmra_mixin]
+instance _root_.Iris.cmraOption : CMRA (Option α) where
+  toRABase := raBase
+  toOrderN := orderN
+  op_monoN_left {n x y} z h :=
+    match x, y, z, h with
+    | none, none, none, _ => trivial
+    | none, none, some _, _ => Or.inl .rfl
+    | none, some _, none, h => h
+    | none, some _, some z, h => Or.inr (Increasing.incN h z)
+    | some _, none, _, h => False.elim h
+    | some _, some _, none, h => h
+    | some _, some _, some z, h => OrderN.IncludedNR.op_left z h
+  op_mono_left {x y} z h :=
+    match x, y, z, h with
+    | none, none, none, _ => trivial
+    | none, none, some _, _ => Or.inl rfl
+    | none, some _, none, h => h
+    | none, some _, some z, h => Or.inr (h.increasing z)
+    | some _, none, _, h => False.elim h
+    | some _, some _, none, h => h
+    | some _, some _, some z, h => OrderN.IncludedR.op_left z h
+  validN_of_incN {n x y} h v :=
+    match x, y, h with
+    | none, _, _ => trivial
+    | some _, none, h => False.elim h
+    | some _, some _, h => OrderN.IncludedNR.validN h v
+  pcore_monoN {n x y _} h := by
+    rintro ⟨⟩
+    refine ⟨_, rfl, ?_⟩
+    match x, y, h with
+    | none, none, _ => trivial
+    | none, some y, _ => exact none_incN_pcore y
+    | some _, none, h => exact False.elim h
+    | some x, some y, h => exact pcore_incN_pcore h
+  pcore_mono {x y _} h := by
+    rintro ⟨⟩
+    refine ⟨_, rfl, ?_⟩
+    match x, y, h with
+    | none, none, _ => trivial
+    | none, some y, _ => exact none_inc_pcore y
+    | some _, none, h => exact False.elim h
+    | some x, some y, h => exact pcore_inc_pcore h
+  pcore_order_op {x _} := by
+    rintro ⟨⟩ y
+    refine ⟨_, rfl, ?_⟩
+    match x, y with
+    | none, none => trivial
+    | none, some y => exact none_inc_pcore y
+    | some x, none => exact inc_refl _
+    | some x, some y => exact pcore_inc_pcore_op x y
+  pcore_increasing {x _} := by
+    rintro ⟨⟩
+    match x with
+    | none => exact (inferInstance : Increasing (none : Option α))
+    | some x => exact increasing_pcore x
+  increasing_closed {n x y} h h' :=
+    match x, y, h' with
+    | none, none, _ => inferInstance
+    | none, some _, .inl e => False.elim e
+    | none, some _, .inr i => increasing_some_iff.mpr i
+    | some _, none, .inl e => False.elim e
+    | some _, none, .inr i => False.elim i
+    | some _, some _, .inl e => increasing_some_iff.mpr ((increasing_some_iff.mp h).of_dist e)
+    | some _, some _, .inr i => increasing_some_iff.mpr ((increasing_some_iff.mp h).of_incNR i)
+  incN_extend {n x y} v h :=
+    match x, y, h with
+    | none, none, _ => ⟨none, trivial, .rfl⟩
+    | none, some _, h => ⟨none, h, .rfl⟩
+    | some _, none, h => False.elim h
+    | some _, some y, .inl e => ⟨some y, Or.inl .rfl, e.symm⟩
+    | some _, some _, .inr i =>
+      let ⟨z, hz, ez⟩ := incN_extend v i
+      ⟨some z, Or.inr hz, ez⟩
+
 #rocq_ignore option_unit_instance "Use UCMRA instance"
 #rocq_ignore option_ucmra_mixin "Use UCMRA instance"
 
 @[rocq_alias optionUR]
-instance ucmraOption : UCMRA (Option α) where
+instance _root_.Iris.ucmraOption : UCMRA (Option α) where
+  toCMRA := cmraOption
   unit := none
-  unit_valid := by simp [Valid]
+  unit_valid := trivial
   unit_left_id := by rintro ⟨⟩ <;> rfl
   pcore_unit := by rfl
+  inc_refl := inc_refl
 
-namespace Option
+end
 
 @[rocq_alias Some_op]
 theorem some_op (a b : α) : some (a • b) = some a • some b := rfl
@@ -1508,19 +2330,6 @@ theorem opM_map_some {ma₁ ma₂ : Option α} : ma₁ •? ma₂.map some = ma�
 theorem op_some_opM_assoc_dist {x y : α} {mz : Option α} : (x • y) •? mz ≡{n}≡ x •? (some y • mz) :=
   match mz with | none => .rfl | some _ => assoc.dist.symm
 
-theorem some_inc_some_of_dist_opM {mz : Option α} (H : x ≡{n}≡ y •? mz) : some y ≼{n} some x :=
-  match mz with | none => ⟨none, H⟩ | some z => ⟨some z, H⟩
-
-theorem inc_of_some_inc_some [IsTotal α] {x y : α} (H : some y ≼ some x) : y ≼ x :=
-  let ⟨mz, hmz⟩ := H
-  match mz with
-  | none => ⟨core y, (Option.some.inj hmz).trans (op_core y).symm⟩
-  | some z => ⟨z, Option.some.inj hmz⟩
-
-theorem some_incN_some_iff_some [IsTotal α] {x y : α} : some y ≼{n} some x → y ≼{n} x
-  | ⟨none, hmz⟩ => ⟨core y, dist_of_some_dist_some hmz |>.trans (op_core_dist y).symm⟩
-  | ⟨some z, hmz⟩ => ⟨z, hmz⟩
-
 theorem exists_op_some_eqv_some (x : Option α) (y : α) : ∃ z, x • some y = some z :=
   match x with | .none => ⟨y, rfl⟩ | .some w => ⟨w • y, rfl⟩
 
@@ -1555,9 +2364,117 @@ theorem exclusive_some_right {a : α} [Exclusive a] {mb : Option α}
 theorem validN_op_unit {n} {x : Option α} (vx : ✓{n} x) : ✓{n} x • unit := by
   rcases x with ⟨_|_⟩ <;> trivial
 
+/-! ### The order on `Option α` -/
+
+theorem dist_or_incN_of_some_incN_some {n} {a b : α} (h : some a ≼{n} some b) :
+    a ≡{n}≡ b ∨ a ≼{n} b := h
+
+theorem some_incN_some_of_dist_or_incN {n} {a b : α} (h : a ≡{n}≡ b ∨ a ≼{n} b) :
+    some a ≼{n} some b := h
+
+theorem some_incN_some_of_incN {n} {a b : α} (h : a ≼{n} b) : some a ≼{n} some b := Or.inr h
+
+theorem some_incN_some_of_dist {n} {a b : α} (h : a ≡{n}≡ b) : some a ≼{n} some b := Or.inl h
+
+theorem isSome_of_some_incN {n} {a : α} {mb : Option α} (h : some a ≼{n} mb) : mb.isSome :=
+  match mb, h with
+  | some _, _ => rfl
+  | none, h => False.elim h
+
+theorem eq_or_inc_of_some_inc_some {a b : α} (h : some a ≼ some b) : a = b ∨ a ≼ b := h
+
+theorem some_inc_some_of_eq_or_inc {a b : α} (h : a = b ∨ a ≼ b) : some a ≼ some b := h
+
+theorem some_inc_some_of_inc {a b : α} (h : a ≼ b) : some a ≼ some b := Or.inr h
+
+theorem some_inc_some_of_eq {a b : α} (h : a = b) : some a ≼ some b := Or.inl h
+
+theorem isSome_of_some_inc {a : α} {mb : Option α} (h : some a ≼ mb) : mb.isSome :=
+  match mb, h with
+  | some _, _ => rfl
+  | none, h => False.elim h
+
+theorem isSome_monoN {n} {ma mb : Option α} (h : ma ≼{n} mb) : ma.isSome → mb.isSome := by
+  cases ma with
+  | none => simp
+  | some _ => exact fun _ => isSome_of_some_incN h
+
+theorem isSome_mono {ma mb : Option α} (h : ma ≼ mb) : ma.isSome → mb.isSome := by
+  cases ma with
+  | none => simp
+  | some _ => exact fun _ => isSome_of_some_inc h
+
+theorem inc_of_some_inc_some [IncRefl α] {x y : α} (H : some y ≼ some x) : y ≼ x :=
+  Or.elim H (· ▸ inc_refl y) id
+
+theorem incN_of_some_incN_some [IncRefl α] {n} {x y : α} (H : some y ≼{n} some x) :
+    y ≼{n} x :=
+  Or.elim H Dist.to_incN id
+
+theorem some_inc_some_iff_incRefl [IncRefl α] {a b : α} : some a ≼ some b ↔ a ≼ b :=
+  ⟨inc_of_some_inc_some, Or.inr⟩
+
+theorem some_incN_some_iff_incRefl [IncRefl α] {n} {a b : α} :
+    some a ≼{n} some b ↔ a ≼{n} b :=
+  ⟨incN_of_some_incN_some, Or.inr⟩
+
+theorem validN_of_incN_validN {n} {a b : α} (Hv : ✓{n} a) (Hinc : some b ≼{n} some a) :
+    ✓{n} b :=
+  validN_of_incN (α := Option α) Hinc Hv
+
+theorem valid_of_inc_valid {a b : α} (Hv : ✓ a) (Hinc : some b ≼ some a) : ✓ b :=
+  valid_of_inc (α := Option α) Hinc Hv
+
+/-- Transport a pointwise order-to-extension conversion through `Option`. The conversion is a
+plain hypothesis: classical components discharge it with `fun h => h`. -/
+theorem incExtN_of_incN {n} {mx my : Option α}
+    (hsub : ∀ {n : Nat} {x y : α}, x ≼{n} y → x ≼ₑ{n} y) (h : mx ≼{n} my) : mx ≼ₑ{n} my :=
+  match mx, my, h with
+  | none, none, _ => ⟨none, .rfl⟩
+  | none, some b, _ => ⟨some b, .rfl⟩
+  | some _, some _, .inl e => ⟨none, OFE.some_dist_some.mpr e.symm⟩
+  | some _, some _, .inr i =>
+    let ⟨z, hz⟩ := hsub i
+    ⟨some z, OFE.some_dist_some.mpr hz⟩
+
+/-- The limit-level form of `Option.incExtN_of_incN`. -/
+theorem incExt_of_inc {mx my : Option α}
+    (hsub : ∀ {x y : α}, x ≼ y → x ≼ₑ y) (h : mx ≼ my) : mx ≼ₑ my :=
+  match mx, my, h with
+  | none, none, _ => ⟨none, rfl⟩
+  | none, some b, _ => ⟨some b, rfl⟩
+  | some _, some _, .inl e => ⟨none, congrArg some e.symm⟩
+  | some _, some _, .inr i =>
+    let ⟨z, hz⟩ := hsub i
+    ⟨some z, congrArg some hz⟩
+
+instance [Affine α] : Affine (Option α) where
+  increasing
+    | none => inferInstance
+    | some a => increasing_some_iff.mpr (Affine.increasing a)
+
+/-! ### The extension inclusion on `Option α` -/
+
+theorem some_incExt_some_of_dist_opM {n} {x y : α} {mz : Option α} (H : x ≡{n}≡ y •? mz) :
+    some y ≼ₑ{n} some x :=
+  match mz with | none => ⟨none, H⟩ | some z => ⟨some z, H⟩
+
+theorem incExt_of_some_incExt_some [IsTotal α] {x y : α} (H : some y ≼ₑ some x) :
+    y ≼ₑ x :=
+  let ⟨mz, hmz⟩ := H
+  match mz with
+  | none => ⟨core y, (Option.some.inj hmz).trans (op_core y).symm⟩
+  | some z => ⟨z, Option.some.inj hmz⟩
+
+theorem incExtN_of_some_incExtN_some [IsTotal α] {n} {x y : α} :
+    some y ≼ₑ{n} some x → y ≼ₑ{n} x
+  | ⟨none, hmz⟩ => ⟨core y, dist_of_some_dist_some hmz |>.trans (op_core_dist y).symm⟩
+  | ⟨some z, hmz⟩ => ⟨z, hmz⟩
+
 @[rocq_alias option_included]
-theorem inc_iff {ma mb : Option α} :
-    ma ≼ mb ↔ ma = none ∨ ∃ a b, ma = some a ∧ mb = some b ∧ (a = b ∨ a ≼ b) := by
+theorem incExt_iff {ma mb : Option α} :
+    ma ≼ₑ mb ↔
+      ma = none ∨ ∃ a b, ma = some a ∧ mb = some b ∧ (a = b ∨ a ≼ₑ b) := by
   refine ⟨fun ⟨mc, Hmc⟩ => ?_, ?_⟩
   · rcases ma with _|a
     · exact .inl rfl
@@ -1573,8 +2490,9 @@ theorem inc_iff {ma mb : Option α} :
     · exists some z
 
 @[rocq_alias option_includedN]
-theorem incN_iff {ma mb : Option α} :
-    ma ≼{n} mb ↔ ma = none ∨ ∃ a b, ma = some a ∧ mb = some b ∧ (a ≡{n}≡ b ∨ a ≼{n} b) := by
+theorem incExtN_iff {n} {ma mb : Option α} :
+    ma ≼ₑ{n} mb ↔
+      ma = none ∨ ∃ a b, ma = some a ∧ mb = some b ∧ (a ≡{n}≡ b ∨ a ≼ₑ{n} b) := by
   refine ⟨fun ⟨mc, Hmc⟩ => ?_, ?_⟩
   · rcases ma, mb, mc with ⟨_|_, _|_, _|_⟩ <;> simp_all [op]
     · exact .inl Hmc.symm
@@ -1585,9 +2503,9 @@ theorem incN_iff {ma mb : Option α} :
     · exists some z
 
 @[rocq_alias option_included_total]
-theorem inc_iff_isTotal [IsTotal α] {ma mb : Option α} :
-    ma ≼ mb ↔ ma = none ∨ ∃ a b, ma = some a ∧ mb = some b ∧ a ≼ b := by
-  rw [inc_iff]
+theorem incExt_iff_isTotal [IsTotal α] {ma mb : Option α} :
+    ma ≼ₑ mb ↔ ma = none ∨ ∃ a b, ma = some a ∧ mb = some b ∧ a ≼ₑ b := by
+  rw [incExt_iff]
   constructor
   · rintro (rfl | ⟨a, b, ⟨⟩, ⟨⟩, (Heqv | Hinc)⟩)
     · simp
@@ -1598,9 +2516,9 @@ theorem inc_iff_isTotal [IsTotal α] {ma mb : Option α} :
     · exact .inr ⟨a, b, rfl, rfl, .inr Hinc⟩
 
 @[rocq_alias option_includedN_total]
-theorem incN_iff_is_total [IsTotal α] {ma mb : Option α} :
-    ma ≼{n} mb ↔ ma = none ∨ ∃ a b, ma = some a ∧ mb = some b ∧ a ≼{n} b := by
-  rw [incN_iff]
+theorem incExtN_iff_is_total [IsTotal α] {n} {ma mb : Option α} :
+    ma ≼ₑ{n} mb ↔ ma = none ∨ ∃ a b, ma = some a ∧ mb = some b ∧ a ≼ₑ{n} b := by
+  rw [incExtN_iff]
   constructor
   · rintro (rfl | ⟨a, b, ⟨⟩, ⟨⟩, (Heqv | Hinc)⟩)
     · simp
@@ -1611,103 +2529,111 @@ theorem incN_iff_is_total [IsTotal α] {ma mb : Option α} :
     · exact .inr ⟨a, b, rfl, rfl, .inr Hinc⟩
 
 @[rocq_alias Some_includedN]
-theorem some_incN_some_iff {a b : α} : some a ≼{n} some b ↔ a ≡{n}≡ b ∨ a ≼{n} b := by
-  apply incN_iff.trans; simp
+theorem some_incExtN_some_iff {n} {a b : α} :
+    some a ≼ₑ{n} some b ↔ a ≡{n}≡ b ∨ a ≼ₑ{n} b := by
+  apply incExtN_iff.trans; simp
 
 @[rocq_alias Some_includedN_1]
-theorem dist_or_incN_of_some_incN_some {a b : α} (h : some a ≼{n} some b) :
-    a ≡{n}≡ b ∨ a ≼{n} b := some_incN_some_iff.mp h
+theorem dist_or_incExtN_of_some_incExtN_some {n} {a b : α} (h : some a ≼ₑ{n} some b) :
+    a ≡{n}≡ b ∨ a ≼ₑ{n} b := some_incExtN_some_iff.mp h
 
 @[rocq_alias Some_includedN_2]
-theorem some_incN_some_of_dist_or_incN {a b : α} (h : a ≡{n}≡ b ∨ a ≼{n} b) :
-    some a ≼{n} some b := some_incN_some_iff.mpr h
+theorem some_incExtN_some_of_dist_or_incExtN {n} {a b : α} (h : a ≡{n}≡ b ∨ a ≼ₑ{n} b) :
+    some a ≼ₑ{n} some b := some_incExtN_some_iff.mpr h
 
 @[rocq_alias Some_includedN_mono]
-theorem some_incN_some_of_incN {a b : α} (h : a ≼{n} b) : some a ≼{n} some b :=
-  some_incN_some_iff.mpr (.inr h)
+theorem some_incExtN_some_of_incExtN {n} {a b : α} (h : a ≼ₑ{n} b) : some a ≼ₑ{n} some b :=
+  some_incExtN_some_iff.mpr (.inr h)
 
 @[rocq_alias Some_includedN_refl]
-theorem some_incN_some_of_dist {a b : α} (h : a ≡{n}≡ b) : some a ≼{n} some b :=
-  some_incN_some_iff.mpr (.inl h)
+theorem some_incExtN_some_of_dist {n} {a b : α} (h : a ≡{n}≡ b) : some a ≼ₑ{n} some b :=
+  some_incExtN_some_iff.mpr (.inl h)
 
 @[rocq_alias Some_includedN_is_Some]
-theorem isSome_of_some_incN {a : α} {mb : Option α} (h : some a ≼{n} mb) : mb.isSome := by
-  rcases incN_iff.mp h with h | ⟨_, _, _, rfl, _⟩ <;> simp_all
+theorem isSome_of_some_incExtN {n} {a : α} {mb : Option α} (h : some a ≼ₑ{n} mb) :
+    mb.isSome := by
+  rcases incExtN_iff.mp h with h | ⟨_, _, _, rfl, _⟩ <;> simp_all
 
 @[rocq_alias Some_included]
-theorem some_inc_some_iff {a b : α} : some a ≼ some b ↔ a = b ∨ a ≼ b := by
-  apply inc_iff.trans; simp
+theorem some_incExt_some_iff {a b : α} : some a ≼ₑ some b ↔ a = b ∨ a ≼ₑ b := by
+  apply incExt_iff.trans; simp
 
 @[rocq_alias Some_included_1]
-theorem eq_or_inc_of_some_inc_some {a b : α} (h : some a ≼ some b) : a = b ∨ a ≼ b :=
-  some_inc_some_iff.mp h
+theorem eq_or_incExt_of_some_incExt_some {a b : α} (h : some a ≼ₑ some b) :
+    a = b ∨ a ≼ₑ b :=
+  some_incExt_some_iff.mp h
 
 @[rocq_alias Some_included_2]
-theorem some_inc_some_of_eq_or_inc {a b : α} (h : a = b ∨ a ≼ b) : some a ≼ some b :=
-  some_inc_some_iff.mpr h
+theorem some_incExt_some_of_eq_or_incExt {a b : α} (h : a = b ∨ a ≼ₑ b) :
+    some a ≼ₑ some b :=
+  some_incExt_some_iff.mpr h
 
 @[rocq_alias Some_included_mono]
-theorem some_inc_some_of_inc {a b : α} (h : a ≼ b) : some a ≼ some b :=
-  some_inc_some_iff.mpr (.inr h)
+theorem some_incExt_some_of_incExt {a b : α} (h : a ≼ₑ b) : some a ≼ₑ some b :=
+  some_incExt_some_iff.mpr (.inr h)
 
 @[rocq_alias Some_included_refl]
-theorem some_inc_some_of_eq {a b : α} (h : a = b) : some a ≼ some b :=
-  some_inc_some_iff.mpr (.inl h)
+theorem some_incExt_some_of_eq {a b : α} (h : a = b) : some a ≼ₑ some b :=
+  some_incExt_some_iff.mpr (.inl h)
 
 @[rocq_alias Some_included_is_Some]
-theorem isSome_of_some_inc {a : α} {mb : Option α} (h : some a ≼ mb) : mb.isSome := by
-  rcases inc_iff.mp h with h | ⟨_, _, _, rfl, _⟩ <;> simp_all
+theorem isSome_of_some_incExt {a : α} {mb : Option α} (h : some a ≼ₑ mb) : mb.isSome := by
+  rcases incExt_iff.mp h with h | ⟨_, _, _, rfl, _⟩ <;> simp_all
 
 @[rocq_alias is_Some_includedN]
-theorem isSome_monoN {ma mb : Option α} (h : ma ≼{n} mb) : ma.isSome → mb.isSome := by
+theorem isSome_monoN_ext {n} {ma mb : Option α} (h : ma ≼ₑ{n} mb) :
+    ma.isSome → mb.isSome := by
   cases ma with
   | none => simp
-  | some _ => exact fun _ => isSome_of_some_incN h
+  | some _ => exact fun _ => isSome_of_some_incExtN h
 
 @[rocq_alias is_Some_included]
-theorem isSome_mono {ma mb : Option α} (h : ma ≼ mb) : ma.isSome → mb.isSome := by
+theorem isSome_mono_ext {ma mb : Option α} (h : ma ≼ₑ mb) : ma.isSome → mb.isSome := by
   cases ma with
   | none => simp
-  | some _ => exact fun _ => isSome_of_some_inc h
+  | some _ => exact fun _ => isSome_of_some_incExt h
 
 @[rocq_alias Some_included_exclusive]
-theorem eqv_of_inc_exclusive [Exclusive (a : α)] {b : α} (H : some a ≼ some b) (Hv : ✓ b) :
-     a = b := by
-  rcases inc_iff.mp H with (Hcontra|H)
+theorem eqv_of_incExt_exclusive [Exclusive (a : α)] {b : α} (H : some a ≼ₑ some b)
+    (Hv : ✓ b) : a = b := by
+  rcases incExt_iff.mp H with (Hcontra|H)
   · simp at Hcontra
   · obtain ⟨_, _, ⟨_, _⟩, ⟨_, _⟩, (He|H)⟩ := H
     · exact He
-    · exact not_valid_of_excl_inc H Hv |>.elim
+    · exact not_valid_of_excl_incExt H Hv |>.elim
 
 @[rocq_alias Some_includedN_exclusive]
-theorem dist_of_inc_exclusive [Exclusive (a : α)] {b : α} (H : some a ≼{n} some b) (Hv : ✓{n} b)  :
-    a ≡{n}≡ b := by
-  rcases incN_iff.mp H with (Hcontra|H)
+theorem dist_of_incExtN_exclusive [Exclusive (a : α)] {n} {b : α} (H : some a ≼ₑ{n} some b)
+    (Hv : ✓{n} b) : a ≡{n}≡ b := by
+  rcases incExtN_iff.mp H with (Hcontra|H)
   · simp at Hcontra
   · obtain ⟨_, _, ⟨_, _⟩, ⟨_, _⟩, (_|H)⟩ := H
     · trivial
-    · exact not_valid_of_exclN_inc H Hv |>.elim
+    · exact not_valid_of_exclN_incExt H Hv |>.elim
 
 @[rocq_alias Some_included_total]
-theorem some_inc_some_iff_is_total [IsTotal α] {a b : α} : some a ≼ some b ↔ a ≼ b := by
-  apply some_inc_some_iff.trans
+theorem some_incExt_some_iff_is_total [IsTotal α] {a b : α} :
+    some a ≼ₑ some b ↔ a ≼ₑ b := by
+  apply some_incExt_some_iff.trans
   refine ⟨?_, .inr⟩
   rintro (H|H)
   · exact ⟨_, H.symm.trans (op_core a).symm⟩
   · exact H
 
 @[rocq_alias option_fmap_mono]
-theorem map_mono {β : Type _} [CMRA β] (f : α → β) {ma mb : Option α}
-    (hf : ∀ x y : α, x ≼ y → f x ≼ f y) (h : ma ≼ mb) : ma.map f ≼ mb.map f := by
-  rcases inc_iff.mp h with rfl | ⟨a, b, rfl, rfl, hab⟩
+theorem map_mono_ext {β : Type _} [CMRA β] (f : α → β) {ma mb : Option α}
+    (hf : ∀ x y : α, x ≼ₑ y → f x ≼ₑ f y) (h : ma ≼ₑ mb) :
+    ma.map f ≼ₑ mb.map f := by
+  rcases incExt_iff.mp h with rfl | ⟨a, b, rfl, rfl, hab⟩
   · exact ⟨mb.map f, by cases mb.map f <;> rfl⟩
   · rcases hab with rfl | hab
-    · exact .rfl
-    · exact some_inc_some_iff.mpr (.inr (hf a b hab))
+    · exact incExt_refl _
+    · exact some_incExt_some_iff.mpr (.inr (hf a b hab))
 
 @[rocq_alias Some_includedN_total]
-theorem some_incN_some_iff_is_total [IsTotal α] {a b : α} : some a ≼{n} some b ↔ a ≼{n} b := by
-  apply some_incN_some_iff.trans
+theorem some_incExtN_some_iff_is_total [IsTotal α] {n} {a b : α} :
+    some a ≼ₑ{n} some b ↔ a ≼ₑ{n} b := by
+  apply some_incExtN_some_iff.trans
   refine ⟨?_, .inr⟩
   rintro (H|H)
   · exact ⟨_, H.symm.trans (CMRA.op_core_dist a).symm⟩
@@ -1731,16 +2657,17 @@ instance {ma : Option α} [∀ a : α, IdFree a] [∀ a : α, Cancelable a] : Ca
   · infer_instance
 
 @[rocq_alias cmra_validN_Some_includedN]
-theorem validN_of_incN_validN {a b : α} (Hv : ✓{n} a) (Hinc : some b ≼{n} some a) : ✓{n} b :=
-  validN_of_incN (α := Option α) Hinc Hv
+theorem validN_of_incExtN_validN {n} {a b : α} (Hv : ✓{n} a) (Hinc : some b ≼ₑ{n} some a) :
+    ✓{n} b :=
+  validN_of_incExtN (α := Option α) Hinc Hv
 
 @[rocq_alias cmra_valid_Some_included]
-theorem valid_of_inc_valid {a b : α} (Hv : ✓ a) (Hinc : some b ≼ some a) : ✓ b :=
-  valid_of_inc (α := Option α) Hinc Hv
+theorem valid_of_incExt_valid {a b : α} (Hv : ✓ a) (Hinc : some b ≼ₑ some a) : ✓ b :=
+  valid_of_incExt (α := Option α) Hinc Hv
 
 @[rocq_alias Some_included_opM]
-theorem some_inc_some_iff_opM {a b : α} : some a ≼ some b ↔ ∃ mc, b = a •? mc := by
-  simp [inc_iff]
+theorem some_incExt_some_iff_opM {a b : α} : some a ≼ₑ some b ↔ ∃ mc, b = a •? mc := by
+  simp [incExt_iff]
   constructor
   · rintro (Heqv | ⟨mc', Hinc⟩)
     · exact ⟨none, by simpa [CMRA.op?] using Heqv.symm⟩
@@ -1750,8 +2677,9 @@ theorem some_inc_some_iff_opM {a b : α} : some a ≼ some b ↔ ∃ mc, b = a �
     · exact .inr ⟨z, H⟩
 
 @[rocq_alias Some_includedN_opM]
-theorem some_incN_some_iff_opM {a b : α} : some a ≼{n} some b ↔ ∃ mc, b ≡{n}≡ a •? mc := by
-  simp [incN_iff]
+theorem some_incExtN_some_iff_opM {n} {a b : α} :
+    some a ≼ₑ{n} some b ↔ ∃ mc, b ≡{n}≡ a •? mc := by
+  simp [incExtN_iff]
   constructor
   · rintro (H|H)
     · exists none; simpa [op?] using H.symm
@@ -1763,9 +2691,18 @@ theorem some_incN_some_iff_opM {a b : α} : some a ≼{n} some b ↔ ∃ mc, b �
 
 @[rocq_alias option_cmra_discrete]
 instance [CMRA.Discrete α] : CMRA.Discrete (Option α) where
-  discrete_valid {x} := by
-    cases x <;> simp [Valid, optionValid]
-    exact (CMRA.discrete_valid ·)
+  discrete_valid {x} :=
+    match x with
+    | none => fun _ => trivial
+    | some _ => discrete_valid (α := α)
+  discrete_inc {x y} h :=
+    match x, y, h with
+    | none, none, _ => trivial
+    | none, some _, h => h
+    | some _, none, h => False.elim h
+    | some _, some _, h =>
+      Or.elim h (fun e => Or.inl (OFE.Discrete.discrete_0 e))
+        fun i => Or.inr (discrete_inc (α := α) i)
 
 end Option
 end option
@@ -1779,8 +2716,8 @@ section unit
 #rocq_ignore unit_cancelable "Subsumed by empty_cancelable"
 #rocq_ignore unit_core_id "Subsumed by unit_CoreId"
 
-@[rocq_alias unitR, rocq_alias unit_cmra_mixin]
-instance cmraUnit : CMRA Unit where
+@[rocq_alias unit_cmra_mixin]
+instance raBaseUnit : RABase Unit where
   pcore _ := some ()
   op _ _ := ()
   ValidN _ _ := True
@@ -1795,22 +2732,30 @@ instance cmraUnit : CMRA Unit where
   comm := rfl
   pcore_op_left _ := rfl
   pcore_idem _ := rfl
-  pcore_op_mono _ _ := ⟨.unit, rfl⟩
   extend _ _ := ⟨(), (), rfl, .rfl, .rfl⟩
+
+instance : RABase.ExtensionLaws Unit where
+  pcore_op_mono _ _ := ⟨.unit, rfl⟩
+
+@[rocq_alias unitR]
+instance cmraUnit : CMRA Unit := CMRA.withExtensionOrder
 
 #rocq_ignore unit_unit_instance "Use UCMRA instance"
 #rocq_ignore unit_ucmra_mixin "Use UCMRA instance"
 
-@[rocq_alias unitUR]
-instance ucmraUnit : UCMRA Unit where
+instance unitalUnit : Unital Unit where
   unit := ()
   unit_valid := ⟨⟩
   unit_left_id := rfl
   pcore_unit := rfl
 
+@[rocq_alias unitUR]
+instance ucmraUnit : UCMRA Unit := UCMRA.withExtensionOrder
+
 @[rocq_alias unit_cmra_discrete]
 instance : CMRA.Discrete Unit where
   discrete_valid _ := ⟨⟩
+  discrete_inc _ := ⟨(), rfl⟩
 
 end unit
 
@@ -1822,8 +2767,7 @@ section empty
 #rocq_ignore Empty_set_validN_instance "Use CMRA instance"
 #rocq_ignore Empty_set_cmra_mixin "Use CMRA instance"
 
-@[rocq_alias Empty_setR]
-instance cmraEmpty : CMRA Empty where
+instance raBaseEmpty : RABase Empty where
   pcore x := some x
   op x _ := x
   ValidN _ _ := False
@@ -1838,12 +2782,18 @@ instance cmraEmpty : CMRA Empty where
   comm {x} := x.elim
   pcore_op_left {x} := x.elim
   pcore_idem {x} := x.elim
-  pcore_op_mono {x} := x.elim
   extend {_ x} := x.elim
+
+instance : RABase.ExtensionLaws Empty where
+  pcore_op_mono {x} := x.elim
+
+@[rocq_alias Empty_setR]
+instance cmraEmpty : CMRA Empty := CMRA.withExtensionOrder
 
 @[rocq_alias Empty_set_cmra_discrete]
 instance : CMRA.Discrete Empty where
   discrete_valid := id
+  discrete_inc {x} := x.elim
 
 @[rocq_alias Empty_set_core_id]
 instance (x : Empty) : CMRA.CoreId x where
@@ -1871,13 +2821,17 @@ abbrev ValidN n (x : α × β) := ✓{n} x.fst ∧ ✓{n} x.snd
 
 abbrev Valid (x : α × β) := ✓ x.fst ∧ ✓ x.snd
 
+abbrev IncludedN n (x y : α × β) := x.fst ≼{n} y.fst ∧ x.snd ≼{n} y.snd
+
+abbrev Included (x y : α × β) := x.fst ≼ y.fst ∧ x.snd ≼ y.snd
+
 #rocq_ignore prod_op_instance "Use CMRA instance"
 #rocq_ignore prod_pcore_instance "Use CMRA instance"
 #rocq_ignore prod_valid_instance "Use CMRA instance"
 #rocq_ignore prod_validN_instance "Use CMRA instance"
 
-@[rocq_alias prodR, rocq_alias prod_cmra_mixin]
-instance cmraProd : CMRA (α × β) where
+/-- The componentwise resource algebra. -/
+@[reducible] def raBase : RABase (α × β) where
   pcore := pcore
   op := op
   ValidN := ValidN
@@ -1916,20 +2870,81 @@ instance cmraProd : CMRA (α × β) where
     rw [Option.some.inj hcx.symm]
     simp only [ha, hb, pcore]
     exact congrArg some g
-  pcore_op_mono {x cx} h y := by
-    have ⟨cx₁, hcx₁, this⟩ := Option.bind_eq_some_iff.mp h
-    have ⟨cx₂, hcx₂, hcx⟩ := Option.bind_eq_some_iff.mp this
-    have ⟨cy₁, hcy₁⟩ := CMRA.pcore_op_mono hcx₁ y.fst
-    have ⟨cy₂, hcy₂⟩ := CMRA.pcore_op_mono hcx₂ y.snd
-    have ⟨a, ha, ea⟩ := equiv_some hcy₁
-    have ⟨b, hb, eb⟩ := equiv_some hcy₂
-    unfold pcore
-    rw [Option.some.inj hcx.symm, ha, hb]
-    exact ⟨(cy₁, cy₂), congrArg some (equiv_prod_ext ea eb)⟩
   extend {n x y₁ y₂} := fun ⟨vx₁, vx₂⟩ e =>
     let ⟨z₁, w₁, hx₁, hz₁, hw₁⟩ := CMRA.extend vx₁ (OFE.dist_fst e)
     let ⟨z₂, w₂, hx₂, hz₂, hw₂⟩ := CMRA.extend vx₂ (OFE.dist_snd e)
     ⟨(z₁, z₂), (w₁, w₂), equiv_prod_ext hx₁ hx₂, ⟨hz₁, hz₂⟩, ⟨hw₁, hw₂⟩⟩
+
+/-- The componentwise order. -/
+@[reducible] def orderN : OrderN (α × β) where
+  IncludedN := IncludedN
+  Included := Included
+  incN_ne ex ey h :=
+    ⟨CMRA.incN_ne (dist_fst ex) (dist_fst ey) h.1, CMRA.incN_ne (dist_snd ex) (dist_snd ey) h.2⟩
+  incN_succ h := ⟨CMRA.incN_succ h.1, CMRA.incN_succ h.2⟩
+  incN_trans h₁ h₂ := ⟨CMRA.incN_trans h₁.1 h₂.1, CMRA.incN_trans h₁.2 h₂.2⟩
+  inc_trans h₁ h₂ := ⟨CMRA.inc_trans h₁.1 h₂.1, CMRA.inc_trans h₁.2 h₂.2⟩
+  incN_of_inc n h := ⟨CMRA.incN_of_inc n h.1, CMRA.incN_of_inc n h.2⟩
+
+section
+attribute [local instance] raBase orderN
+
+@[rocq_alias prod_pcore_Some, rocq_alias prod_pcore_Some']
+theorem pcore_eq_some {x cx : α × β} :
+    CMRA.pcore x = some cx ↔ CMRA.pcore x.1 = some cx.1 ∧ CMRA.pcore x.2 = some cx.2 := by
+  refine ⟨fun h => ?_, fun ⟨h₁, h₂⟩ =>
+    Option.bind_eq_some_iff.mpr ⟨cx.1, h₁, Option.bind_eq_some_iff.mpr ⟨cx.2, h₂, rfl⟩⟩⟩
+  obtain ⟨c₁, h₁, h⟩ := Option.bind_eq_some_iff.mp h
+  obtain ⟨c₂, h₂, h⟩ := Option.bind_eq_some_iff.mp h
+  cases Option.some.inj h
+  exact ⟨h₁, h₂⟩
+
+theorem increasing_iff {x : α × β} :
+    CMRA.Increasing x ↔ CMRA.Increasing x.1 ∧ CMRA.Increasing x.2 :=
+  ⟨fun h =>
+    ⟨⟨fun y => (h.increasing (y, x.2)).1⟩, ⟨fun y => (h.increasing (x.1, y)).2⟩⟩,
+   fun ⟨h₁, h₂⟩ => ⟨fun y => ⟨h₁.increasing y.1, h₂.increasing y.2⟩⟩⟩
+
+theorem incNR_fst {n} {x y : α × β} (h : x ≼*{n} y) : x.1 ≼*{n} y.1 :=
+  h.imp dist_fst And.left
+theorem incNR_snd {n} {x y : α × β} (h : x ≼*{n} y) : x.2 ≼*{n} y.2 :=
+  h.imp dist_snd And.right
+
+@[rocq_alias prodR, rocq_alias prod_cmra_mixin]
+instance cmraProd : CMRA (α × β) where
+  toRABase := raBase
+  toOrderN := orderN
+  op_monoN_left z h := ⟨CMRA.op_monoN_left z.1 h.1, CMRA.op_monoN_left z.2 h.2⟩
+  op_mono_left z h := ⟨CMRA.op_mono_left z.1 h.1, CMRA.op_mono_left z.2 h.2⟩
+  validN_of_incN h v := ⟨CMRA.validN_of_incN h.1 v.1, CMRA.validN_of_incN h.2 v.2⟩
+  pcore_monoN h e :=
+    let ⟨e₁, e₂⟩ := pcore_eq_some.mp e
+    let ⟨cy₁, hcy₁, i₁⟩ := CMRA.pcore_monoN h.1 e₁
+    let ⟨cy₂, hcy₂, i₂⟩ := CMRA.pcore_monoN h.2 e₂
+    ⟨(cy₁, cy₂), pcore_eq_some.mpr ⟨hcy₁, hcy₂⟩, i₁, i₂⟩
+  pcore_mono h e :=
+    let ⟨e₁, e₂⟩ := pcore_eq_some.mp e
+    let ⟨cy₁, hcy₁, i₁⟩ := CMRA.pcore_mono h.1 e₁
+    let ⟨cy₂, hcy₂, i₂⟩ := CMRA.pcore_mono h.2 e₂
+    ⟨(cy₁, cy₂), pcore_eq_some.mpr ⟨hcy₁, hcy₂⟩, i₁, i₂⟩
+  pcore_order_op e y :=
+    let ⟨e₁, e₂⟩ := pcore_eq_some.mp e
+    let ⟨cxy₁, h₁, i₁⟩ := CMRA.pcore_order_op e₁ y.1
+    let ⟨cxy₂, h₂, i₂⟩ := CMRA.pcore_order_op e₂ y.2
+    ⟨(cxy₁, cxy₂), pcore_eq_some.mpr ⟨h₁, h₂⟩, i₁, i₂⟩
+  pcore_increasing e :=
+    let ⟨e₁, e₂⟩ := pcore_eq_some.mp e
+    increasing_iff.mpr ⟨CMRA.pcore_increasing e₁, CMRA.pcore_increasing e₂⟩
+  increasing_closed h h' :=
+    let ⟨h₁, h₂⟩ := increasing_iff.mp h
+    increasing_iff.mpr
+      ⟨CMRA.increasing_closed h₁ (incNR_fst h'), CMRA.increasing_closed h₂ (incNR_snd h')⟩
+  incN_extend v h :=
+    let ⟨z₁, h₁, e₁⟩ := CMRA.incN_extend v.1 h.1
+    let ⟨z₂, h₂, e₂⟩ := CMRA.incN_extend v.2 h.2
+    ⟨(z₁, z₂), ⟨h₁, h₂⟩, dist_prod_ext e₁ e₂⟩
+
+end
 
 theorem valid_fst {x : α × β} (h : ✓ x) : ✓ x.fst := h.left
 theorem valid_snd {x : α × β} (h : ✓ x) : ✓ x.snd := h.right
@@ -1951,38 +2966,58 @@ theorem mk_pcore (a : α) (b : β) :
     CMRA.pcore (a, b) = (CMRA.pcore a).bind fun c₁ => (CMRA.pcore b).bind fun c₂ => some (c₁, c₂) :=
   rfl
 
-@[rocq_alias prod_pcore_Some, rocq_alias prod_pcore_Some']
-theorem pcore_eq_some {x cx : α × β} :
-    CMRA.pcore x = some cx ↔ CMRA.pcore x.1 = some cx.1 ∧ CMRA.pcore x.2 = some cx.2 := by
-  refine ⟨fun h => ?_, fun ⟨h₁, h₂⟩ =>
-    Option.bind_eq_some_iff.mpr ⟨cx.1, h₁, Option.bind_eq_some_iff.mpr ⟨cx.2, h₂, rfl⟩⟩⟩
-  obtain ⟨c₁, h₁, h⟩ := Option.bind_eq_some_iff.mp h
-  obtain ⟨c₂, h₂, h⟩ := Option.bind_eq_some_iff.mp h
-  cases Option.some.inj h
-  exact ⟨h₁, h₂⟩
-
 @[rocq_alias pair_core]
 theorem mk_core [CMRA.IsTotal α] [CMRA.IsTotal β] (a : α) (b : β) :
     CMRA.core (a, b) = (CMRA.core a, CMRA.core b) :=
   congrArg (Option.getD · (a, b))
     (pcore_eq_some.mpr ⟨CMRA.pcore_eq_core a, CMRA.pcore_eq_core b⟩)
 
+theorem inc_def {x y : α × β} : x ≼ y ↔ x.1 ≼ y.1 ∧ x.2 ≼ y.2 := .rfl
+
+theorem incN_def {n} {x y : α × β} : x ≼{n} y ↔ x.1 ≼{n} y.1 ∧ x.2 ≼{n} y.2 := .rfl
+
+theorem mk_inc_mk (a a' : α) (b b' : β) : (a, b) ≼ (a', b') ↔ a ≼ a' ∧ b ≼ b' := .rfl
+
+theorem mk_incN_mk {n} (a a' : α) (b b' : β) :
+    (a, b) ≼{n} (a', b') ↔ a ≼{n} a' ∧ b ≼{n} b' := .rfl
+
+/-- Transport pointwise order-to-extension conversions through the product. The conversions
+are plain hypotheses: classical components discharge them with `fun h => h`. -/
+theorem incExtN_of_incN {n} {x y : α × β}
+    (hsub₁ : ∀ {n : Nat} {a b : α}, a ≼{n} b → a ≼ₑ{n} b)
+    (hsub₂ : ∀ {n : Nat} {a b : β}, a ≼{n} b → a ≼ₑ{n} b)
+    (h : x ≼{n} y) : x ≼ₑ{n} y :=
+  let ⟨z₁, hz₁⟩ := hsub₁ h.1
+  let ⟨z₂, hz₂⟩ := hsub₂ h.2
+  ⟨(z₁, z₂), ⟨hz₁, hz₂⟩⟩
+
+/-- The limit-level form of `Prod.incExtN_of_incN`. -/
+theorem incExt_of_inc {x y : α × β}
+    (hsub₁ : ∀ {a b : α}, a ≼ b → a ≼ₑ b)
+    (hsub₂ : ∀ {a b : β}, a ≼ b → a ≼ₑ b)
+    (h : x ≼ y) : x ≼ₑ y :=
+  let ⟨z₁, hz₁⟩ := hsub₁ h.1
+  let ⟨z₂, hz₂⟩ := hsub₂ h.2
+  ⟨(z₁, z₂), Prod.ext hz₁ hz₂⟩
+
 @[rocq_alias prod_included]
-theorem inc_def {x y : α × β} : x ≼ y ↔ x.1 ≼ y.1 ∧ x.2 ≼ y.2 :=
+theorem incExt_def {x y : α × β} : x ≼ₑ y ↔ x.1 ≼ₑ y.1 ∧ x.2 ≼ₑ y.2 :=
   ⟨fun ⟨z, hz⟩ => ⟨⟨z.1, congrArg Prod.fst hz⟩, ⟨z.2, congrArg Prod.snd hz⟩⟩,
    fun ⟨⟨z₁, hz₁⟩, ⟨z₂, hz₂⟩⟩ => ⟨(z₁, z₂), Prod.ext hz₁ hz₂⟩⟩
 
 @[rocq_alias prod_includedN]
-theorem incN_def {n} {x y : α × β} : x ≼{n} y ↔ x.1 ≼{n} y.1 ∧ x.2 ≼{n} y.2 :=
+theorem incExtN_def {n} {x y : α × β} :
+    x ≼ₑ{n} y ↔ x.1 ≼ₑ{n} y.1 ∧ x.2 ≼ₑ{n} y.2 :=
   ⟨fun ⟨z, hz⟩ => ⟨⟨z.1, dist_fst hz⟩, ⟨z.2, dist_snd hz⟩⟩,
    fun ⟨⟨z₁, hz₁⟩, ⟨z₂, hz₂⟩⟩ => ⟨(z₁, z₂), dist_prod_ext hz₁ hz₂⟩⟩
 
 @[rocq_alias pair_included]
-theorem mk_inc_mk (a a' : α) (b b' : β) : (a, b) ≼ (a', b') ↔ a ≼ a' ∧ b ≼ b' := inc_def
+theorem mk_incExt_mk (a a' : α) (b b' : β) :
+    (a, b) ≼ₑ (a', b') ↔ a ≼ₑ a' ∧ b ≼ₑ b' := incExt_def
 
 @[rocq_alias pair_includedN]
-theorem mk_incN_mk {n} (a a' : α) (b b' : β) :
-    (a, b) ≼{n} (a', b') ↔ a ≼{n} a' ∧ b ≼{n} b' := incN_def
+theorem mk_incExtN_mk {n} (a a' : α) (b b' : β) :
+    (a, b) ≼ₑ{n} (a', b') ↔ a ≼ₑ{n} a' ∧ b ≼ₑ{n} b' := incExtN_def
 
 @[rocq_alias prod_cmra_total]
 instance instIsTotalProd [CMRA.IsTotal α] [CMRA.IsTotal β] : CMRA.IsTotal (α × β) where
@@ -1992,11 +3027,15 @@ instance instIsTotalProd [CMRA.IsTotal α] [CMRA.IsTotal β] : CMRA.IsTotal (α 
     ⟨(ca, cb), pcore_eq_some.mpr ⟨ha, hb⟩⟩
 
 @[rocq_alias prod_cmra_discrete]
-instance instCmraDistreteProd [CMRA.Discrete α] [CMRA.Discrete β] : CMRA.Discrete (α × β) where
-  discrete_valid := by
-    rintro ⟨_, _⟩
-    simp [CMRA.ValidN]
-    exact (⟨CMRA.discrete_valid ·, CMRA.discrete_valid ·⟩)
+instance instCmraDiscreteProd [CMRA.Discrete α] [CMRA.Discrete β] : CMRA.Discrete (α × β) where
+  discrete_valid v := ⟨CMRA.discrete_valid v.1, CMRA.discrete_valid v.2⟩
+  discrete_inc h := ⟨CMRA.discrete_inc h.1, CMRA.discrete_inc h.2⟩
+
+instance [IncRefl α] [IncRefl β] : IncRefl (α × β) where
+  inc_refl x := ⟨CMRA.inc_refl x.1, CMRA.inc_refl x.2⟩
+
+instance [CMRA.Affine α] [CMRA.Affine β] : CMRA.Affine (α × β) where
+  increasing x := increasing_iff.mpr ⟨CMRA.Affine.increasing x.1, CMRA.Affine.increasing x.2⟩
 
 @[rocq_alias pair_core_id]
 instance instCoreIdPair {x : α} {y : β} [CMRA.CoreId x] [CMRA.CoreId y] :
@@ -2044,6 +3083,7 @@ instance ucmraProd : UCMRA (α × β) where
   unit_valid := ⟨UCMRA.unit_valid, UCMRA.unit_valid⟩
   unit_left_id := Prod.ext UCMRA.unit_left_id UCMRA.unit_left_id
   pcore_unit := pcore_eq_some.mpr ⟨UCMRA.pcore_unit, UCMRA.pcore_unit⟩
+  inc_refl x := ⟨CMRA.inc_refl x.1, CMRA.inc_refl x.2⟩
 
 @[rocq_alias pair_split, rocq_alias pair_split_L]
 theorem mk_split (a : α) (b : β) : (a, b) = ((a, UCMRA.unit) : α × β) • (UCMRA.unit, b) :=
@@ -2064,68 +3104,99 @@ end ProdUnit
 
 section OptionProd
 
-open CMRA Option
+open CMRA RABase Option
 
 variable {α β : Type _} [CMRA α] [CMRA β]
 
 namespace Option
 
-@[rocq_alias Some_pair_includedN]
 theorem some_mk_incN {n} {a₁ a₂ : α} {b₁ b₂ : β} (h : some (a₁, b₁) ≼{n} some (a₂, b₂)) :
-    some a₁ ≼{n} some a₂ ∧ some b₁ ≼{n} some b₂ := by
-  rcases some_incN_some_iff.mp h with hd | hi
-  · exact ⟨some_incN_some_of_dist hd.1, some_incN_some_of_dist hd.2⟩
-  · have ⟨h₁, h₂⟩ := Prod.incN_def.mp hi
-    exact ⟨some_incN_some_of_incN h₁, some_incN_some_of_incN h₂⟩
+    some a₁ ≼{n} some a₂ ∧ some b₁ ≼{n} some b₂ :=
+  Or.elim h (fun e => ⟨Or.inl e.1, Or.inl e.2⟩) fun i => ⟨Or.inr i.1, Or.inr i.2⟩
 
-@[rocq_alias Some_pair_includedN_l]
 theorem some_mk_incN_left {n} {a₁ a₂ : α} {b₁ b₂ : β} (h : some (a₁, b₁) ≼{n} some (a₂, b₂)) :
     some a₁ ≼{n} some a₂ := (some_mk_incN h).1
 
-@[rocq_alias Some_pair_includedN_r]
 theorem some_mk_incN_right {n} {a₁ a₂ : α} {b₁ b₂ : β} (h : some (a₁, b₁) ≼{n} some (a₂, b₂)) :
     some b₁ ≼{n} some b₂ := (some_mk_incN h).2
 
-@[rocq_alias Some_pair_includedN_total_1]
-theorem some_mk_incN_total_fst [IsTotal α] {n} {a₁ a₂ : α} {b₁ b₂ : β}
-    (h : some (a₁, b₁) ≼{n} some (a₂, b₂)) : a₁ ≼{n} a₂ ∧ some b₁ ≼{n} some b₂ :=
-  let ⟨h₁, h₂⟩ := some_mk_incN h
-  ⟨some_incN_some_iff_is_total.mp h₁, h₂⟩
-
-@[rocq_alias Some_pair_includedN_total_2]
-theorem some_mk_incN_total_snd [IsTotal β] {n} {a₁ a₂ : α} {b₁ b₂ : β}
-    (h : some (a₁, b₁) ≼{n} some (a₂, b₂)) : some a₁ ≼{n} some a₂ ∧ b₁ ≼{n} b₂ :=
-  let ⟨h₁, h₂⟩ := some_mk_incN h
-  ⟨h₁, some_incN_some_iff_is_total.mp h₂⟩
-
-@[rocq_alias Some_pair_included]
 theorem some_mk_inc {a₁ a₂ : α} {b₁ b₂ : β} (h : some (a₁, b₁) ≼ some (a₂, b₂)) :
-    some a₁ ≼ some a₂ ∧ some b₁ ≼ some b₂ := by
-  rcases some_inc_some_iff.mp h with he | hi
-  · exact ⟨some_inc_some_of_eq (congrArg Prod.fst he),
-      some_inc_some_of_eq (congrArg Prod.snd he)⟩
-  · have ⟨h₁, h₂⟩ := Prod.inc_def.mp hi
-    exact ⟨some_inc_some_of_inc h₁, some_inc_some_of_inc h₂⟩
+    some a₁ ≼ some a₂ ∧ some b₁ ≼ some b₂ :=
+  Or.elim h (fun e => ⟨Or.inl (congrArg Prod.fst e), Or.inl (congrArg Prod.snd e)⟩)
+    fun i => ⟨Or.inr i.1, Or.inr i.2⟩
 
-@[rocq_alias Some_pair_included_l]
 theorem some_mk_inc_left {a₁ a₂ : α} {b₁ b₂ : β} (h : some (a₁, b₁) ≼ some (a₂, b₂)) :
     some a₁ ≼ some a₂ := (some_mk_inc h).1
 
-@[rocq_alias Some_pair_included_r]
 theorem some_mk_inc_right {a₁ a₂ : α} {b₁ b₂ : β} (h : some (a₁, b₁) ≼ some (a₂, b₂)) :
     some b₁ ≼ some b₂ := (some_mk_inc h).2
 
+@[rocq_alias Some_pair_includedN]
+theorem some_mk_incExtN {n} {a₁ a₂ : α} {b₁ b₂ : β}
+    (h : some (a₁, b₁) ≼ₑ{n} some (a₂, b₂)) :
+    some a₁ ≼ₑ{n} some a₂ ∧ some b₁ ≼ₑ{n} some b₂ := by
+  rcases some_incExtN_some_iff.mp h with hd | hi
+  · exact ⟨some_incExtN_some_of_dist hd.1, some_incExtN_some_of_dist hd.2⟩
+  · have ⟨h₁, h₂⟩ := Prod.incExtN_def.mp hi
+    exact ⟨some_incExtN_some_of_incExtN h₁, some_incExtN_some_of_incExtN h₂⟩
+
+@[rocq_alias Some_pair_includedN_l]
+theorem some_mk_incExtN_left {n} {a₁ a₂ : α} {b₁ b₂ : β}
+    (h : some (a₁, b₁) ≼ₑ{n} some (a₂, b₂)) : some a₁ ≼ₑ{n} some a₂ :=
+  (some_mk_incExtN h).1
+
+@[rocq_alias Some_pair_includedN_r]
+theorem some_mk_incExtN_right {n} {a₁ a₂ : α} {b₁ b₂ : β}
+    (h : some (a₁, b₁) ≼ₑ{n} some (a₂, b₂)) : some b₁ ≼ₑ{n} some b₂ :=
+  (some_mk_incExtN h).2
+
+@[rocq_alias Some_pair_includedN_total_1]
+theorem some_mk_incExtN_total_fst [IsTotal α] {n} {a₁ a₂ : α} {b₁ b₂ : β}
+    (h : some (a₁, b₁) ≼ₑ{n} some (a₂, b₂)) :
+    a₁ ≼ₑ{n} a₂ ∧ some b₁ ≼ₑ{n} some b₂ :=
+  let ⟨h₁, h₂⟩ := some_mk_incExtN h
+  ⟨some_incExtN_some_iff_is_total.mp h₁, h₂⟩
+
+@[rocq_alias Some_pair_includedN_total_2]
+theorem some_mk_incExtN_total_snd [IsTotal β] {n} {a₁ a₂ : α} {b₁ b₂ : β}
+    (h : some (a₁, b₁) ≼ₑ{n} some (a₂, b₂)) :
+    some a₁ ≼ₑ{n} some a₂ ∧ b₁ ≼ₑ{n} b₂ :=
+  let ⟨h₁, h₂⟩ := some_mk_incExtN h
+  ⟨h₁, some_incExtN_some_iff_is_total.mp h₂⟩
+
+@[rocq_alias Some_pair_included]
+theorem some_mk_incExt {a₁ a₂ : α} {b₁ b₂ : β}
+    (h : some (a₁, b₁) ≼ₑ some (a₂, b₂)) :
+    some a₁ ≼ₑ some a₂ ∧ some b₁ ≼ₑ some b₂ := by
+  rcases some_incExt_some_iff.mp h with he | hi
+  · exact ⟨some_incExt_some_of_eq (congrArg Prod.fst he),
+      some_incExt_some_of_eq (congrArg Prod.snd he)⟩
+  · have ⟨h₁, h₂⟩ := Prod.incExt_def.mp hi
+    exact ⟨some_incExt_some_of_incExt h₁, some_incExt_some_of_incExt h₂⟩
+
+@[rocq_alias Some_pair_included_l]
+theorem some_mk_incExt_left {a₁ a₂ : α} {b₁ b₂ : β}
+    (h : some (a₁, b₁) ≼ₑ some (a₂, b₂)) : some a₁ ≼ₑ some a₂ :=
+  (some_mk_incExt h).1
+
+@[rocq_alias Some_pair_included_r]
+theorem some_mk_incExt_right {a₁ a₂ : α} {b₁ b₂ : β}
+    (h : some (a₁, b₁) ≼ₑ some (a₂, b₂)) : some b₁ ≼ₑ some b₂ :=
+  (some_mk_incExt h).2
+
 @[rocq_alias Some_pair_included_total_1]
-theorem some_mk_inc_total_fst [IsTotal α] {a₁ a₂ : α} {b₁ b₂ : β}
-    (h : some (a₁, b₁) ≼ some (a₂, b₂)) : a₁ ≼ a₂ ∧ some b₁ ≼ some b₂ :=
-  let ⟨h₁, h₂⟩ := some_mk_inc h
-  ⟨some_inc_some_iff_is_total.mp h₁, h₂⟩
+theorem some_mk_incExt_total_fst [IsTotal α] {a₁ a₂ : α} {b₁ b₂ : β}
+    (h : some (a₁, b₁) ≼ₑ some (a₂, b₂)) :
+    a₁ ≼ₑ a₂ ∧ some b₁ ≼ₑ some b₂ :=
+  let ⟨h₁, h₂⟩ := some_mk_incExt h
+  ⟨some_incExt_some_iff_is_total.mp h₁, h₂⟩
 
 @[rocq_alias Some_pair_included_total_2]
-theorem some_mk_inc_total_snd [IsTotal β] {a₁ a₂ : α} {b₁ b₂ : β}
-    (h : some (a₁, b₁) ≼ some (a₂, b₂)) : some a₁ ≼ some a₂ ∧ b₁ ≼ b₂ :=
-  let ⟨h₁, h₂⟩ := some_mk_inc h
-  ⟨h₁, some_inc_some_iff_is_total.mp h₂⟩
+theorem some_mk_incExt_total_snd [IsTotal β] {a₁ a₂ : α} {b₁ b₂ : β}
+    (h : some (a₁, b₁) ≼ₑ some (a₂, b₂)) :
+    some a₁ ≼ₑ some a₂ ∧ b₁ ≼ₑ b₂ :=
+  let ⟨h₁, h₂⟩ := some_mk_incExt h
+  ⟨h₁, some_incExt_some_iff_is_total.mp h₂⟩
 
 end Option
 end OptionProd
@@ -2145,6 +3216,22 @@ def Option.mapC (f : α -C> β) : Option α -C> Option β where
   op x y := by
     cases x <;> cases y <;> try rfl
     exact congrArg some (f.op ..)
+  monoN {n x y} h :=
+    match x, y, h with
+    | none, none, _ => trivial
+    | none, some _, h => f.increasing h
+    | some _, none, h => False.elim h
+    | some _, some _, h => Or.elim h (fun e => Or.inl (f.ne.ne e)) fun i => Or.inr (f.monoN i)
+  mono {x y} h :=
+    match x, y, h with
+    | none, none, _ => trivial
+    | none, some _, h => f.increasing h
+    | some _, none, h => False.elim h
+    | some _, some _, h => Or.elim h (fun e => Or.inl (congrArg f e)) fun i => Or.inr (f.mono i)
+  increasing {x} h :=
+    match x, h with
+    | none, _ => (inferInstance : Increasing (none : Option β))
+    | some _, h => Option.increasing_some_iff.mpr (f.increasing (Option.increasing_some_iff.mp h))
 
 end OptionMor
 
@@ -2170,6 +3257,11 @@ def Prod.mapC (f : A -C> A') (g : B -C> B') : A × B -C> A' × B' where
       cases _ : CMRA.pcore (g.f x.snd) <;>
       simp_all
   op x y := equiv_prod_ext (f.op x.fst y.fst) (g.op x.snd y.snd)
+  monoN h := ⟨f.monoN h.1, g.monoN h.2⟩
+  mono h := ⟨f.mono h.1, g.mono h.2⟩
+  increasing h :=
+    Prod.increasing_iff.mpr
+      ⟨f.increasing (Prod.increasing_iff.mp h).1, g.increasing (Prod.increasing_iff.mp h).2⟩
 
 end ProdMor
 
@@ -2185,6 +3277,10 @@ instance instRFunctorProdOF [RFunctor F1] [RFunctor F2] : RFunctor (ProdOF F1 F2
   map_id _ := equiv_prod_ext (map_id _) (map_id _)
   map_comp _ _ _ _ _ :=
     equiv_prod_ext (map_comp _ _ _ _ _) (map_comp _ _ _ _ _)
+
+instance [RFunctor F1] [RFunctor F2] [RFunctorAffine F1] [RFunctorAffine F2] :
+    RFunctorAffine (ProdOF F1 F2) where
+  affine := inferInstance
 
 @[rocq_alias prodRF_contractive]
 instance instRFunctorContractiveProdOF
@@ -2219,25 +3315,14 @@ variable {F : COFE.OFunctorPre}
 
 @[rocq_alias optionURF]
 instance urFunctorOptionOF [RFunctor F] : URFunctor (OptionOF F) where
-  cmra {α β} := ucmraOption
-  map f g := {
-    toHom := COFE.OFunctor.map f g
-    validN := by
-      simp [COFE.OFunctor.map, CMRA.ValidN, optionMap]
-      rintro n (_|x) <;> simp
-      exact (RFunctor.map f g).validN
-    pcore := by
-      rintro (_|x) <;> simp [optionCore, CMRA.pcore, COFE.OFunctor.map, optionMap]
-      have := (RFunctor.map f g).pcore x; revert this
-      cases CMRA.pcore x <;> cases CMRA.pcore (RFunctor.map f g x)
-        <;> simp
-    op := by
-      rintro (_|x) (_|y) <;> simp [CMRA.op, COFE.OFunctor.map, optionOp, optionMap]
-      exact (RFunctor.map f g).op x y
-  }
+  cmra := ucmraOption
+  map f g := Option.mapC (RFunctor.map f g)
   map_ne.ne := COFE.OFunctor.map_ne.ne
   map_id x := COFE.OFunctor.map_id x
   map_comp f g f' g' x := COFE.OFunctor.map_comp f g f' g' x
+
+instance [RFunctor F] [RFunctorAffine F] : RFunctorAffine (OptionOF F) where
+  affine := inferInstance
 
 @[rocq_alias optionURF_contractive]
 instance urFunctorContractiveOptionOF
@@ -2251,20 +3336,21 @@ instance urFunctorContractiveOptionOF
 end optionOF
 
 section CmraMixin
-namespace CMRA
+
+namespace RABase
 
 variable {α β : Type _}
 
-/-- Constructing a CMRA `β` through a mapping into a CMRA `α`.
+/-- Constructing a resource algebra `β` through a mapping into a resource algebra `α`.
 
 The mapping may restrict the domain (i.e., we have an injection from `β` to `α`, not a
 bijection) and validity. These two restrictions work on opposite "ends" of `α` according to
-`≼`: domain restriction must prove that when an element is in the domain, so is its
+`≼ₑ`: domain restriction must prove that when an element is in the domain, so is its
 composition with other elements; validity restriction must prove that if the composition of
 two elements is valid, then so are both of the elements. The "domain" is the image of `g` in
 `α`, or equivalently the part of `α` where `f` returns `some`. -/
 @[reducible, rocq_alias inj_cmra_mixin_restrict_validity]
-def ofInjRestrictValidity [CMRA α] [OFE β]
+def ofInjRestrictValidity [RABase α] [OFE β]
     (pcore : β → Option β) (op : β → β → β) (Valid : β → Prop) (ValidN : Nat → β → Prop)
     (f : α → Option β) (g : β → α)
     -- `g` is non-expansive and injective w.r.t. OFE equality
@@ -2275,8 +3361,6 @@ def ofInjRestrictValidity [CMRA α] [OFE β]
     (g_pcore_dist : ∀ (y cy : β) n,
       pcore y ≡{n}≡ some cy ↔ CMRA.pcore (g y) ≡{n}≡ some (g cy))
     (g_op : ∀ y₁ y₂, g (op y₁ y₂) = g y₁ • g y₂)
-    -- `g` also commutes with `opM` when the right-hand side is produced by `f`, cancelling it
-    (g_opM_f : ∀ (x : α) (y : β), g ((f x).elim y (op y)) = g y • x)
     -- the validity predicate on `β` restricts the one on `α`
     (g_validN : ∀ n (y : β), ValidN n y → ✓{n} (g y))
     -- the validity predicate on `β` satisfies the laws of validity
@@ -2284,7 +3368,7 @@ def ofInjRestrictValidity [CMRA α] [OFE β]
     (valid_validN : ∀ y : β, Valid y ↔ ∀ n, ValidN n y)
     (validN_le : ∀ n n' (y : β), ValidN n y → n' ≤ n → ValidN n' y)
     (validN_op_left : ∀ n (y₁ y₂ : β), ValidN n (op y₁ y₂) → ValidN n y₁) :
-    CMRA β :=
+    RABase β :=
   have g_ne : ∀ {n} {y₁ y₂ : β}, y₁ ≡{n}≡ y₂ → g y₁ ≡{n}≡ g y₂ := (g_dist ..).mp
   have g_eq : ∀ {y₁ y₂ : β}, y₁ = y₂ ↔ g y₁ = g y₂ :=
     eq_dist.trans <| (forall_congr' fun n => g_dist n _ _).trans eq_dist.symm
@@ -2292,10 +3376,6 @@ def ofInjRestrictValidity [CMRA α] [OFE β]
     eq_dist.trans <| (forall_congr' fun n => g_pcore_dist _ _ n).trans eq_dist.symm
   have gf : ∀ {x : α} {y : β}, f x = some y ↔ g y = x :=
     eq_dist.trans <| (forall_congr' fun n => gf_dist _ _ n).trans eq_dist.symm
-  have pcore_op_left : ∀ {y cy : β}, pcore y = some cy → op cy y = y := fun h =>
-    g_eq.mpr <| (g_op ..).trans <| CMRA.pcore_op_left (g_pcore.mp h)
-  have pcore_idem : ∀ {y cy : β}, pcore y = some cy → pcore cy = some cy := fun h =>
-    g_pcore.mpr <| CMRA.pcore_idem (g_pcore.mp h)
   { pcore, op, Valid, ValidN
     op_ne.ne _ _ _ h := (g_dist ..).mpr <|
       (g_op ..).dist.trans <| (g_ne h).op_r.trans (g_op ..).symm.dist
@@ -2310,16 +3390,8 @@ def ofInjRestrictValidity [CMRA α] [OFE β]
       simp only [g_op]
       exact CMRA.assoc
     comm := g_eq.mpr <| (g_op ..).trans <| CMRA.comm.trans (g_op ..).symm
-    pcore_op_left := pcore_op_left
-    pcore_idem := pcore_idem
-    pcore_op_mono := fun {y cy} h z => by
-      obtain ⟨c, hc⟩ := CMRA.pcore_op_mono (g_pcore.mp h) (g z)
-      obtain ⟨w, hw⟩ : ∃ w, (f c).elim cy (op cy) = op cy w :=
-        match f c with
-        | some w => ⟨w, rfl⟩
-        | none => ⟨cy, (pcore_op_left (pcore_idem h)).symm⟩
-      rw [← g_op, ← g_opM_f c cy, hw] at hc
-      exact ⟨w, g_pcore.mpr hc⟩
+    pcore_op_left h := g_eq.mpr <| (g_op ..).trans <| CMRA.pcore_op_left (g_pcore.mp h)
+    pcore_idem h := g_pcore.mpr <| CMRA.pcore_idem (g_pcore.mp h)
     extend := fun hv he => by
       obtain ⟨x₁, x₂, hx, hx₁, hx₂⟩ :=
         CMRA.extend (g_validN _ _ hv) (((g_dist ..).mp he).trans (g_op ..).dist)
@@ -2329,9 +3401,40 @@ def ofInjRestrictValidity [CMRA α] [OFE β]
       rw [g_op, gf.mp hw₁, gf.mp hw₂]
       exact hx }
 
-/-- Constructing a CMRA through an isomorphism that may restrict validity. -/
+/-- `RABase.ofInjRestrictValidity` inherits the extension laws of `α`, provided `g` commutes
+with `opM` when the right-hand side is produced by `f`, cancelling it. -/
+theorem ofInjRestrictValidity_extensionLaws [RABase α] [ExtensionLaws α] [OFE β]
+    (pcore : β → Option β) (op : β → β → β) (Valid : β → Prop) (ValidN : Nat → β → Prop)
+    (f : α → Option β) (g : β → α)
+    (g_dist : ∀ n (y₁ y₂ : β), y₁ ≡{n}≡ y₂ ↔ g y₁ ≡{n}≡ g y₂)
+    (gf_dist : ∀ (x : α) (y : β) n, f x ≡{n}≡ some y ↔ g y ≡{n}≡ x)
+    (g_pcore_dist : ∀ (y cy : β) n,
+      pcore y ≡{n}≡ some cy ↔ CMRA.pcore (g y) ≡{n}≡ some (g cy))
+    (g_op : ∀ y₁ y₂, g (op y₁ y₂) = g y₁ • g y₂)
+    (g_opM_f : ∀ (x : α) (y : β), g ((f x).elim y (op y)) = g y • x)
+    (g_validN : ∀ n (y : β), ValidN n y → ✓{n} (g y))
+    (validN_ne : ∀ n (y₁ y₂ : β), y₁ ≡{n}≡ y₂ → ValidN n y₁ → ValidN n y₂)
+    (valid_validN : ∀ y : β, Valid y ↔ ∀ n, ValidN n y)
+    (validN_le : ∀ n n' (y : β), ValidN n y → n' ≤ n → ValidN n' y)
+    (validN_op_left : ∀ n (y₁ y₂ : β), ValidN n (op y₁ y₂) → ValidN n y₁) :
+    @ExtensionLaws β (ofInjRestrictValidity pcore op Valid ValidN f g g_dist gf_dist
+      g_pcore_dist g_op g_validN validN_ne valid_validN validN_le validN_op_left) :=
+  letI := ofInjRestrictValidity pcore op Valid ValidN f g g_dist gf_dist g_pcore_dist g_op
+    g_validN validN_ne valid_validN validN_le validN_op_left
+  have g_pcore : ∀ {y cy : β}, pcore y = some cy ↔ CMRA.pcore (g y) = some (g cy) :=
+    eq_dist.trans <| (forall_congr' fun n => g_pcore_dist _ _ n).trans eq_dist.symm
+  ⟨fun {y cy} h z => by
+    obtain ⟨c, hc⟩ := pcore_op_mono (g_pcore.mp h) (g z)
+    obtain ⟨w, hw⟩ : ∃ w, (f c).elim cy (op cy) = op cy w :=
+      match f c with
+      | some w => ⟨w, rfl⟩
+      | none => ⟨cy, (CMRA.pcore_op_left (CMRA.pcore_idem h)).symm⟩
+    rw [← g_op, ← g_opM_f c cy, hw] at hc
+    exact ⟨w, g_pcore.mpr hc⟩⟩
+
+/-- Constructing a resource algebra through an isomorphism that may restrict validity. -/
 @[reducible, rocq_alias iso_cmra_mixin_restrict_validity]
-def ofIsoRestrictValidity [CMRA α] [OFE β]
+def ofIsoRestrictValidity [RABase α] [OFE β]
     (pcore : β → Option β) (op : β → β → β) (Valid : β → Prop) (ValidN : Nat → β → Prop)
     (f : α → β) (g : β → α)
     -- `g` is non-expansive and injective w.r.t. OFE equality
@@ -2348,7 +3451,7 @@ def ofIsoRestrictValidity [CMRA α] [OFE β]
     (valid_validN : ∀ y : β, Valid y ↔ ∀ n, ValidN n y)
     (validN_le : ∀ n n' (y : β), ValidN n y → n' ≤ n → ValidN n' y)
     (validN_op_left : ∀ n (y₁ y₂ : β), ValidN n (op y₁ y₂) → ValidN n y₁) :
-    CMRA β :=
+    RABase β :=
   ofInjRestrictValidity pcore op Valid ValidN (fun x => some (f x)) g g_dist
     (fun x y n => ⟨fun h => ((g_dist ..).mp h.symm).trans (gf x).dist,
       fun h => (g_dist ..).mpr <| (gf x).dist.trans h.symm⟩)
@@ -2357,12 +3460,30 @@ def ofIsoRestrictValidity [CMRA α] [OFE β]
       cases pcore y with
       | none => simp
       | some z => exact g_dist n z cy)
+    g_op g_validN validN_ne valid_validN validN_le validN_op_left
+
+/-- `RABase.ofIsoRestrictValidity` inherits the extension laws of `α`. -/
+theorem ofIsoRestrictValidity_extensionLaws [RABase α] [ExtensionLaws α] [OFE β]
+    (pcore : β → Option β) (op : β → β → β) (Valid : β → Prop) (ValidN : Nat → β → Prop)
+    (f : α → β) (g : β → α)
+    (g_dist : ∀ n (y₁ y₂ : β), y₁ ≡{n}≡ y₂ ↔ g y₁ ≡{n}≡ g y₂)
+    (gf : ∀ x : α, g (f x) = x)
+    (g_pcore : ∀ y : β, CMRA.pcore (g y) = (pcore y).map g)
+    (g_op : ∀ y₁ y₂, g (op y₁ y₂) = g y₁ • g y₂)
+    (g_validN : ∀ n (y : β), ValidN n y → ✓{n} (g y))
+    (validN_ne : ∀ n (y₁ y₂ : β), y₁ ≡{n}≡ y₂ → ValidN n y₁ → ValidN n y₂)
+    (valid_validN : ∀ y : β, Valid y ↔ ∀ n, ValidN n y)
+    (validN_le : ∀ n n' (y : β), ValidN n y → n' ≤ n → ValidN n' y)
+    (validN_op_left : ∀ n (y₁ y₂ : β), ValidN n (op y₁ y₂) → ValidN n y₁) :
+    @ExtensionLaws β (ofIsoRestrictValidity pcore op Valid ValidN f g g_dist gf g_pcore g_op
+      g_validN validN_ne valid_validN validN_le validN_op_left) :=
+  ofInjRestrictValidity_extensionLaws pcore op Valid ValidN (fun x => some (f x)) g g_dist _ _
     g_op (fun x y => (g_op y (f x)).trans <| congrArg (g y • ·) (gf x))
     g_validN validN_ne valid_validN validN_le validN_op_left
 
-/-- Constructing a CMRA through an isomorphism. -/
+/-- Constructing a resource algebra through an isomorphism. -/
 @[reducible, rocq_alias iso_cmra_mixin]
-def ofIso [CMRA α] [OFE β]
+def ofIso [RABase α] [OFE β]
     (pcore : β → Option β) (op : β → β → β) (Valid : β → Prop) (ValidN : Nat → β → Prop)
     (f : α → β) (g : β → α)
     -- `g` is non-expansive and injective w.r.t. OFE equality
@@ -2374,7 +3495,7 @@ def ofIso [CMRA α] [OFE β]
     (g_op : ∀ y₁ y₂, g (op y₁ y₂) = g y₁ • g y₂)
     (g_valid : ∀ y : β, ✓ (g y) ↔ Valid y)
     (g_validN : ∀ n (y : β), ✓{n} (g y) ↔ ValidN n y) :
-    CMRA β :=
+    RABase β :=
   ofIsoRestrictValidity pcore op Valid ValidN f g g_dist gf g_pcore g_op
     (fun n y => (g_validN n y).mpr)
     (fun n y₁ y₂ h hv =>
@@ -2385,6 +3506,19 @@ def ofIso [CMRA α] [OFE β]
     (fun n y₁ y₂ hv => (g_validN n y₁).mp <| CMRA.validN_op_left <|
       g_op y₁ y₂ ▸ (g_validN n (op y₁ y₂)).mpr hv)
 
+/-- `RABase.ofIso` inherits the extension laws of `α`. -/
+theorem ofIso_extensionLaws [RABase α] [ExtensionLaws α] [OFE β]
+    (pcore : β → Option β) (op : β → β → β) (Valid : β → Prop) (ValidN : Nat → β → Prop)
+    (f : α → β) (g : β → α)
+    (g_dist : ∀ n (y₁ y₂ : β), y₁ ≡{n}≡ y₂ ↔ g y₁ ≡{n}≡ g y₂)
+    (gf : ∀ x : α, g (f x) = x)
+    (g_pcore : ∀ y : β, CMRA.pcore (g y) = (pcore y).map g)
+    (g_op : ∀ y₁ y₂, g (op y₁ y₂) = g y₁ • g y₂)
+    (g_valid : ∀ y : β, ✓ (g y) ↔ Valid y)
+    (g_validN : ∀ n (y : β), ✓{n} (g y) ↔ ValidN n y) :
+    @ExtensionLaws β (ofIso pcore op Valid ValidN f g g_dist gf g_pcore g_op g_valid g_validN) :=
+  ofIsoRestrictValidity_extensionLaws pcore op Valid ValidN f g g_dist gf g_pcore g_op _ _ _ _ _
+
 @[reducible, rocq_alias discrete_cmra_mixin]
 def ofDiscrete [OFE α] [OFE.Discrete α]
     (pcore : α → Option α) (op : α → α → α) (Valid : α → Prop)
@@ -2392,10 +3526,8 @@ def ofDiscrete [OFE α] [OFE.Discrete α]
     (comm : ∀ x y : α, op x y = op y x)
     (pcore_op_left : ∀ x cx : α, pcore x = some cx → op cx x = x)
     (pcore_idem : ∀ x cx : α, pcore x = some cx → pcore cx = some cx)
-    (pcore_mono : ∀ x cx y : α, (∃ z, y = op x z) → pcore x = some cx →
-      ∃ cy, pcore y = some cy ∧ ∃ z, cy = op cx z)
     (valid_op_left : ∀ x y : α, Valid (op x y) → Valid x) :
-    CMRA α where
+    RABase α where
   pcore := pcore
   op := op
   ValidN _ := Valid
@@ -2410,7 +3542,6 @@ def ofDiscrete [OFE α] [OFE.Discrete α]
   comm := comm ..
   pcore_op_left := pcore_op_left _ _
   pcore_idem := pcore_idem _ _
-  pcore_op_mono := pcore_op_mono_of_core_op_mono op pcore pcore_mono _ _
   extend _ h := ⟨_, _, OFE.discrete h, .rfl, .rfl⟩
 
 @[reducible, rocq_alias ra_total_mixin]
@@ -2420,26 +3551,27 @@ def ofDiscreteTotal [OFE α] [OFE.Discrete α]
     (comm : ∀ x y : α, op x y = op y x)
     (core_op_left : ∀ x : α, op (core x) x = x)
     (core_idem : ∀ x : α, core (core x) = core x)
-    (core_mono : ∀ x y : α, (∃ z, y = op x z) → ∃ z, core y = op (core x) z)
     (valid_op_left : ∀ x y : α, Valid (op x y) → Valid x) :
-    CMRA α :=
+    RABase α :=
   ofDiscrete (fun x => some (core x)) op Valid assoc comm
     (fun _ _ h => Option.some.inj h ▸ core_op_left _)
     (fun _ _ h => Option.some.inj h ▸ congrArg some (core_idem _))
-    (fun _ _ _ hy h => ⟨core _, rfl, Option.some.inj h ▸ core_mono _ _ hy⟩)
     valid_op_left
 
 section OfDiscrete
 
 @[rocq_alias discrete_cmra_discrete]
 instance ofDiscrete_discrete [OFE α] [OFE.Discrete α] (pcore : α → Option α)
-  (op : α → α → α) (Valid : α → Prop)
-  h₁ h₂ h₃ h₄ h₅ h₆ :
-    @CMRA.Discrete α (ofDiscrete pcore op Valid h₁ h₂ h₃ h₄ h₅ h₆) :=
-  letI := ofDiscrete pcore op Valid h₁ h₂ h₃ h₄ h₅ h₆
-  { discrete_valid := id }
+    (op : α → α → α) (Valid : α → Prop) h₁ h₂ h₃ h₄ h₅
+    [H : @ExtensionLaws α (ofDiscrete pcore op Valid h₁ h₂ h₃ h₄ h₅)] :
+    @CMRA.Discrete α
+      (@CMRA.withExtensionOrder α (ofDiscrete pcore op Valid h₁ h₂ h₃ h₄ h₅) H) :=
+  letI := ofDiscrete pcore op Valid h₁ h₂ h₃ h₄ h₅
+  letI := CMRA.withExtensionOrder (α := α)
+  { discrete_valid := id
+    discrete_inc := incExt_of_incExt0 }
 
 end OfDiscrete
 
-end CMRA
+end RABase
 end CmraMixin

--- a/Iris/Iris/Algebra/Csum.lean
+++ b/Iris/Iris/Algebra/Csum.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Markus de Medeiros
+Authors: Markus de Medeiros, Janine Lohse
 -/
 module
 
@@ -200,8 +200,24 @@ private theorem pcore_map_inr_eq [CMRA β] {b : β} {cx : Csum α β}
     ∃ cb, CMRA.pcore b = some cb ∧ cx = inr cb := by
   cases _ : CMRA.pcore b <;> simp_all
 
-@[rocq_alias csum_cmra_mixin]
-instance [CMRA α] [CMRA β] : CMRA (Csum α β) where
+/-- The step-indexed order on `Csum α β`: the orders of `α` and `β` on the two summands, with
+`invalid` as the top element. -/
+abbrev IncludedN [CMRA α] [CMRA β] (n : Nat) : Csum α β → Csum α β → Prop
+  | _, invalid => True
+  | inl a, inl a' => a ≼{n} a'
+  | inr b, inr b' => b ≼{n} b'
+  | _, _ => False
+
+/-- The order on `Csum α β`; see `Csum.IncludedN`. -/
+abbrev Included [CMRA α] [CMRA β] : Csum α β → Csum α β → Prop
+  | _, invalid => True
+  | inl a, inl a' => a ≼ a'
+  | inr b, inr b' => b ≼ b'
+  | _, _ => False
+
+/-- The resource algebra on `Csum α β`. -/
+@[reducible, rocq_alias csum_cmra_mixin]
+def raBase [CMRA α] [CMRA β] : RABase (Csum α β) where
   pcore := Csum.pcore
   op := Csum.op
   Valid := Csum.valid
@@ -211,10 +227,10 @@ instance [CMRA α] [CMRA β] : CMRA (Csum α β) where
   pcore_ne {n x y cx} hxy hpx := by
     cases x <;> cases y <;> try exact hxy.elim
     · obtain ⟨ca, hpa, rfl⟩ := pcore_map_inl_eq hpx
-      obtain ⟨cy, hcy, ecy⟩ := CMRA.pcore_ne hxy hpa
+      obtain ⟨cy, hcy, ecy⟩ := CMRA.pcore_ne (cx := ca) hxy hpa
       exact ⟨inl cy, by simp [Csum.pcore, hcy], ecy⟩
     · obtain ⟨cb, hpb, rfl⟩ := pcore_map_inr_eq hpx
-      obtain ⟨cy, hcy, ecy⟩ := CMRA.pcore_ne hxy hpb
+      obtain ⟨cy, hcy, ecy⟩ := CMRA.pcore_ne (cx := cb) hxy hpb
       exact ⟨inr cy, by simp [Csum.pcore, hcy], ecy⟩
     · simp only [Csum.pcore, Option.some.injEq] at hpx
       exact ⟨invalid, rfl, hpx ▸ .rfl⟩
@@ -238,21 +254,6 @@ instance [CMRA α] [CMRA β] : CMRA (Csum α β) where
       obtain ⟨cb, hpb, rfl⟩ := pcore_map_inr_eq hpx
       exact Option.map_forall₂ inr (CMRA.pcore_idem hpb)
     | invalid => simp only [Csum.pcore, Option.some.injEq] at hpx; exact hpx ▸ rfl
-  pcore_op_mono {x cx} hpx y := by cases x with
-    | inl a =>
-      obtain ⟨ca, hpa, rfl⟩ := pcore_map_inl_eq hpx; cases y with
-      | inl a' =>
-        obtain ⟨cy, hcy⟩ := CMRA.pcore_op_mono hpa a'
-        exact ⟨inl cy, Option.map_forall₂ inl hcy⟩
-      | _ => exact ⟨invalid, rfl⟩
-    | inr b =>
-      obtain ⟨cb, hpb, rfl⟩ := pcore_map_inr_eq hpx; cases y with
-      | inr b' =>
-        obtain ⟨cy, hcy⟩ := CMRA.pcore_op_mono hpb b'
-        exact ⟨inr cy, Option.map_forall₂ inr hcy⟩
-      | _ => exact ⟨invalid, rfl⟩
-    | invalid =>
-      simp only [Csum.pcore, Option.some.injEq] at hpx; exact hpx ▸ ⟨invalid, rfl⟩
   validN_op_left {n x y} h := by
     cases x <;> cases y <;> first | exact CMRA.validN_op_left h | exact h.elim
   extend {n x y₁ y₂} hv he := by
@@ -263,6 +264,128 @@ instance [CMRA α] [CMRA β] : CMRA (Csum α β) where
          exact ⟨inl z₁, inl z₂, congrArg _ hz, hz₁, hz₂⟩)
       | (obtain ⟨z₁, z₂, hz, hz₁, hz₂⟩ := CMRA.extend hv he
          exact ⟨inr z₁, inr z₂, congrArg _ hz, hz₁, hz₂⟩)
+
+/-- The order on `Csum α β`. -/
+@[reducible] def orderN [CMRA α] [CMRA β] : OrderN (Csum α β) where
+  IncludedN := IncludedN
+  Included := Included
+  incN_ne {n x x' y y'} ex ey h := by
+    cases x <;> cases x' <;> cases y <;> cases y' <;>
+      first | trivial | exact ex.elim | exact ey.elim | exact h.elim | exact CMRA.incN_ne ex ey h
+  incN_succ {n x y} h := by
+    cases x <;> cases y <;> first | trivial | exact h.elim | exact CMRA.incN_succ h
+  incN_trans {n x y z} h₁ h₂ := by
+    cases x <;> cases y <;> cases z <;>
+      first | trivial | exact h₁.elim | exact h₂.elim | exact CMRA.incN_trans h₁ h₂
+  inc_trans {x y z} h₁ h₂ := by
+    cases x <;> cases y <;> cases z <;>
+      first | trivial | exact h₁.elim | exact h₂.elim | exact CMRA.inc_trans h₁ h₂
+  incN_of_inc {x y} n h := by
+    cases x <;> cases y <;> first | trivial | exact h.elim | exact CMRA.incN_of_inc n h
+
+section
+variable [CMRA α] [CMRA β]
+attribute [local instance] raBase orderN
+
+theorem increasing_inl_iff {a : α} : Increasing (inl (β := β) a) ↔ Increasing a where
+  mp h := ⟨fun a' => h.increasing (inl a')⟩
+  mpr h := ⟨fun | inl a' => h.increasing a' | inr _ | invalid => trivial⟩
+
+theorem increasing_inr_iff {b : β} : Increasing (inr (α := α) b) ↔ Increasing b where
+  mp h := ⟨fun b' => h.increasing (inr b')⟩
+  mpr h := ⟨fun | inr b' => h.increasing b' | inl _ | invalid => trivial⟩
+
+instance : Increasing (invalid : Csum α β) := ⟨fun _ => trivial⟩
+
+theorem incNR_inl {n} {a a' : α} (h : inl (β := β) a ≼*{n} inl a') : a ≼*{n} a' := h.imp id id
+theorem incNR_inr {n} {b b' : β} (h : inr (α := α) b ≼*{n} inr b') : b ≼*{n} b' := h.imp id id
+
+instance instCMRA : CMRA (Csum α β) where
+  toRABase := raBase
+  toOrderN := orderN
+  op_monoN_left {n x y} z h := by
+    cases x <;> cases y <;> cases z <;>
+      first | trivial | exact h.elim | exact CMRA.op_monoN_left _ h
+  op_mono_left {x y} z h := by
+    cases x <;> cases y <;> cases z <;>
+      first | trivial | exact h.elim | exact CMRA.op_mono_left _ h
+  validN_of_incN {n x y} h v := by
+    cases x <;> cases y <;> first | trivial | exact h.elim | exact v.elim | exact CMRA.validN_of_incN h v
+  pcore_monoN {n x y cx} h e := by
+    match x, y, h with
+    | inl a, inl a', h =>
+      obtain ⟨ca, hpa, rfl⟩ := pcore_map_inl_eq e
+      obtain ⟨ca', hpa', hi⟩ := CMRA.pcore_monoN h hpa
+      exact ⟨inl ca', Option.map_forall₂ inl hpa', hi⟩
+    | inr b, inr b', h =>
+      obtain ⟨cb, hpb, rfl⟩ := pcore_map_inr_eq e
+      obtain ⟨cb', hpb', hi⟩ := CMRA.pcore_monoN h hpb
+      exact ⟨inr cb', Option.map_forall₂ inr hpb', hi⟩
+    | inl _, invalid, _ | inr _, invalid, _ | invalid, invalid, _ => exact ⟨invalid, rfl, trivial⟩
+    | inl _, inr _, h | inr _, inl _, h | invalid, inl _, h | invalid, inr _, h => exact h.elim
+  pcore_mono {x y cx} h e := by
+    match x, y, h with
+    | inl a, inl a', h =>
+      obtain ⟨ca, hpa, rfl⟩ := pcore_map_inl_eq e
+      obtain ⟨ca', hpa', hi⟩ := CMRA.pcore_mono h hpa
+      exact ⟨inl ca', Option.map_forall₂ inl hpa', hi⟩
+    | inr b, inr b', h =>
+      obtain ⟨cb, hpb, rfl⟩ := pcore_map_inr_eq e
+      obtain ⟨cb', hpb', hi⟩ := CMRA.pcore_mono h hpb
+      exact ⟨inr cb', Option.map_forall₂ inr hpb', hi⟩
+    | inl _, invalid, _ | inr _, invalid, _ | invalid, invalid, _ => exact ⟨invalid, rfl, trivial⟩
+    | inl _, inr _, h | inr _, inl _, h | invalid, inl _, h | invalid, inr _, h => exact h.elim
+  pcore_order_op {x cx} e y := by
+    match x, y with
+    | inl a, inl a' =>
+      obtain ⟨ca, hpa, rfl⟩ := pcore_map_inl_eq e
+      obtain ⟨caa, hpaa, hi⟩ := CMRA.pcore_order_op hpa a'
+      exact ⟨inl caa, Option.map_forall₂ inl hpaa, hi⟩
+    | inr b, inr b' =>
+      obtain ⟨cb, hpb, rfl⟩ := pcore_map_inr_eq e
+      obtain ⟨cbb, hpbb, hi⟩ := CMRA.pcore_order_op hpb b'
+      exact ⟨inr cbb, Option.map_forall₂ inr hpbb, hi⟩
+    | inl _, inr _ | inl _, invalid | inr _, inl _ | inr _, invalid
+    | invalid, inl _ | invalid, inr _ | invalid, invalid => exact ⟨invalid, rfl, trivial⟩
+  pcore_increasing {x cx} e := by
+    match x with
+    | inl a =>
+      obtain ⟨ca, hpa, rfl⟩ := pcore_map_inl_eq e
+      exact increasing_inl_iff.mpr (CMRA.pcore_increasing hpa)
+    | inr b =>
+      obtain ⟨cb, hpb, rfl⟩ := pcore_map_inr_eq e
+      exact increasing_inr_iff.mpr (CMRA.pcore_increasing hpb)
+    | invalid => cases e; exact inferInstance
+  increasing_closed {n x y} h h' := by
+    match x, y, h' with
+    | _, invalid, _ => exact inferInstance
+    | inl _, inl _, h' =>
+      exact increasing_inl_iff.mpr ((increasing_inl_iff.mp h).of_incNR (incNR_inl h'))
+    | inr _, inr _, h' =>
+      exact increasing_inr_iff.mpr ((increasing_inr_iff.mp h).of_incNR (incNR_inr h'))
+    | inl _, inr _, h' | inr _, inl _, h' | invalid, inl _, h' | invalid, inr _, h' =>
+      exact h'.elim (·.elim) (·.elim)
+  incN_extend {n x y} v h := by
+    match x, y, h with
+    | inl _, inl _, h =>
+      obtain ⟨z, hz, ez⟩ := CMRA.incN_extend v h
+      exact ⟨inl z, hz, ez⟩
+    | inr _, inr _, h =>
+      obtain ⟨z, hz, ez⟩ := CMRA.incN_extend v h
+      exact ⟨inr z, hz, ez⟩
+    | inl _, invalid, _ | inr _, invalid, _ | invalid, invalid, _ => exact v.elim
+    | inl _, inr _, h | inr _, inl _, h | invalid, inl _, h | invalid, inr _, h => exact h.elim
+
+end
+
+instance [CMRA α] [CMRA β] [IncRefl α] [IncRefl β] : IncRefl (Csum α β) where
+  inc_refl | inl a => CMRA.inc_refl a | inr b => CMRA.inc_refl b | invalid => trivial
+
+instance [CMRA α] [CMRA β] [Affine α] [Affine β] : Affine (Csum α β) where
+  increasing
+    | inl a => increasing_inl_iff.mpr (Affine.increasing a)
+    | inr b => increasing_inr_iff.mpr (Affine.increasing b)
+    | invalid => inferInstance
 
 #rocq_ignore csumR "Use Csum type with typeclass inference"
 #rocq_ignore csum_op_instance "Use CMRA instance"
@@ -285,6 +408,9 @@ instance [CMRA α] [CMRA β] [CMRA.Discrete α] [CMRA.Discrete β] : CMRA.Discre
     | inl a => CMRA.discrete_valid (x := a) hv
     | inr b => CMRA.discrete_valid (x := b) hv
     | invalid => hv
+  discrete_inc {x y} h := by
+    cases x <;> cases y <;>
+      first | trivial | exact h.elim | exact CMRA.discrete_inc (α := α) h | exact CMRA.discrete_inc (α := β) h
 
 /-! ## CoreId -/
 
@@ -334,11 +460,100 @@ instance [CMRA α] [CMRA β] {b : β} [IdFree b] : IdFree (inr (α := α) b) whe
 
 /-! ## Included -/
 
-@[rocq_alias csum_included]
 theorem included [CMRA α] [CMRA β] {x y : Csum α β} :
     x ≼ y ↔ y = invalid ∨
       (∃ a a', x = inl a ∧ y = inl a' ∧ a ≼ a') ∨
       (∃ b b', x = inr b ∧ y = inr b' ∧ b ≼ b') := by
+  constructor
+  · intro h
+    cases x <;> cases y <;>
+      first
+      | exact Or.inl rfl
+      | exact Or.inr (Or.inl ⟨_, _, rfl, rfl, h⟩)
+      | exact Or.inr (Or.inr ⟨_, _, rfl, rfl, h⟩)
+      | exact h.elim
+  · rintro (rfl | ⟨a, a', rfl, rfl, h⟩ | ⟨b, b', rfl, rfl, h⟩)
+    · cases x <;> trivial
+    · exact h
+    · exact h
+
+theorem inl_included [CMRA α] [CMRA β] {a a' : α} : (inl (β := β) a) ≼ inl a' ↔ a ≼ a' := .rfl
+
+theorem inr_included [CMRA α] [CMRA β] {b b' : β} : (inr (α := α) b) ≼ inr b' ↔ b ≼ b' := .rfl
+
+theorem invalid_included [CMRA α] [CMRA β] (x : Csum α β) : x ≼ invalid := by cases x <;> trivial
+
+theorem includedN [CMRA α] [CMRA β] {n} {x y : Csum α β} :
+    x ≼{n} y ↔ y = invalid ∨
+      (∃ a a', x = inl a ∧ y = inl a' ∧ a ≼{n} a') ∨
+      (∃ b b', x = inr b ∧ y = inr b' ∧ b ≼{n} b') := by
+  constructor
+  · intro h
+    cases x <;> cases y <;>
+      first
+      | exact Or.inl rfl
+      | exact Or.inr (Or.inl ⟨_, _, rfl, rfl, h⟩)
+      | exact Or.inr (Or.inr ⟨_, _, rfl, rfl, h⟩)
+      | exact h.elim
+  · rintro (rfl | ⟨a, a', rfl, rfl, h⟩ | ⟨b, b', rfl, rfl, h⟩)
+    · cases x <;> trivial
+    · exact h
+    · exact h
+
+theorem some_included [CMRA α] [CMRA β] {x y : Csum α β} :
+    some x ≼ some y ↔ y = invalid ∨
+      (∃ a a', x = inl a ∧ y = inl a' ∧ some a ≼ some a') ∨
+      (∃ b b', x = inr b ∧ y = inr b' ∧ some b ≼ some b') := by
+  rw [Option.some_inc_some_iff]
+  constructor
+  · rintro (rfl | h)
+    · cases x <;>
+        first
+        | exact .inl rfl
+        | exact .inr (Or.inl ⟨_, _, rfl, rfl, Or.inl rfl⟩)
+        | exact .inr (Or.inr ⟨_, _, rfl, rfl, Or.inl rfl⟩)
+    · rcases included.mp h with rfl | ⟨a, a', rfl, rfl, ha⟩ | ⟨b, b', rfl, rfl, hb⟩
+      · exact .inl rfl
+      · exact .inr (Or.inl ⟨a, a', rfl, rfl, Or.inr ha⟩)
+      · exact .inr (Or.inr ⟨b, b', rfl, rfl, Or.inr hb⟩)
+  · rintro (rfl | ⟨a, a', rfl, rfl, (rfl | h)⟩ | ⟨b, b', rfl, rfl, (rfl | h)⟩)
+    · exact .inr (invalid_included x)
+    · exact .inl rfl
+    · exact .inr h
+    · exact .inl rfl
+    · exact .inr h
+
+theorem some_includedN [CMRA α] [CMRA β] {n} {x y : Csum α β} :
+    some x ≼{n} some y ↔ y = invalid ∨
+      (∃ a a', x = inl a ∧ y = inl a' ∧ some a ≼{n} some a') ∨
+      (∃ b b', x = inr b ∧ y = inr b' ∧ some b ≼{n} some b') := by
+  rw [Option.some_incN_some_iff]
+  constructor
+  · rintro (heq | h)
+    · cases x <;> cases y <;>
+        first
+        | exact .inl rfl
+        | exact heq.elim
+        | exact .inr (Or.inl ⟨_, _, rfl, rfl, Or.inl heq⟩)
+        | exact .inr (Or.inr ⟨_, _, rfl, rfl, Or.inl heq⟩)
+    · rcases includedN.mp h with rfl | ⟨a, a', rfl, rfl, ha⟩ | ⟨b, b', rfl, rfl, hb⟩
+      · exact .inl rfl
+      · exact .inr (Or.inl ⟨a, a', rfl, rfl, Or.inr ha⟩)
+      · exact .inr (Or.inr ⟨b, b', rfl, rfl, Or.inr hb⟩)
+  · rintro (rfl | ⟨a, a', rfl, rfl, (heq | h)⟩ | ⟨b, b', rfl, rfl, (heq | h)⟩)
+    · exact .inr (invalid_included x)
+    · exact .inl heq
+    · exact .inr h
+    · exact .inl heq
+    · exact .inr h
+
+/-! ### The extension inclusion -/
+
+@[rocq_alias csum_included]
+theorem included_ext [CMRA α] [CMRA β] {x y : Csum α β} :
+    x ≼ₑ y ↔ y = invalid ∨
+      (∃ a a', x = inl a ∧ y = inl a' ∧ a ≼ₑ a') ∨
+      (∃ b b', x = inr b ∧ y = inr b' ∧ b ≼ₑ b') := by
   constructor
   · rintro ⟨z, hz⟩; cases x <;> cases z <;> cases y <;>
       first
@@ -352,30 +567,30 @@ theorem included [CMRA α] [CMRA β] {x y : Csum α β} :
     · exact ⟨inr c, congrArg inr hc⟩
 
 @[rocq_alias Cinl_included]
-theorem inl_included [CMRA α] [CMRA β] {a a' : α} :
-    (inl (β := β) a) ≼ inl a' ↔ a ≼ a' := by
+theorem inl_included_ext [CMRA α] [CMRA β] {a a' : α} :
+    (inl (β := β) a) ≼ₑ inl a' ↔ a ≼ₑ a' := by
   constructor
   · rintro ⟨z, hz⟩; cases z <;>
       first | exact ⟨_, Csum.inl.inj hz⟩ | exact absurd hz (by simp [CMRA.op, Csum.op])
   · rintro ⟨c, hc⟩; exact ⟨inl c, congrArg inl hc⟩
 
 @[rocq_alias Cinr_included]
-theorem inr_included [CMRA α] [CMRA β] {b b' : β} :
-    (inr (α := α) b) ≼ inr b' ↔ b ≼ b' := by
+theorem inr_included_ext [CMRA α] [CMRA β] {b b' : β} :
+    (inr (α := α) b) ≼ₑ inr b' ↔ b ≼ₑ b' := by
   constructor
   · rintro ⟨z, hz⟩; cases z <;>
       first | exact ⟨_, Csum.inr.inj hz⟩ | exact absurd hz (by simp [CMRA.op, Csum.op])
   · rintro ⟨c, hc⟩; exact ⟨inr c, congrArg inr hc⟩
 
 @[rocq_alias CsumInvalid_included]
-theorem invalid_included [CMRA α] [CMRA β] (x : Csum α β) : x ≼ invalid :=
+theorem invalid_included_ext [CMRA α] [CMRA β] (x : Csum α β) : x ≼ₑ invalid :=
   ⟨invalid, by cases x <;> rfl⟩
 
 @[rocq_alias csum_includedN]
-theorem includedN [CMRA α] [CMRA β] {n} {x y : Csum α β} :
-    x ≼{n} y ↔ y = invalid ∨
-      (∃ a a', x = inl a ∧ y = inl a' ∧ a ≼{n} a') ∨
-      (∃ b b', x = inr b ∧ y = inr b' ∧ b ≼{n} b') := by
+theorem includedN_ext [CMRA α] [CMRA β] {n} {x y : Csum α β} :
+    x ≼ₑ{n} y ↔ y = invalid ∨
+      (∃ a a', x = inl a ∧ y = inl a' ∧ a ≼ₑ{n} a') ∨
+      (∃ b b', x = inr b ∧ y = inr b' ∧ b ≼ₑ{n} b') := by
   constructor
   · rintro ⟨z, hz⟩; cases x <;> cases z <;> cases y <;>
       first
@@ -389,44 +604,44 @@ theorem includedN [CMRA α] [CMRA β] {n} {x y : Csum α β} :
     · exact ⟨inr c, hc⟩
 
 @[rocq_alias Some_csum_included]
-theorem some_included [CMRA α] [CMRA β] {x y : Csum α β} :
-    some x ≼ some y ↔ y = invalid ∨
-      (∃ a a', x = inl a ∧ y = inl a' ∧ some a ≼ some a') ∨
-      (∃ b b', x = inr b ∧ y = inr b' ∧ some b ≼ some b') := by
+theorem some_included_ext [CMRA α] [CMRA β] {x y : Csum α β} :
+    some x ≼ₑ some y ↔ y = invalid ∨
+      (∃ a a', x = inl a ∧ y = inl a' ∧ some a ≼ₑ some a') ∨
+      (∃ b b', x = inr b ∧ y = inr b' ∧ some b ≼ₑ some b') := by
   constructor
-  · intro h; rcases Option.some_inc_some_iff.mp h with heq | hinc
+  · intro h; rcases Option.some_incExt_some_iff.mp h with heq | hinc
     · subst heq
       cases x <;>
         first
         | exact .inl rfl
-        | exact .inr (Or.inl ⟨_, _, rfl, rfl, Option.some_inc_some_iff.mpr (.inl rfl)⟩)
-        | exact .inr (Or.inr ⟨_, _, rfl, rfl, Option.some_inc_some_iff.mpr (.inl rfl)⟩)
-    · rcases included.mp hinc with rfl | ⟨a, a', rfl, rfl, ha⟩ | ⟨b, b', rfl, rfl, hb⟩
+        | exact .inr (Or.inl ⟨_, _, rfl, rfl, Option.some_incExt_some_iff.mpr (.inl rfl)⟩)
+        | exact .inr (Or.inr ⟨_, _, rfl, rfl, Option.some_incExt_some_iff.mpr (.inl rfl)⟩)
+    · rcases included_ext.mp hinc with rfl | ⟨a, a', rfl, rfl, ha⟩ | ⟨b, b', rfl, rfl, hb⟩
       · exact .inl rfl
-      · exact .inr (Or.inl ⟨a, a', rfl, rfl, Option.some_inc_some_iff.mpr (.inr ha)⟩)
-      · exact .inr (Or.inr ⟨b, b', rfl, rfl, Option.some_inc_some_iff.mpr (.inr hb)⟩)
+      · exact .inr (Or.inl ⟨a, a', rfl, rfl, Option.some_incExt_some_iff.mpr (.inr ha)⟩)
+      · exact .inr (Or.inr ⟨b, b', rfl, rfl, Option.some_incExt_some_iff.mpr (.inr hb)⟩)
   · rintro (rfl | ⟨a, a', rfl, rfl, mz, hmz⟩ | ⟨b, b', rfl, rfl, mz, hmz⟩)
     · exact ⟨some invalid, by cases x <;> rfl⟩
     · exact ⟨mz.map inl, by cases mz <;> exact congrArg (Option.map inl) hmz⟩
     · exact ⟨mz.map inr, by cases mz <;> exact congrArg (Option.map inr) hmz⟩
 
 @[rocq_alias Some_csum_includedN]
-theorem some_includedN [CMRA α] [CMRA β] {n} {x y : Csum α β} :
-    some x ≼{n} some y ↔ y = invalid ∨
-      (∃ a a', x = inl a ∧ y = inl a' ∧ some a ≼{n} some a') ∨
-      (∃ b b', x = inr b ∧ y = inr b' ∧ some b ≼{n} some b') := by
+theorem some_includedN_ext [CMRA α] [CMRA β] {n} {x y : Csum α β} :
+    some x ≼ₑ{n} some y ↔ y = invalid ∨
+      (∃ a a', x = inl a ∧ y = inl a' ∧ some a ≼ₑ{n} some a') ∨
+      (∃ b b', x = inr b ∧ y = inr b' ∧ some b ≼ₑ{n} some b') := by
   constructor
-  · intro h; rcases Option.some_incN_some_iff.mp h with heq | hinc
+  · intro h; rcases Option.some_incExtN_some_iff.mp h with heq | hinc
     · cases x <;> cases y <;>
         first
         | exact .inl rfl
         | exact heq.elim | exact (heq 0).elim
-        | exact .inr (Or.inl ⟨_, _, rfl, rfl, Option.some_incN_some_iff.mpr (.inl heq)⟩)
-        | exact .inr (Or.inr ⟨_, _, rfl, rfl, Option.some_incN_some_iff.mpr (.inl heq)⟩)
-    · rcases includedN.mp hinc with rfl | ⟨a, a', rfl, rfl, ha⟩ | ⟨b, b', rfl, rfl, hb⟩
+        | exact .inr (Or.inl ⟨_, _, rfl, rfl, Option.some_incExtN_some_iff.mpr (.inl heq)⟩)
+        | exact .inr (Or.inr ⟨_, _, rfl, rfl, Option.some_incExtN_some_iff.mpr (.inl heq)⟩)
+    · rcases includedN_ext.mp hinc with rfl | ⟨a, a', rfl, rfl, ha⟩ | ⟨b, b', rfl, rfl, hb⟩
       · exact .inl rfl
-      · exact .inr (Or.inl ⟨a, a', rfl, rfl, Option.some_incN_some_iff.mpr (.inr ha)⟩)
-      · exact .inr (Or.inr ⟨b, b', rfl, rfl, Option.some_incN_some_iff.mpr (.inr hb)⟩)
+      · exact .inr (Or.inl ⟨a, a', rfl, rfl, Option.some_incExtN_some_iff.mpr (.inr ha)⟩)
+      · exact .inr (Or.inr ⟨b, b', rfl, rfl, Option.some_incExtN_some_iff.mpr (.inr hb)⟩)
   · rintro (rfl | ⟨a, a', rfl, rfl, mz, hmz⟩ | ⟨b, b', rfl, rfl, mz, hmz⟩)
     · exact ⟨some invalid, by cases x <;> exact Dist.rfl⟩
     · exact ⟨mz.map inl, by cases mz <;> exact hmz⟩
@@ -578,6 +793,15 @@ def cMap [CMRA α] [CMRA α'] [CMRA β] [CMRA β']
     | invalid => trivial
   op x y := by cases x <;> cases y <;>
     first | exact congrArg _ (fa.op _ _) | exact congrArg _ (fb.op _ _) | trivial
+  monoN {n x y} h := by
+    cases x <;> cases y <;> first | trivial | exact h.elim | exact fa.monoN h | exact fb.monoN h
+  mono {x y} h := by
+    cases x <;> cases y <;> first | trivial | exact h.elim | exact fa.mono h | exact fb.mono h
+  increasing {x} h := by
+    cases x with
+    | inl a => exact increasing_inl_iff.mpr (fa.increasing (increasing_inl_iff.mp h))
+    | inr b => exact increasing_inr_iff.mpr (fb.increasing (increasing_inr_iff.mp h))
+    | invalid => exact (inferInstance : Increasing (invalid : Csum α' β'))
 
 instance {Fa Fb} [RFunctor Fa] [RFunctor Fb] : RFunctor (OF Fa Fb) where
   map f g := cMap (RFunctor.map f g) (RFunctor.map f g)
@@ -586,6 +810,10 @@ instance {Fa Fb} [RFunctor Fa] [RFunctor Fb] : RFunctor (OF Fa Fb) where
   map_id x := by cases x <;> simp [cMap, map] <;> exact RFunctor.map_id _
   map_comp f g f' g' x := by
     cases x <;> simp [cMap, map] <;> exact RFunctor.map_comp f g f' g' _
+
+instance {Fa Fb} [RFunctor Fa] [RFunctor Fb] [RFunctorAffine Fa] [RFunctorAffine Fb] :
+    RFunctorAffine (OF Fa Fb) where
+  affine := inferInstance
 
 @[rocq_alias csumRF_contractive]
 instance {Fa Fb} [RFunctorContractive Fa] [RFunctorContractive Fb] :

--- a/Iris/Iris/Algebra/DFrac.lean
+++ b/Iris/Iris/Algebra/DFrac.lean
@@ -69,8 +69,7 @@ def op : DFrac → DFrac → DFrac
 #rocq_ignore dfrac_valid_instance "Use CMRA instance"
 #rocq_ignore dfrac_ra_mixin "Not needed"
 
-@[rocq_alias dfracR]
-instance instCMRADFrac : CMRA DFrac where
+instance instRABaseDFrac : RABase DFrac where
   pcore := pcore
   op := op
   Valid := valid
@@ -85,12 +84,17 @@ instance instCMRADFrac : CMRA DFrac where
   comm := by rintro ⟨⟩ ⟨⟩ <;> grind [op]
   pcore_op_left := by rintro ⟨⟩ ⟨⟩ <;> simp [op, pcore]
   pcore_idem := by rintro ⟨⟩ ⟨⟩ <;> simp [pcore]
+  extend _ Hxyz := ⟨_, _, discrete Hxyz, .rfl, .rfl⟩
+
+instance : RABase.ExtensionLaws DFrac where
   pcore_op_mono := by
-    rintro ⟨⟩ ⟨⟩ <;> simp [pcore] <;>
+    rintro ⟨⟩ ⟨⟩ <;> simp [CMRA.pcore, pcore] <;>
     · intro z
       exists discard
-      rcases z with z|_|z <;> simp [op]
-  extend _ Hxyz := ⟨_, _, discrete Hxyz, .rfl, .rfl⟩
+      rcases z with z|_|z <;> simp [CMRA.op, op]
+
+@[rocq_alias dfracR]
+instance instCMRADFrac : CMRA DFrac := CMRA.withExtensionOrder
 
 @[rocq_alias dfrac_full_exclusive]
 instance own_whole_exclusive : CMRA.Exclusive (α := DFrac) (own 1) where
@@ -158,6 +162,7 @@ theorem valid_own_op_discard {q : Qp} : ✓ own q • discard ↔ q.val < 1 := b
 @[rocq_alias dfrac_cmra_discrete]
 instance : CMRA.Discrete DFrac where
   discrete_valid {x} := by simp [CMRA.Valid, CMRA.ValidN]
+  discrete_inc := RABase.incExt_of_incExt0
 
 theorem is_discrete {q : DFrac} : OFE.DiscreteE q := ⟨fun h => h⟩
 

--- a/Iris/Iris/Algebra/DynReservationMap.lean
+++ b/Iris/Iris/Algebra/DynReservationMap.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Zongyuan Liu. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Zongyuan Liu
+Authors: Zongyuan Liu, Janine Lohse
 -/
 module
 
@@ -245,8 +245,7 @@ theorem infinite_op_left {x y : DynReservationMap A H} (vt : ✓{n} (x.token •
 #rocq_ignore dyn_reservation_mapR "Derivable using UCMRA"
 #rocq_ignore dyn_reservation_map_empty_instance "Part of UCMRA instance"
 
-@[rocq_alias dyn_reservation_mapUR]
-instance instUCMRADynReservationMap : UCMRA (DynReservationMap A H) where
+instance instRABaseDynReservationMap : RABase (DynReservationMap A H) where
   pcore := some ∘ core
   Valid := Valid
   ValidN := ValidN
@@ -315,19 +314,94 @@ instance instUCMRADynReservationMap : UCMRA (DynReservationMap A H) where
     cases Option.some_inj.mp h.symm
     rcases x with ⟨xd, xt⟩
     grind only [core, core_idem]
-  pcore_op_mono {x cx} h y := by
-    obtain ⟨z, hz⟩ := core_op_mono x.data y.data
-    obtain ⟨w, hw⟩ := core_op_mono x.token y.token
-    refine ⟨mk z w, eq_dist_2 ?_⟩
-    refine fun n => ⟨?_, ?_⟩
-    · simp only [op_data', core_data, (Option.some_inj.mp h.symm)]
-      exact hz.dist
-    · simp only [core_token, op_token', (Option.some_inj.mp h.symm)]
-      exact hw.dist
   extend {n x y₁ y₂} v exy := by
     obtain ⟨z₁, z₂, xzz, zy₁, zy₂⟩ := CMRA.extend (validN_data_of_validN v) exy.left
     refine ⟨mk z₁ y₁.token, mk z₂ y₂.token, eq_dist_2 ?_, ⟨zy₁, rfl⟩, ⟨zy₂, rfl⟩⟩
     exact fun m => ⟨xzz.dist, exy.right⟩
+
+/-- The order on `DynReservationMap A H`, inherited componentwise. -/
+@[reducible] def orderN : OrderN (DynReservationMap A H) where
+  IncludedN n x y := x.data ≼{n} y.data ∧ x.token ≼{n} y.token
+  Included x y := x.data ≼ y.data ∧ x.token ≼ y.token
+  incN_ne ex ey h := ⟨CMRA.incN_ne ex.1 ey.1 h.1, CMRA.incN_ne ex.2 ey.2 h.2⟩
+  incN_succ h := ⟨CMRA.incN_succ h.1, CMRA.incN_succ h.2⟩
+  incN_trans h1 h2 := ⟨CMRA.incN_trans h1.1 h2.1, CMRA.incN_trans h1.2 h2.2⟩
+  inc_trans h1 h2 := ⟨CMRA.inc_trans h1.1 h2.1, CMRA.inc_trans h1.2 h2.2⟩
+  incN_of_inc n h := ⟨CMRA.incN_of_inc n h.1, CMRA.incN_of_inc n h.2⟩
+
+section
+attribute [local instance] orderN
+
+theorem increasing_data {v : DynReservationMap A H}
+    (h : CMRA.Increasing v) : CMRA.Increasing v.data where
+  increasing w := (h.increasing (mk w ∅)).1
+
+theorem increasing_token {v : DynReservationMap A H}
+    (h : CMRA.Increasing v) : CMRA.Increasing v.token where
+  increasing w := (h.increasing (mk ∅ w)).2
+
+theorem increasing_mk {v : DynReservationMap A H}
+    (hd : CMRA.Increasing v.data) (ht : CMRA.Increasing v.token) : CMRA.Increasing v where
+  increasing w := ⟨hd.increasing w.data, ht.increasing w.token⟩
+
+instance instCMRADynReservationMap : CMRA (DynReservationMap A H) where
+  toOrderN := orderN
+  op_monoN_left z h := ⟨CMRA.op_monoN_left z.data h.1, CMRA.op_monoN_left z.token h.2⟩
+  op_mono_left z h := ⟨CMRA.op_mono_left z.data h.1, CMRA.op_mono_left z.token h.2⟩
+  validN_of_incN {n x y} h v := by
+    refine validN_iff.mpr ⟨?_, ?_, ?_, fun i => ?_⟩
+    · exact CMRA.validN_of_incN h.1 (validN_data_of_validN v)
+    · exact CMRA.validN_of_incN h.2 (validN_token_of_validN v)
+    · obtain ⟨w, hw⟩ := h.2
+      refine infinite_op_left (y := mk ∅ w)
+        ((hw : y.token = x.token • w) ▸ validN_token_of_validN v) ?_
+      rw [Infinite, op_token', ← (hw : y.token = x.token • w)]
+      exact validN_infinite v
+    · rcases validN_disj v i with hd | ht
+      · refine .inl ?_
+        have hi := h.1 i
+        rw [hd] at hi
+        match hx : get? x.data i with
+        | none => rfl
+        | some _ => exact absurd (hx ▸ hi) Option.not_some_incN_none
+      · refine .inr fun hc => ht ?_
+        obtain ⟨w, hw⟩ := h.2
+        rw [(hw : y.token = x.token • w)]
+        exact (mem_iff_of_validN_union
+          ((hw : y.token = x.token • w) ▸ validN_token_of_validN v) i).mpr (.inl hc)
+  pcore_monoN {_ x y _} h e := by
+    cases Option.some_inj.mp e
+    exact ⟨_, rfl, CMRA.core_incN_core h.1, CMRA.core_incN_core h.2⟩
+  pcore_mono {x y _} h e := by
+    cases Option.some_inj.mp e
+    exact ⟨_, rfl, CMRA.core_mono h.1, CMRA.core_mono h.2⟩
+  pcore_order_op {x _} e y := by
+    cases Option.some_inj.mp e
+    exact ⟨_, rfl, CMRA.core_op_mono x.data y.data, CMRA.core_op_mono x.token y.token⟩
+  pcore_increasing {x _} e := by
+    cases Option.some_inj.mp e
+    refine increasing_mk ?_ ?_
+    · rw [core_data]; exact inferInstance
+    · rw [core_token]; exact inferInstance
+  increasing_closed {n x y} h h' :=
+    increasing_mk
+      (CMRA.increasing_closed (increasing_data h) (Or.imp (·.1) (·.1) h'))
+      (CMRA.increasing_closed (increasing_token h) (Or.imp (·.2) (·.2) h'))
+  incN_extend {n x y} v h := by
+    obtain ⟨zd, hzd, ed⟩ := CMRA.incN_extend (validN_data_of_validN v) h.1
+    obtain ⟨zt, hzt, et⟩ := CMRA.incN_extend (validN_token_of_validN v) h.2
+    exact ⟨mk zd zt, ⟨hzd, hzt⟩, ed, et⟩
+
+end
+
+/-- A dynamic reservation map over an affine algebra is affine. -/
+instance [CMRA.Affine A] : CMRA.Affine (DynReservationMap A H) where
+  increasing v :=
+    increasing_mk (CMRA.Affine.increasing v.data) (CMRA.Affine.increasing v.token)
+
+@[rocq_alias dyn_reservation_mapUR]
+instance instUCMRADynReservationMap : UCMRA (DynReservationMap A H) where
+  toCMRA := instCMRADynReservationMap
   unit := mk ∅ ∅
   unit_valid := valid_iff.mpr ⟨Heap.valid_empty, valid_set,
     show setInfinite ((⊤ : CoPset) \ ∅) by rw [diff_empty]; exact top_infinite,
@@ -336,6 +410,7 @@ instance instUCMRADynReservationMap : UCMRA (DynReservationMap A H) where
     exact fun n => ⟨(Algebra.MonoidOps.op_left_id : (∅ : H A) • x.data = x.data).dist,
       (pcore_op_left' rfl).dist⟩
   pcore_unit := eq_dist_2 <| by exact fun n => ⟨Heap.core_empty.dist, .rfl⟩
+  inc_refl x := ⟨CMRA.inc_refl x.data, CMRA.inc_refl x.token⟩
 
 @[simp]
 theorem op_data (x y : DynReservationMap A H) : (x • y).data = x.data • y.data := rfl
@@ -344,8 +419,8 @@ theorem op_data (x y : DynReservationMap A H) : (x • y).data = x.data • y.da
 theorem op_token (x y : DynReservationMap A H) : (x • y).token = x.token • y.token := rfl
 
 @[rocq_alias dyn_reservation_map_included]
-theorem included {x y : DynReservationMap A H} :
-    x ≼ y ↔ x.data ≼ y.data ∧ x.token ≼ y.token := by
+theorem incExt_iff {x y : DynReservationMap A H} :
+    x ≼ₑ y ↔ x.data ≼ₑ y.data ∧ x.token ≼ₑ y.token := by
   refine ⟨fun ⟨z, hz⟩ => ⟨⟨z.data, congrArg (·.data) hz⟩,
     ⟨z.token, congrArg (·.token) hz⟩⟩, ?_⟩
   exact fun ⟨⟨z₁, hz₁⟩, ⟨z₂, hz₂⟩⟩ =>
@@ -363,6 +438,7 @@ theorem token_proj_validN {n} {x : DynReservationMap A H} (h : ✓{n} x) : ✓{n
 instance [CMRA.Discrete A] : CMRA.Discrete (DynReservationMap A H) where
   discrete_valid {_} v := valid_iff.mpr ⟨discrete_valid (validN_data_of_validN v),
     validN_token_of_validN v, validN_infinite v, validN_disj v⟩
+  discrete_inc h := ⟨fun k => CMRA.discrete_inc (h.1 k), CMRA.discrete_inc h.2⟩
 
 @[rocq_alias dyn_reservation_map_data_core_id]
 instance instCoreIdSingleton {a : A} [CoreId a] : CoreId (mkData (H := H) k a) where
@@ -410,8 +486,8 @@ theorem mkData_op k (a b : A) :
     Dist.of_eq (pcore_op_right_L rfl).symm⟩
 
 @[rocq_alias dyn_reservation_map_data_mono]
-theorem mkData_mono {k} {a b : A} (Hab : a ≼ b) :
-    mkData (H := H) k a ≼ mkData k b :=
+theorem mkData_mono_ext {k} {a b : A} (Hab : a ≼ₑ b) :
+    mkData (H := H) k a ≼ₑ mkData k b :=
   let ⟨z, hz⟩ := Hab
   ⟨mkData k z, (congrArg (mkData k) hz).trans (mkData_op k a z)⟩
 

--- a/Iris/Iris/Algebra/Excl.lean
+++ b/Iris/Iris/Algebra/Excl.lean
@@ -132,8 +132,7 @@ instance [OFE α] [IsCOFE α] : IsCOFE (Excl α) where
 #rocq_ignore excl_valid_instance "Use CMRA instance"
 #rocq_ignore excl_cmra_mixin "Not needed"
 
-@[rocq_alias exclR]
-instance [OFE α] : CMRA (Excl α) where
+instance [OFE α] : RABase (Excl α) where
   pcore _ := none
   op _ _ := invalid
   ValidN _ := Valid
@@ -150,9 +149,14 @@ instance [OFE α] : CMRA (Excl α) where
   comm := by simp
   pcore_op_left := by simp
   pcore_idem := by simp
-  pcore_op_mono := by simp
   validN_op_left := by simp
   extend {n x y₁ y₂} h₁ h₂ := by cases x <;> trivial
+
+instance [OFE α] : RABase.ExtensionLaws (Excl α) where
+  pcore_op_mono := by simp
+
+@[rocq_alias exclR]
+instance [OFE α] : CMRA (Excl α) := CMRA.withExtensionOrder
 
 @[rocq_alias excl_included]
 theorem inc_iff [OFE α] {x y : Excl α} : x ≼ y ↔ y = invalid := by
@@ -180,19 +184,18 @@ theorem excl_dist_inj [OFE α] {a b : α} {n}
 @[rocq_alias Excl_included]
 theorem excl_included [OFE α] {a b : α} :
     (some (excl a) : Option (Excl α)) ≼ some (excl b) ↔ a = b := by
-  refine ⟨fun ⟨z, hz⟩ => ?_,
-    fun h => ⟨none, congrArg (fun x => some (excl x)) h.symm⟩⟩
-  rcases z with _|z
-  · exact (excl_inj hz).symm
+  refine ⟨fun h => ?_, fun h => Or.inl (congrArg excl h)⟩
+  rcases h with h | ⟨_, hz⟩
+  · exact excl.inj h
   · exact (hz.dist (n := 0)).elim
 
 @[rocq_alias Excl_includedN]
 theorem excl_includedN [OFE α] {a b : α} {n} :
     (some (excl a) : Option (Excl α)) ≼{n} some (excl b) ↔ a ≡{n}≡ b := by
-  refine ⟨fun ⟨z, hz⟩ => ?_, fun h => ⟨none, OFE.some_dist_some.mpr (show excl b ≡{n}≡ excl a from h.symm)⟩⟩
-  rcases z with _|z
-  · exact (OFE.some_dist_some.mp hz : excl b ≡{n}≡ excl a).symm
-  · exact (OFE.some_dist_some.mp hz : excl b ≡{n}≡ invalid).elim
+  refine ⟨fun h => ?_, fun h => Or.inl h⟩
+  rcases h with h | ⟨_, hz⟩
+  · exact h
+  · exact (hz : excl b ≡{n}≡ invalid).elim
 
 @[rocq_alias excl_validN_inv_l]
 theorem validN_inv_some_l [OFE α] {n} {mx : Option (Excl α)} {a : α}
@@ -214,6 +217,7 @@ instance [OFE α] {x : Excl α} : CMRA.Exclusive x where exclusive0_l := fun _ a
 @[rocq_alias excl_cmra_discrete]
 instance [OFE α] [OFE.Discrete α] : CMRA.Discrete (Excl α) where
   discrete_valid a := a
+  discrete_inc := RABase.incExt_of_incExt0
 
 @[rocq_alias ExclInvalid_included]
 theorem invalid_inc [OFE α] (ea : Excl α) : ea ≼ invalid := by exists invalid
@@ -242,11 +246,9 @@ theorem map_ne [OFE α] [OFE β] (f : α -n> β) : NonExpansive (map f) where
 #rocq_ignore Excl_proper "Derivable from NonExpansive.eqv"
 
 @[rocq_alias excl_map_cmra_morphism]
-def hom [OFE α] [OFE β] (f : α -n> β) : Excl α -C> Excl β := by
-  refine ⟨⟨map f, map_ne f⟩, ?_, ?_, ?_⟩
-  · intro n x h; cases x <;> trivial
-  · intro x; trivial
-  · intro x y; trivial
+def hom [OFE α] [OFE β] (f : α -n> β) : Excl α -C> Excl β :=
+  CMRA.Hom.withExtensionOrder ⟨map f, map_ne f⟩ (fun {_ x} _ => by cases x <;> trivial)
+    (fun _ => rfl) (fun _ _ => rfl)
 
 @[rocq_alias exclO_map]
 def oMap [OFE α] [OFE β] (f : α -n> β) : Excl α -n> Excl β := ⟨map f, map_ne f⟩
@@ -280,6 +282,9 @@ instance {F} [COFE.OFunctor F] : RFunctor (ExclOF F) where
     cases x
     · exact congrArg excl (COFE.OFunctor.map_comp _ _ _ _ _)
     · trivial
+
+instance {F} [COFE.OFunctor F] : RFunctorAffine (ExclOF F) where
+  affine := inferInstance
 
 @[rocq_alias exclRF_contractive]
 instance {F} [COFE.OFunctorContractive F] : RFunctorContractive (ExclOF F) where

--- a/Iris/Iris/Algebra/Frac.lean
+++ b/Iris/Iris/Algebra/Frac.lean
@@ -69,7 +69,7 @@ def Qp.divide_even (q : Qp) (n : Nat) (hn : 0 < n) : Qp :=
 
 instance instCOFEQp : COFE Qp := COFE.ofDiscrete _
 
-instance instCMRAQp : CMRA Qp where
+instance instRABaseQp : RABase Qp where
   pcore _ := none
   op x y := x + y
   ValidN _ x := x.val ≤ 1
@@ -87,9 +87,13 @@ instance instCMRAQp : CMRA Qp where
   comm := Subtype.ext (Rat.add_comm ..)
   pcore_op_left H := by rcases H
   pcore_idem H := by rcases H
-  pcore_op_mono H := by rcases H
   extend {_ x y z} := by
     rintro H He; exact ⟨y, z, He, .rfl, .rfl⟩
+
+instance : RABase.ExtensionLaws Qp where
+  pcore_op_mono H := by rcases H
+
+instance instCMRAQp : CMRA Qp := CMRA.withExtensionOrder
 
 -- TODO: A different solution to having these bridge lemmas might be to internalize
 -- positivity into the CMRA's validity predicate, removing the sybtype, and having Qp
@@ -139,6 +143,7 @@ theorem Frac.le_of_inc {p q : Qp} (H : p ≼ q) : p ≤ q := by
 instance instDiscreteQp : CMRA.Discrete Qp where
   discrete_0 := fun h => h
   discrete_valid := id
+  discrete_inc | ⟨z, hz⟩ => ⟨z, hz⟩
 
 @[rocq_alias frac_full_exclusive]
 instance instExclusiveQp1 : CMRA.Exclusive (α := Qp) 1 where

--- a/Iris/Iris/Algebra/Functions.lean
+++ b/Iris/Iris/Algebra/Functions.lean
@@ -104,6 +104,7 @@ variable {ι : Type _} [DecidableEq ι] {β : ι → Type _} [∀ i, UCMRA (β i
 instance instDiscreteFunCmraDiscrete [∀ i, CMRA.Discrete (β i)] :
     CMRA.Discrete ((i : ι) → β i) where
   discrete_valid h i := CMRA.Discrete.discrete_valid (h i)
+  discrete_inc h i := CMRA.Discrete.discrete_inc (h i)
 
 @[rocq_alias discrete_fun_singleton_ne]
 instance instDiscreteFunSingletonNonExpansive (x : ι) :

--- a/Iris/Iris/Algebra/GenMap.lean
+++ b/Iris/Iris/Algebra/GenMap.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Markus de Medeiros
+Authors: Markus de Medeiros, Janine Lohse
 -/
 module
 
@@ -182,7 +182,8 @@ def pcore_genmap (x : GenMap β) : Option (GenMap β) :=
     refine ⟨N, fun k hk => ?_⟩
     simp [CMRA.core, CMRA.pcore, optionCore, hN k hk]⟩
 
-instance instCMRA_GenMap : CMRA (GenMap β) where
+/-- The resource algebra on `GenMap β`, inherited pointwise from `Nat → Option β`. -/
+@[reducible] def GenMap.raBase : RABase (GenMap β) where
   pcore := pcore_genmap β
   op x y := ⟨x.car • y.car, op_bound β x y⟩
   ValidN n x := ✓{n} x.car
@@ -223,27 +224,6 @@ instance instCMRA_GenMap : CMRA (GenMap β) where
     have H : cx.car k = CMRA.core (x.car k) := congrFun hcx k
     simp only [H]
     exact (core_idem (x.car k)).dist
-  pcore_op_mono {x cx} H y := by
-    have hcx : cx.car = fun k => CMRA.core (x.car k) := by
-      simp [pcore_genmap] at H; exact (congrArg GenMap.car H).symm
-    have hpc_fun : CMRA.pcore x.car = some cx.car := by rw [hcx]; rfl
-    obtain ⟨cy, Hcy⟩ := pcore_op_mono hpc_fun y.car
-    refine ⟨⟨cy, ?_⟩, OFE.eq_dist_2 ?_⟩
-    · obtain ⟨N, hN⟩ := op_bound β x y
-      refine ⟨N, fun k hk => ?_⟩
-      have hxyk := hN k hk
-      simp [CMRA.op, optionOp] at hxyk
-      cases hx : x.car k <;> cases hy : y.car k <;> simp_all
-      have hcxy : CMRA.core (x.car • y.car) k = none := by
-        simp [CMRA.core, CMRA.pcore, optionCore, hx, hy, CMRA.op, optionOp]
-      have hHeqk := (OFE.eq_dist_1 Hcy) 0 k
-      simp only [CMRA.core, CMRA.pcore, optionCore, CMRA.op, optionOp,
-        hx, hy, Option.bind] at hHeqk
-      cases hcy : cy k <;> simp_all
-    · intro n k
-      have hHeqk := (OFE.eq_dist_1 Hcy) n k
-      simp [CMRA.core, CMRA.pcore, optionCore, CMRA.op, optionOp] at hHeqk ⊢
-      exact hHeqk
   extend {n x y1 y2} := by
     intro Hv H
     have eb := extend_bound β Hv H
@@ -251,7 +231,66 @@ instance instCMRA_GenMap : CMRA (GenMap β) where
     exact ⟨⟨fun k => (F k).1, eb.1⟩, ⟨fun k => (F k).2.1, eb.2⟩,
       OFE.eq_dist_2 fun _ k => ((F k).2.2.1).dist, fun k => (F k).2.2.2.1, fun k => (F k).2.2.2.2⟩
 
+/-- The order on `GenMap β`, inherited pointwise from `Nat → Option β`. -/
+@[reducible] def GenMap.orderN : OrderN (GenMap β) where
+  IncludedN n x y := x.car ≼{n} y.car
+  Included x y := x.car ≼ y.car
+  incN_ne ex ey h := incN_ne ex ey h
+  incN_succ := incN_succ
+  incN_trans := incN_trans
+  inc_trans := inc_trans
+  incN_of_inc n h := incN_of_inc n h
+
+section
+attribute [local instance] GenMap.raBase GenMap.orderN
+
+@[simp] theorem GenMap.op_car (x y : GenMap β) : (x • y).car = x.car • y.car := rfl
+
+theorem GenMap.increasing_apply {x : GenMap β} (h : Increasing x) (k : Nat) :
+    Increasing (x.car k) where
+  increasing b := by
+    have := h.increasing (empty.alter k b) k
+    simpa [alter, Iris.alter, DiscreteFun.op_apply] using this
+
+theorem GenMap.increasing_car {x : GenMap β} (h : Increasing x) : Increasing x.car :=
+  DiscreteFun.increasing_iff.mpr (increasing_apply β h)
+
+theorem GenMap.increasing_of_car {x : GenMap β} (h : Increasing x.car) : Increasing x where
+  increasing z := h.increasing z.car
+
+instance instCMRA_GenMap : CMRA (GenMap β) where
+  toRABase := GenMap.raBase β
+  toOrderN := GenMap.orderN β
+  op_monoN_left z h := op_monoN_left z.car h
+  op_mono_left z h := op_mono_left z.car h
+  validN_of_incN {_ x y} h v := validN_of_incN (x := x.car) (y := y.car) h v
+  pcore_monoN {_ x y _} h e := by
+    obtain rfl := Option.some.inj e
+    exact ⟨_, rfl, core_incN_core (x := x.car) (y := y.car) h⟩
+  pcore_mono {x y _} h e := by
+    obtain rfl := Option.some.inj e
+    exact ⟨_, rfl, core_mono (x := x.car) (y := y.car) h⟩
+  pcore_order_op {x _} e y := by
+    obtain rfl := Option.some.inj e
+    exact ⟨_, rfl, core_op_mono x.car y.car⟩
+  pcore_increasing {x _} e := by
+    obtain rfl := Option.some.inj e
+    exact increasing_of_car β (inferInstance : Increasing (core x.car))
+  increasing_closed h h' := increasing_of_car β (increasing_closed (increasing_car β h) h')
+  incN_extend {n x y} v h :=
+    let ⟨z, hz, ez⟩ := incN_extend v h
+    ⟨⟨z, by
+      obtain ⟨N, hN⟩ := x.bound
+      refine ⟨N, fun k hk => ?_⟩
+      have := ez k
+      rw [hN k hk] at this
+      revert this
+      cases z k <;> simp [Dist, Option.Forall₂]⟩, hz, ez⟩
+
+end
+
 instance instUCMRA_GenMap : UCMRA (GenMap β) where
+  toCMRA := instCMRA_GenMap β
   unit := GenMap.empty
   unit_valid _ := trivial
   unit_left_id {x} := OFE.eq_dist_2 fun _ k => by
@@ -260,8 +299,12 @@ instance instUCMRA_GenMap : UCMRA (GenMap β) where
   pcore_unit := OFE.eq_dist_2 fun _ => by
     refine OFE.some_dist_some.mpr fun k => ?_
     simp [empty, CMRA.core, CMRA.pcore, optionCore]
+  inc_refl x := inc_refl x.car
 
 instance : IsTotal (GenMap β) := unit_total
+
+instance [Affine β] : Affine (GenMap β) where
+  increasing x := GenMap.increasing_of_car β (Affine.increasing x.car)
 
 theorem GenMap.alter_valid {g : GenMap β} (Hb : ✓{n} b) (Hg : ✓{n} g) :
     ✓{n} g.alter a b := by
@@ -385,7 +428,7 @@ instance instURFunctor_GenMapOF (F : COFE.OFunctorPre) [RFunctor F] :
       intro _ γ
       have Hcore := @(URFunctor.map (F := OptionOF F) f g).pcore (x.car γ)
       simp only [CMRA.pcore, optionCore, Option.bind, Option.map, URFunctor.map,
-                 OFunctor.map, optionMap, CMRA.core] at Hcore ⊢
+                 OFunctor.map, CMRA.core] at Hcore ⊢
       cases h : x.car γ with
       | none => simp
       | some v =>
@@ -396,12 +439,20 @@ instance instURFunctor_GenMapOF (F : COFE.OFunctorPre) [RFunctor F] :
       intro _ γ
       have Hop := @(URFunctor.map (F := OptionOF F) f g).op (z.car γ) (x.car γ)
       simp only [Option.map, CMRA.op, optionOp, URFunctor.map] at Hop ⊢
-      cases h : z.car γ <;> cases h' : x.car γ <;>
-        simp_all [OFunctor.map, optionMap]
+      cases h : z.car γ <;> cases h' : x.car γ <;> simp_all [OFunctor.map]
+      exact ((RFunctor.map f g).op _ _).dist
+    monoN h t := (URFunctor.map (F := OptionOF F) f g).monoN (h t)
+    mono h t := (URFunctor.map (F := OptionOF F) f g).mono (h t)
+    increasing h :=
+      GenMap.increasing_of_car _ <| DiscreteFun.increasing_iff.mpr fun t =>
+        (URFunctor.map (F := OptionOF F) f g).increasing (GenMap.increasing_apply _ h t)
   }
   map_ne.ne := OFunctor.map_ne.ne
   map_id x := OFunctor.map_id x
   map_comp f g f' g' x := OFunctor.map_comp f g f' g' x
+
+instance (F : COFE.OFunctorPre) [RFunctor F] [RFunctorAffine F] : RFunctorAffine (GenMapOF F) where
+  affine := inferInstance
 
 instance instURFunctorContractive_GenMapOF (F : COFE.OFunctorPre) [RFunctorContractive F] :
     URFunctorContractive (GenMapOF F) where

--- a/Iris/Iris/Algebra/Heap.lean
+++ b/Iris/Iris/Algebra/Heap.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 Markus de Medeiros. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Markus de Medeiros, Puming Liu
+Authors: Markus de Medeiros, Puming Liu, Janine Lohse
 -/
 module
 
@@ -365,8 +365,9 @@ theorem lookup_inc {m1 m2 : M V} :
       exact fun h => (OFE.not_none_eqv_some h).elim
 
 open OFE in
-@[rocq_alias gmap_cmra_mixin, rocq_alias gmapR]
-instance instStoreCMRA : CMRA (M V) where
+/-- The resource algebra on partial maps, pointwise on `get?`. -/
+@[reducible, rocq_alias gmap_cmra_mixin]
+def raBase : RABase (M V) where
   pcore := pcore
   op := op
   ValidN := validN
@@ -419,25 +420,6 @@ instance instStoreCMRA : CMRA (M V) where
     rcases get? x k with (_|v) <;> simp
     cases HY : CMRA.pcore v; simp
     exact (pcore_idem HY).dist
-  pcore_op_mono := by
-    apply pcore_op_mono_of_core_op_mono
-    rintro x cx y ⟨z, Hz⟩
-    suffices ∃ z, (pcore y |>.getD y) = op (pcore x |>.getD x) z by
-      rintro Hx
-      simp only [pcore, Option.some.injEq, op, exists_eq_left']
-      rcases this with ⟨z', Hz'⟩
-      exists z'
-      refine Hz'.trans (OFE.eq_dist_2 fun n i => ?_)
-      cases get? z' i <;> cases get? x i <;> simp_all
-    refine lookup_inc.mpr (fun i => ?_)
-    obtain ⟨v', Hv'⟩ : (core (get? x i)) ≼ (core (get? y i))  := by
-      apply core_mono
-      exists get? z i
-      have Hz := congrArg (get? · i) Hz; revert Hz
-      simp [CMRA.op, optionOp, get?_merge]
-      cases get? x i <;> cases get? z i <;> simp_all
-    exists v'
-    simp_all [CMRA.core, CMRA.pcore, optionCore, get?_bindAlter]
   extend {n x y1 y2} Hm Heq := by
     have Hslice i : get? x i ≡{n}≡ get? y1 i • get? y2 i := by
       refine (get?_ne i |>.ne Heq).trans ?_
@@ -470,14 +452,87 @@ instance instStoreCMRA : CMRA (M V) where
         simp only [h, Option.bind_some]
         refine Hz2.trans (.of_eq h)
 
+/-- The pointwise order on partial maps. -/
+@[reducible] def orderN : OrderN (M V) where
+  IncludedN n m m' := ∀ k, get? m k ≼{n} get? m' k
+  Included m m' := ∀ k, get? m k ≼ get? m' k
+  incN_ne em em' h k := incN_ne ((get?_ne k).ne em) ((get?_ne k).ne em') (h k)
+  incN_succ h k := incN_succ (h k)
+  incN_trans h₁ h₂ k := incN_trans (h₁ k) (h₂ k)
+  inc_trans h₁ h₂ k := inc_trans (h₁ k) (h₂ k)
+  incN_of_inc n h k := incN_of_inc n (h k)
+
+section
+attribute [local instance] raBase orderN
+
+@[rocq_alias lookup_op]
+theorem get?_op (x y : M V) : get? (x • y) i = get? x i • get? y i := by
+  simp only [CMRA.op, op, get?_merge, Option.merge, optionOp]
+  grind
+
+@[rocq_alias lookup_core]
+theorem get?_core (m : M V) (i : K) : get? (core m) i = core (get? m i) := by
+  simp only [core, CMRA.pcore, pcore, Option.getD_some, get?_bindAlter, optionCore]
+
+theorem increasing_get? {m : M V} (h : Increasing m) (k : K) : Increasing (get? m k) where
+  increasing
+    | none => by simpa [get?_op, get?_empty] using h.increasing unit k
+    | some v => by simpa [get?_op, get?_insert_eq rfl] using h.increasing (insert ∅ k v) k
+
+theorem increasing_iff {m : M V} : Increasing m ↔ ∀ k, Increasing (get? m k) :=
+  ⟨increasing_get?, fun h => { increasing := fun m' k => by rw [get?_op]; exact (h k).increasing _ }⟩
+
+@[rocq_alias gmapR]
+instance instStoreCMRA : CMRA (M V) where
+  toRABase := raBase
+  toOrderN := orderN
+  op_monoN_left z h k := by rw [get?_op, get?_op]; exact op_monoN_left _ (h k)
+  op_mono_left z h k := by rw [get?_op, get?_op]; exact op_mono_left _ (h k)
+  validN_of_incN h v k := validN_of_incN (h k) (v k)
+  pcore_monoN {n x y cx} h e :=
+    have hcx : cx = core x := Option.some.inj e.symm
+    ⟨core y, rfl, fun k => by rw [hcx, get?_core, get?_core]; exact core_incN_core (h k)⟩
+  pcore_mono {x y cx} h e :=
+    have hcx : cx = core x := Option.some.inj e.symm
+    ⟨core y, rfl, fun k => by rw [hcx, get?_core, get?_core]; exact core_mono (h k)⟩
+  pcore_order_op {x cx} e y :=
+    have hcx : cx = core x := Option.some.inj e.symm
+    ⟨core (x • y), rfl, fun k => by
+      rw [hcx, get?_core, get?_core, get?_op]; exact core_op_mono _ _⟩
+  pcore_increasing {x cx} e :=
+    have hcx : cx = core x := Option.some.inj e.symm
+    hcx ▸ increasing_iff.mpr fun k => by rw [get?_core]; exact inferInstance
+  increasing_closed h h' :=
+    increasing_iff.mpr fun k =>
+      increasing_closed (increasing_get? h k) (h'.imp (fun e => (get?_ne k).ne e) (· k))
+  incN_extend {n x y} v h :=
+    let ⟨f, hf⟩ := Classical.axiomOfChoice fun k => incN_extend (v k) (h k)
+    have hfx : ∀ k, get? (bindAlter (fun k _ => f k) x) k = f k := fun k => by
+      rw [get?_bindAlter]
+      cases hx : get? x k
+      · have := (hf k).2
+        rw [hx] at this
+        revert this
+        cases f k <;> simp [OFE.Dist, Option.Forall₂]
+      · rfl
+    ⟨bindAlter (fun k _ => f k) x, fun k => by rw [hfx]; exact (hf k).1,
+      fun k => by rw [hfx]; exact (hf k).2⟩
+
+end
+
 @[rocq_alias gmap_ucmra_mixin, rocq_alias gmapUR]
 instance instStoreUCMRA : UCMRA (M V) where
+  toCMRA := instStoreCMRA
   unit := unit
   unit_valid := by simp [CMRA.Valid, get?_empty]
   unit_left_id := OFE.eq_dist_2 fun _ k => by simp [CMRA.op, get?_merge, get?_empty]
   pcore_unit := OFE.eq_dist_2 fun _ => by
     refine OFE.some_dist_some.mpr fun k => ?_
     simp [get?_bindAlter, get?_empty]
+  inc_refl _ := fun _ => inc_refl _
+
+instance [Affine V] : Affine (M V) where
+  increasing _ := increasing_iff.mpr fun _ => Affine.increasing _
 
 @[rocq_alias gmap_op_empty_l_L]
 theorem op_empty_left {m : M V} : (∅ : M V) • m = m := CMRA.unit_left_id_L
@@ -499,11 +554,6 @@ variable {K V : Type _} [LawfulPartialMap M K] [CMRA V]
 
 open CMRA
 
-@[rocq_alias lookup_op]
-theorem get?_op (x y : M V) : get? (x • y) i = get? x i • get? y i := by
-  simp only [CMRA.op, op, get?_merge, Option.merge, optionOp]
-  grind
-
 @[rocq_alias lookup_opM]
 theorem get?_opM (m : M V) (mm : Option (M V)) (i : K) :
     get? (m •? mm) i = get? m i • mm.bind (get? · i) := by
@@ -512,10 +562,6 @@ theorem get?_opM (m : M V) (mm : Option (M V)) (i : K) :
     show get? m i = get? m i • none
     cases get? m i <;> rfl
   | some m' => exact get?_op m m'
-
-@[rocq_alias lookup_core]
-theorem get?_core (m : M V) (i : K) : get? (core m) i = core (get? m i) := by
-  simp only [core, CMRA.pcore, pcore, Option.getD_some, get?_bindAlter, optionCore]
 
 @[rocq_alias lookup_op_homomorphism]
 instance (i : K) : Algebra.MonoidHomomorphism (CMRA.op (α := M V)) (CMRA.op (α := Option V))
@@ -528,7 +574,7 @@ instance (i : K) : Algebra.MonoidHomomorphism (CMRA.op (α := M V)) (CMRA.op (α
   map_unit := get?_empty i
 
 theorem valid_empty : ✓ (∅ : M V) :=
-  fun k => by simp [Valid, show get? ∅ k = none from get?_empty (M := M) k]
+  fun k => by simp [CMRA.Valid, show get? ∅ k = none from get?_empty (M := M) k]
 
 @[rocq_alias lookup_validN_Some]
 theorem validN_get?_validN {m : M V} (Hv : ✓{n} m) (He : get? m i ≡{n}≡ some x) : ✓{n} x := by
@@ -665,9 +711,36 @@ instance [CoreId (x : V)] : CoreId (singleton i x : M V) where
     exact core_id.dist
 
 open Classical in
+theorem singleton_incN_singleton_iff :
+    (singleton i x : M V) ≼{n} (singleton i y : M V) ↔ some x ≼{n} some y := by
+  refine ⟨fun h => by simpa [get?_singleton_eq rfl] using h i, fun h k => ?_⟩
+  by_cases hk : i = k
+  · subst hk; simpa [get?_singleton_eq rfl] using h
+  · simp only [get?_singleton, hk, ↓reduceIte]; trivial
+
+open Classical in
+theorem singleton_inc_singleton_iff :
+    (singleton i x : M V) ≼ (singleton i y : M V) ↔ some x ≼ some y := by
+  refine ⟨fun h => by simpa [get?_singleton_eq rfl] using h i, fun h k => ?_⟩
+  by_cases hk : i = k
+  · subst hk; simpa [get?_singleton_eq rfl] using h
+  · simp only [get?_singleton, hk, ↓reduceIte]; trivial
+
+theorem singleton_inc_singleton_mono (Hinc : x ≼ y) :
+    (singleton i x : M V) ≼ (singleton i y) :=
+  singleton_inc_singleton_iff.mpr (Or.inr Hinc)
+
+theorem inc_dom_inc {m1 m2 : M V} (Hinc : m1 ≼ m2) : Set.Included (dom m1) (dom m2) := by
+  intro i
+  unfold dom
+  have := Hinc i
+  revert this
+  cases get? m1 i <;> cases get? m2 i <;> simp <;> exact id
+
+open Classical in
 @[rocq_alias singleton_includedN_l]
-theorem singleton_incN_iff {m : M V} :
-    (singleton i x) ≼{n} m ↔ ∃ y, (get? m i ≡{n}≡ some y) ∧ some x ≼{n} some y := by
+theorem singleton_incExtN_iff {m : M V} :
+    (singleton i x) ≼ₑ{n} m ↔ ∃ y, (get? m i ≡{n}≡ some y) ∧ some x ≼ₑ{n} some y := by
   refine ⟨fun ⟨z, Hz⟩ => ?_, fun ⟨y, Hy, z, Hz⟩ => ?_⟩
   · specialize Hz i; revert Hz
     simp only [CMRA.op, Heap.op, get?_merge, get?_singleton_eq rfl]
@@ -699,8 +772,8 @@ theorem singleton_incN_iff {m : M V} :
 
 open Classical in
 @[rocq_alias singleton_included_l]
-theorem singleton_inc_iff {m : M V} :
-    (singleton i x) ≼ m ↔ ∃ y, (get? m i = some y) ∧ some x ≼ some y := by
+theorem singleton_incExt_iff {m : M V} :
+    (singleton i x) ≼ₑ m ↔ ∃ y, (get? m i = some y) ∧ some x ≼ₑ some y := by
   refine ⟨fun ⟨z, Hz⟩ => ?_, fun ⟨y, Hy, z, Hz⟩ => ?_⟩
   · replace Hz := congrArg (get? · i) Hz; revert Hz
     simp only [CMRA.op, Heap.op, get?_merge, get?_singleton_eq rfl]
@@ -731,30 +804,30 @@ theorem singleton_inc_iff {m : M V} :
       · simp
 
 @[rocq_alias singleton_included_exclusive_l]
-theorem exclusive_singleton_inc_iff {m : M V} (He : Exclusive x) (Hv : ✓ m) :
-    (singleton i x) ≼ m ↔ (get? m i = some x) := by
-  refine singleton_inc_iff.trans ⟨fun ⟨y, Hy, Hxy⟩ => ?_, fun _ => ?_⟩
+theorem exclusive_singleton_incExt_iff {m : M V} (He : Exclusive x) (Hv : ✓ m) :
+    (singleton i x) ≼ₑ m ↔ (get? m i = some x) := by
+  refine singleton_incExt_iff.trans ⟨fun ⟨y, Hy, Hxy⟩ => ?_, fun _ => ?_⟩
   · suffices x = y by exact Hy.trans <| OFE.some_eqv_some.mpr this.symm
-    exact Option.eqv_of_inc_exclusive Hxy <| valid_get?_valid Hv Hy
+    exact Option.eqv_of_incExt_exclusive Hxy <| valid_get?_valid Hv Hy
   · exists x
 
 @[rocq_alias singleton_included]
-theorem singleton_inc_singleton_iff :
-    (singleton i x : M V) ≼ (singleton i y : M V) ↔ some x ≼ some y := by
-  refine singleton_inc_iff.trans ⟨fun ⟨z, Hz, Hxz⟩ => ?_, fun H => ?_⟩
+theorem singleton_incExt_singleton_iff :
+    (singleton i x : M V) ≼ₑ (singleton i y : M V) ↔ some x ≼ₑ some y := by
+  refine singleton_incExt_iff.trans ⟨fun ⟨z, Hz, Hxz⟩ => ?_, fun H => ?_⟩
   · exact (Hz.symm.trans <| get?_singleton_eq rfl) ▸ Hxz
   · refine ⟨y, ?_, H⟩
     exact get?_singleton_eq rfl
 
 @[rocq_alias singleton_included_total]
-theorem total_singleton_inc_singleton_iff [IsTotal V] :
-    (singleton i x : M V) ≼ (singleton i y) ↔ x ≼ y :=
-  singleton_inc_singleton_iff.trans <| Option.some_inc_some_iff_is_total
+theorem total_singleton_incExt_singleton_iff [IsTotal V] :
+    (singleton i x : M V) ≼ₑ (singleton i y) ↔ x ≼ₑ y :=
+  singleton_incExt_singleton_iff.trans <| Option.some_incExt_some_iff_is_total
 
 @[rocq_alias singleton_included_mono]
-theorem singleton_inc_singleton_mono (Hinc : x ≼ y) :
-    (singleton i x : M V) ≼ (singleton i y) :=
-  singleton_inc_singleton_iff.mpr <| Option.some_inc_some_iff.mpr <| .inr Hinc
+theorem singleton_incExt_singleton_mono (Hinc : x ≼ₑ y) :
+    (singleton i x : M V) ≼ₑ (singleton i y) :=
+  singleton_incExt_singleton_iff.mpr <| Option.some_incExt_some_iff.mpr <| .inr Hinc
 
 open Classical in
 @[rocq_alias singleton_cancelable]
@@ -825,7 +898,7 @@ theorem dom_op_union (m1 m2 : M V) : dom (m1 • m2) = Set.Union (dom m1) (dom m
   cases get? m1 k <;> cases get? m2 k <;> simp_all [CMRA.op, dom, Set.Union, get?_merge]
 
 @[rocq_alias dom_included]
-theorem inc_dom_inc {m1 m2 : M V} (Hinc : m1 ≼ m2) : Set.Included (dom m1) (dom m2) := by
+theorem incExt_dom_inc {m1 m2 : M V} (Hinc : m1 ≼ₑ m2) : Set.Included (dom m1) (dom m2) := by
   intro i
   unfold dom
   rcases lookup_inc.mp Hinc i with ⟨z, Hz⟩
@@ -834,10 +907,10 @@ theorem inc_dom_inc {m1 m2 : M V} (Hinc : m1 ≼ m2) : Set.Included (dom m1) (do
     exact fun h => (OFE.not_none_eqv_some h).elim
 
 @[rocq_alias gmap_fmap_mono]
-theorem map_mono [CMRA V'] (f : V → V') (hf : ∀ x y : V, x ≼ y → f x ≼ f y) {m1 m2 : M V}
-    (Hinc : m1 ≼ m2) : PartialMap.map f m1 ≼ PartialMap.map f m2 := by
+theorem map_mono_ext [CMRA V'] (f : V → V') (hf : ∀ x y : V, x ≼ₑ y → f x ≼ₑ f y) {m1 m2 : M V}
+    (Hinc : m1 ≼ₑ m2) : PartialMap.map f m1 ≼ₑ PartialMap.map f m2 := by
   refine lookup_inc.mpr fun i => ?_
-  obtain ⟨z, hz⟩ := Option.map_mono f hf (lookup_inc.mp Hinc i)
+  obtain ⟨z, hz⟩ := Option.map_mono_ext f hf (lookup_inc.mp Hinc i)
   exact ⟨z, by rw [get?_map, get?_map, hz]⟩
 
 open Iris.Algebra in
@@ -874,6 +947,7 @@ nonrec instance [HD : CMRA.Discrete V] [LawfulPartialMap M K] : Discrete (M V) w
     refine OFE.eq_dist_2 ?_
     exact fun _ k => (OFE.Discrete.discrete_0 (H k)).dist
   discrete_valid {_} := (CMRA.Discrete.discrete_valid <| · ·)
+  discrete_inc h k := CMRA.discrete_inc (h k)
 
 /-! ## Frame-preserving updates -/
 
@@ -1223,6 +1297,10 @@ theorem map_compose [OFE α] [OFE β] [OFE γ] (f : α -> β) (g : β -> γ) m :
   simp [map, get?_bindAlter]
   cases get? m k <;> simp
 
+theorem get?_map (f : α → β) (m : H α) (k : K) : get? (map H f m) k = (get? m k).map f := by
+  simp only [map, get?_bindAlter]
+  cases get? m k <;> rfl
+
 @[rocq_alias gmap_fmap_cmra_morphism]
 def mapC [CMRA α] [CMRA β] (f : α -C> β) : CMRA.Hom (H α) (H β) where
   f := PartialMap.map H f
@@ -1248,6 +1326,10 @@ def mapC [CMRA α] [CMRA β] (f : α -C> β) : CMRA.Hom (H α) (H β) where
     simp [CMRA.op, map, get?_bindAlter, get?_merge, Option.merge]
     cases get? m1 k <;> cases get? m2 k <;> simp
     exact (CMRA.Hom.op f _ _).dist
+  monoN h k := by rw [get?_map, get?_map]; exact (Option.mapC f).monoN (h k)
+  mono h k := by rw [get?_map, get?_map]; exact (Option.mapC f).mono (h k)
+  increasing h := Heap.increasing_iff.mpr fun k => by
+    rw [get?_map]; exact (Option.mapC f).increasing (Heap.increasing_get? h k)
 
 abbrev PartialMapOF (F : COFE.OFunctorPre) : COFE.OFunctorPre :=
   fun A B _ _ => H (F A B)
@@ -1294,6 +1376,9 @@ instance {F} [RFunctor F] : URFunctor (PartialMapOF H F) where
     simp [get?_bindAlter]
     cases get? m x <;> simp
     exact (RFunctor.map_comp f g f' g' _).dist
+
+instance {F} [RFunctor F] [RFunctorAffine F] : RFunctorAffine (PartialMapOF H F) where
+  affine := inferInstance
 
 @[rocq_alias gmapURF_contractive]
 instance {F} [RFunctorContractive F] : URFunctorContractive (PartialMapOF H F) where

--- a/Iris/Iris/Algebra/HeapView.lean
+++ b/Iris/Iris/Algebra/HeapView.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 Markus de Medeiros. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Markus de Medeiros, Puming Liu
+Authors: Markus de Medeiros, Puming Liu, Janine Lohse
 -/
 module
 
@@ -38,11 +38,13 @@ open Iris
 section heapView
 open Std PartialMap Heap OFE CMRA
 
-variable (K V : Type _) (H : Type _ → Type _) [LawfulPartialMap H K] [CMRA V]
+variable (K V : Type _) (H : Type _ → Type _) [LawfulPartialMap H K] [CMRA V] [CMRA.Affine V]
 
 #rocq_ignore gmap_view_fragUR "Inlined as the fragment type `H (DFrac × V)`"
 
-/-- The view relation for heaps: relates a model heap to a fragment heap at step index `n`. -/
+/-- The view relation for heaps: relates a model heap to a fragment heap at step index `n`.
+Each fragment cell is bounded by the corresponding model cell in the primitive *order*; for
+classical value algebras this coincides with the extension inclusion of the Rocq original. -/
 @[rocq_alias gmap_view_rel_raw]
 def HeapR (n : Nat) (m : H V) (f : H (DFrac × V)) : Prop :=
   ∀ k fv, get? f k = some fv →
@@ -53,36 +55,35 @@ def HeapR (n : Nat) (m : H V) (f : H (DFrac × V)) : Prop :=
 #rocq_ignore gmap_view_rel_raw_unit "The `rel_unit` field of the `IsViewRel (HeapR ..)` instance"
 
 @[rocq_alias gmap_view_rel]
-instance : IsViewRel (HeapR K V H) where
-  mono {n1 m1 f1 n2 m2 f2 Hrel Hm Hf Hn k} vk Hk := by
-    obtain Hf' : ∃ z, get? f1 k ≡{n2}≡ some vk • z := by
-      have ⟨z, Hz⟩ := lookup_incN (n := n2) (m1 := f2) (m2 := f1) |>.1 Hf k
-      exact ⟨z, Hk ▸ Hz⟩
+instance : IsViewRel (HeapR K V H) := .ofMonoOrd
+  (mono_ord := by
+    intro n1 m1 f1 n2 m2 f2 Hrel Hm Hf Hn k vk Hk
+    obtain Hf' : (some vk : Option ((DFrac) × V)) ≼{n2} get? f1 k := Hk ▸ Hf k
     match h : get? f1 k with
-    | none => rcases h ▸ Hf' with ⟨_|_, HK⟩ <;> simp [CMRA.op, optionOp] at HK
+    | none => exact absurd (h ▸ Hf') Option.not_some_incN_none
     | some ⟨dq', v'⟩ =>
       obtain ⟨v, dq, Hm1, ⟨Hvval, Hdqval⟩, Hvincl⟩ := Hrel k ⟨dq', v'⟩ h
-      obtain ⟨v', Hm2, Hv⟩ : ∃ y : V, get? m2 k = some y ∧ v ≡{n2}≡ y := by
+      obtain ⟨v'', Hm2, Hv⟩ : ∃ y : V, get? m2 k = some y ∧ v ≡{n2}≡ y := by
         have Hmm := Hm1 ▸ Hm k <;> revert Hmm
         cases get? m2 k <;> simp
-      exists v', dq
+      exists v'', dq
       refine ⟨Hm2, ⟨Hvval, validN_ne Hv (validN_of_le Hn Hdqval)⟩, ?_⟩
-      suffices some vk ≼{n2} some (dq, v) by exact incN_of_incN_of_dist this ⟨rfl, Hv⟩
-      refine incN_trans Hf' ?_
-      refine incN_trans ?_ (incN_of_incN_le Hn Hvincl)
-      rw [h]
-  rel_validN n m f Hrel k := by
+      suffices some vk ≼{n2} some (dq, v) by
+        exact CMRA.incN_of_incN_of_dist this (OFE.some_dist_some.mpr ⟨rfl, Hv⟩)
+      exact ((h ▸ Hf').trans (CMRA.incN_of_incN_le Hn Hvincl)))
+  (rel_validN := fun n m f Hrel k => by
     match Hf : get? f k with
     | none => simp [ValidN, optionValidN]
     | some _ =>
       obtain ⟨_, _, _, Hvv, Hvi⟩ := Hf ▸ Hrel k _ Hf
-      exact (Hf ▸ validN_of_incN Hvi Hvv)
-  rel_unit n := by
+      exact (Hf ▸ validN_of_incN Hvi Hvv))
+  (rel_unit := fun n => by
     refine ⟨empty, fun _ _ => ?_⟩
-    simp [UCMRA.unit, Heap.unit, get?_empty]
+    simp [UCMRA.unit, Heap.unit, get?_empty])
 
 namespace HeapR
 
+omit [CMRA.Affine V] in
 @[rocq_alias gmap_view_rel_unit]
 theorem unit : HeapR K V H n m UCMRA.unit := by
   simp [HeapR, UCMRA.unit, Heap.unit, get?_empty]
@@ -100,6 +101,7 @@ theorem exists_iff_validN {n f} : (∃ m, HeapR K V H n m f) ↔ ✓{n} f := by
   simp only [get?_bindAlter, h, Option.bind_some, true_and, FF]
   exact ⟨dq, (h ▸ Hv k : ✓{n} some (dq, v)), incN_refl _⟩
 
+omit [CMRA.Affine V] in
 @[rocq_alias gmap_view_rel_lookup]
 theorem singleton_get_iff n m k dq v :
     HeapR K V H n m (PartialMap.singleton k (dq, v)) ↔
@@ -120,7 +122,7 @@ theorem singleton_get_iff n m k dq v :
 instance [CMRA.Discrete V] : IsViewRelDiscrete (HeapR K V H) where
   discrete n _ _ H k v He := by
     have ⟨v, Hv1, ⟨x, Hx1, Hx2⟩⟩ := H k v He
-    refine ⟨v, Hv1, ⟨x, ?_, inc_0_iff_incN n |>.mp Hx2⟩⟩
+    refine ⟨v, Hv1, ⟨x, ?_, CMRA.incN_of_inc _ (CMRA.discrete_inc Hx2)⟩⟩
     exact ⟨Hx1.1, valid_iff_validN.mp (Discrete.discrete_valid Hx1.2) _⟩
 
 end HeapR
@@ -139,7 +141,7 @@ namespace HeapView
 
 open Heap OFE View One DFrac CMRA PartialMap Std LawfulPartialMap
 
-variable {K V : Type _} {H : Type _ → Type _} [LawfulPartialMap H K] [CMRA V]
+variable {K V : Type _} {H : Type _ → Type _} [LawfulPartialMap H K] [CMRA V] [CMRA.Affine V]
 
 /-- Authoritative (fractional) ownership over an entire heap. -/
 @[rocq_alias gmap_view_auth]
@@ -187,8 +189,7 @@ instance [h : IsOp d dq dq1 dq2] :
 This is the workhorse for proofs that rewrite the authoritative map along identities like
 `PartialMap.map_insert`, `map_delete`, or `map_union`. -/
 theorem auth_inc_of_map_eq (dq : DFrac) (h : m1 = m2) :
-    Auth dq m1 ≼ Auth dq m2 :=
-  by rw [h]
+    Auth dq m1 ≼ Auth dq m2 := h ▸ CMRA.inc_refl _
 
 @[rocq_alias gmap_view_auth_dfrac_op_invN]
 theorem dist_of_validN_auth_op : ✓{n} Auth dp m1 • Auth dq m2 → m1 ≡{n}≡ m2 :=
@@ -252,7 +253,8 @@ theorem frag_add_op_eqv {q1 q2 : Qp} :
 @[rocq_alias gmap_view_both_dfrac_validN]
 nonrec theorem auth_op_frag_validN_iff :
     ✓{n} Auth dp m1 • Frag k dq v ↔
-    ∃ v' dq', ✓ dp ∧ (Std.PartialMap.get? m1 k = some v') ∧ ✓{n} (dq', v') ∧ some (dq, v) ≼{n} some (dq', v') :=
+    ∃ v' dq', ✓ dp ∧ (Std.PartialMap.get? m1 k = some v') ∧ ✓{n} (dq', v') ∧
+      some (dq, v) ≼{n} some (dq', v') :=
   auth_op_frag_validN_iff.trans <|
     (and_congr_right fun _ => (HeapR.singleton_get_iff ..).trans <|
     exists_congr fun _ => exists_and_left).trans (by grind)
@@ -261,8 +263,10 @@ nonrec theorem auth_op_frag_validN_iff :
 theorem auth_op_frag_one_validN_iff :
     ✓{n} (Auth dp m1 • Frag k (.own one) v1) ↔ ✓ dp ∧ ✓{n} v1 ∧ Std.PartialMap.get? m1 k ≡{n}≡ some v1 := by
   refine auth_op_frag_validN_iff.trans ⟨fun ⟨Hp, v', dq', Hl, Hv, Hi⟩ => ?_, fun ⟨Hp, Hv, Hl⟩ => ?_⟩
-  · have Heq : v1 ≡{n}≡ Hp := Option.dist_of_inc_exclusive Hi Hv |>.2
-    exact ⟨dq', validN_ne Heq.symm Hv.2, Hl ▸ Heq.symm⟩
+  · haveI : Exclusive (DFrac.own one) := DFrac.own_whole_exclusive
+    rcases Hi with e | i
+    · exact ⟨dq', validN_ne e.2.symm Hv.2, Hl ▸ e.2.symm⟩
+    · exact absurd Hv.1 (RABase.not_valid_of_exclN_incExt (x := DFrac.own one) i.1)
   · match h : Std.PartialMap.get? m1 k with
     | none => simp [h] at Hl
     | some v' =>
@@ -272,46 +276,46 @@ theorem auth_op_frag_one_validN_iff :
       · exact Option.some_incN_some_iff.mpr <| .inl <| dist_prod_ext rfl (h.symm ▸ Hl).symm
 
 @[rocq_alias gmap_view_both_dfrac_validN_total]
-theorem auth_op_frag_validN_total_iff [IsTotal V] (H : ✓{n} Auth dp m1 • Frag k dq v1) :
+theorem auth_op_frag_validN_total_iff [IncRefl V] (H : ✓{n} Auth dp m1 • Frag k dq v1) :
     ∃ v', ✓ dp ∧ ✓ dq ∧ Std.PartialMap.get? m1 k = some v' ∧ ✓{n} v' ∧ v1 ≼{n} v' := by
-  obtain ⟨v', dq', Hdp, Hl, Hv, ⟨x, Hx⟩⟩ := auth_op_frag_validN_iff.mp H
+  obtain ⟨v', dq', Hdp, Hl, Hv, Hi⟩ := auth_op_frag_validN_iff.mp H
   exists v'
   refine ⟨Hdp, ?_, Hl, Hv.2, ?_⟩
-  · refine Option.valid_of_inc_valid (valid_iff_validN' n |>.mpr Hv.1) ?_
-    refine inc_iff_incN n |>.mpr ?_
-    match x with
-    | none => exact incN_of_incN_of_dist (incN_refl _) Hx.1.symm
-    | some x => exact ⟨x.1, Hx.1⟩
-  · match x with
-    | none => exact incN_of_incN_of_dist (incN_refl _) Hx.2.symm
-    | some x => exact ⟨x.2, Hx.2⟩
+  · rcases Hi with e | i
+    · exact validN_ne e.1.symm Hv.1
+    · exact validN_of_incN i.1 Hv.1
+  · rcases Hi with e | i
+    · exact e.2.to_incN
+    · exact i.2
 
 @[rocq_alias gmap_view_both_dfrac_valid_discrete]
 theorem auth_op_frag_discrete_valid_iff [CMRA.Discrete V] :
     ✓ Auth dp m1 • Frag k dq v1 ↔
-      ∃ v' dq', ✓ dp ∧ Std.PartialMap.get? m1 k = some v' ∧ ✓ (dq', v') ∧ some (dq, v1) ≼ some (dq', v') := by
+      ∃ v' dq', ✓ dp ∧ Std.PartialMap.get? m1 k = some v' ∧ ✓ (dq', v') ∧
+        some (dq, v1) ≼ some (dq', v') := by
   refine valid_iff_validN.trans ?_
   refine forall_congr' (fun _ => auth_op_frag_validN_iff) |>.trans ?_
   refine ⟨fun Hvalid' => ?_, ?_⟩
   · obtain ⟨v', dq', Hdp, Hl, Hv, Hi⟩ := Hvalid' 0
-    refine ⟨v', dq', Hdp, Hl, ?_, inc_iff_incN 0 |>.mpr Hi⟩
+    refine ⟨v', dq', Hdp, Hl, ?_, (CMRA.inc_iff_incN 0).mpr Hi⟩
     exact ⟨discrete_valid Hv.1, discrete_valid Hv.2⟩
-  · exact fun ⟨v', dq', Hdp, Hl, Hv, Hi⟩ n => ⟨v', dq', Hdp, Hl, Hv.validN, inc_iff_incN n |>.mp Hi⟩
+  · exact fun ⟨v', dq', Hdp, Hl, Hv, Hi⟩ n =>
+      ⟨v', dq', Hdp, Hl, Hv.validN, (CMRA.inc_iff_incN n).mp Hi⟩
 
 @[rocq_alias gmap_view_both_dfrac_valid_discrete_total]
-theorem auth_op_frag_valid_total_discrete_iff [IsTotal V] [CMRA.Discrete V]
+theorem auth_op_frag_valid_total_discrete_iff [IncRefl V] [CMRA.Discrete V]
     (H : ✓ Auth dp m1 • Frag k dq v1) :
     ∃ v', ✓ dp ∧ ✓ dq ∧ Std.PartialMap.get? m1 k = some v' ∧ ✓ v' ∧ v1 ≼ v' := by
   obtain ⟨v', dq', Hdp, Hl, Hv, Hi⟩ := auth_op_frag_discrete_valid_iff |>.mp H
   refine ⟨v', Hdp, ?_, Hl, Hv.2, ?_⟩
-  · rcases Hi with ⟨(_|x), Hx⟩
-    · obtain rfl : dq' = dq := congrArg Prod.fst (some_eqv_some.mp Hx)
+  · rcases Hi with e | i
+    · obtain rfl : dq' = dq := (congrArg Prod.fst e).symm
       exact Hv.1
-    · exact Option.valid_of_inc_valid Hv.1 ⟨some x.fst, congrArg (fun p => some p.fst) (some_eqv_some.mp Hx)⟩
-  · rcases Hi with ⟨(_|x), Hx⟩
-    · obtain rfl : v1 = v' := (congrArg Prod.snd (some_eqv_some.mp Hx)).symm
+    · exact valid_of_inc i.1 Hv.1
+  · rcases Hi with e | i
+    · obtain rfl : v1 = v' := congrArg Prod.snd e
       exact CMRA.inc_refl v1
-    · exact ⟨x.snd, congrArg Prod.snd (some_eqv_some.mp Hx)⟩
+    · exact i.2
 
 @[rocq_alias gmap_view_both_valid]
 theorem auth_op_frag_one_valid_iff :
@@ -410,12 +414,16 @@ theorem update_one_delete :
       obtain ⟨v, H, q, H'⟩ := Hrel a b rfl
       exact ⟨v, q, H.symm ▸ get?_delete_ne h, H'⟩
 
+/-- The primitive gmap-view update: at the touched key, transport the order bound of the
+fragment composite past the update, for every fragment frame `f` and any authoritative
+fraction; the new fraction may be chosen. `update_of_local_update` and `update_replace`
+are derived from it. -/
 @[rocq_alias gmap_view_update]
 theorem update_auth_op_frag
-    (Hup :
-      ∀ (n : Nat) (mv : V) (f : Option (DFrac × V)), (Std.PartialMap.get? m1 k = some mv) →
-      ✓{n} ((dq, v) •? f) → (mv ≡{n}≡ ((v : V) •? (Prod.snd <$> f))) →
-      ✓{n} ((dq', v') •? f) ∧ (mv' ≡{n}≡ v' •? (Prod.snd <$> f))) :
+    (Hup : ∀ (n : Nat) (dq₁ : DFrac) (mv : V) (f : Option ((DFrac) × V)),
+      Std.PartialMap.get? m1 k = some mv → ✓{n} (dq₁, mv) →
+      some ((dq, v) •? f) ≼{n} some (dq₁, mv) →
+      ∃ dq₂, ✓{n} (dq₂, mv') ∧ some ((dq', v') •? f) ≼{n} some (dq₂, mv')) :
     Auth (.own one) m1 • Frag k dq v ~~>
     Auth (.own one) (Std.PartialMap.insert m1 k mv') • Frag k dq' v' := by
   refine auth_one_op_frag_update fun n bf Hrel j ⟨df, va⟩ => ?_
@@ -427,83 +435,58 @@ theorem update_auth_op_frag
     case G =>
       simp [CMRA.op, get?_merge, op?]
       cases _ : Std.PartialMap.get? bf k <;> simp [Option.merge, get?_singleton_eq rfl]
-    obtain ⟨mv, mdf, Hlookup, Hval, Hincl'⟩ := Hrel
-    obtain ⟨f', Hincl⟩ := Option.some_incN_some_iff_opM.mp Hincl'
-    clear Hincl'
-    let f := Std.PartialMap.get? bf k • f'
-    have Hincl' : (mdf, mv) ≡{n}≡ (dq, v) •? f := Hincl.trans Option.opM_opM_assoc.dist
-    clear Hincl
-    specialize Hup n mv f Hlookup (Hincl'.validN.mp Hval) ?G
-    case G =>
-      apply Hincl'.2.trans
-      match f with
-      | none => simp [CMRA.op?]
-      | some ⟨_, _⟩ => simp [CMRA.op?, CMRA.op]
-    obtain ⟨Hval', Hincl'⟩ := Hup
-    exists (dq' •? Option.map Prod.fst f)
-    constructor
-    · refine validN_ne (x := (dq' •? Option.map Prod.fst f, v' •? Prod.snd <$> f))
-        ⟨.rfl, Hincl'.symm⟩ ?_
-      cases h : f <;> simp only [op?, Option.map_none, Option.map_eq_map]
-      · exact validN_opM Hval'
-      · simp only [h] at Hval'
-        exact Hval'
-    · rw [← Hbf]
-      suffices HF : some ((dq', v') •? Std.PartialMap.get? bf j) ≼{n} some (dq' •? Option.map Prod.fst f, mv') by
-        subst h
-        rename_i HH
-        simp [f] at HH
-        apply incN_trans ?_ HF
-        simp [Option.merge, CMRA.op?]
-        split <;> simp_all
-        · rename_i H1 H2
-          simp [← H1, get?_singleton_eq rfl]
-          exact incN_refl _
-        · rename_i H1 H2
-          exfalso
-          simp [get?_singleton_eq rfl] at H1
-        · rename_i H1 H2
-          simp [get?_singleton_eq rfl] at H1
-          simp [← H1]
-          exact incN_refl _
-      refine Option.some_incN_some_iff_opM.mpr ?_
-      exists f'
-      refine (dist_prod_ext rfl Hincl').trans ?_
-      refine .trans ?_ Option.opM_opM_assoc.symm.dist
-      obtain H : Std.PartialMap.get? bf j • f' = f := by rw [← h]
-      rw [H]
-      cases _ : f <;> rfl
+    obtain ⟨mv0, mdf, Hlookup, Hval, Hincl⟩ := Hrel
+    obtain ⟨dq₂, Hval₂, Hincl₂⟩ := Hup n mdf mv0 (Std.PartialMap.get? bf k) Hlookup Hval Hincl
+    refine ⟨dq₂, Hval₂, ?_⟩
+    refine CMRA.incN_of_dist_of_incN ?_ Hincl₂
+    rw [← Hbf, h]
+    simp only [Option.merge, CMRA.op?, get?_singleton_eq rfl]
+    cases Std.PartialMap.get? bf j <;> rfl
   · simp [get?_insert_ne h]
     intro Hbf
     have Hrel' := Hrel j (df, va)
-    simp only [CMRA.op, Heap.op, get?_merge, get?_singleton_ne h,  exists_and_left] at Hrel'
+    simp only [CMRA.op, Heap.op, get?_merge, get?_singleton_ne h, exists_and_left] at Hrel'
     refine Hrel' ?_
     rw [← Hbf]
     simp [get?_singleton_ne h]
 
 @[rocq_alias gmap_view_update_local]
-theorem update_of_local_update (Hl : Std.PartialMap.get? m1 k = some mv) (Hup : (mv, v) ~l~> (mv', v')) :
+theorem update_of_local_update (hsub : ∀ {n : Nat} {x y : V}, x ≼{n} y → x ≼ₑ{n} y)
+    (Hl : Std.PartialMap.get? m1 k = some mv) (Hup : (mv, v) ~l~> (mv', v')) :
     Auth (.own one) m1 • Frag k dq v ~~>
     Auth (.own one) (Std.PartialMap.insert m1 k mv') • Frag k dq v' := by
-  refine update_auth_op_frag (fun n mv0 f Hmv0 ⟨Hv1, Hv2⟩ Hincl => ?_)
-  simp [Hl] at Hmv0
-  subst Hmv0
-  have Hup' := Hup n (Prod.snd <$> f) ?G1 Hincl
-  case G1 =>
-    refine validN_ne Hincl.symm ?_
-    cases _ : f <;> simp_all [op?, CMRA.op]
-  cases f <;> exact ⟨⟨Hv1, validN_ne Hup'.2 Hup'.1⟩, Hup'.2⟩
+  refine update_auth_op_frag fun n dq₁ mv0 f Hmv0 Hval Hincl => ?_
+  obtain rfl : mv0 = mv := Option.some_inj.mp (Hmv0.symm.trans Hl)
+  refine ⟨dq₁, ?_⟩
+  match f with
+  | none =>
+    rcases Hincl with e | i
+    · obtain ⟨Hv', He'⟩ := Hup n none Hval.2 e.2.symm
+      exact ⟨⟨Hval.1, Hv'⟩, Option.some_incN_some_iff.mpr (.inl ⟨e.1, He'.symm⟩)⟩
+    · obtain ⟨c, hc⟩ := hsub i.2
+      obtain ⟨Hv', He'⟩ := Hup n (some c) Hval.2 hc
+      refine ⟨⟨Hval.1, Hv'⟩, Option.some_incN_some_iff.mpr (.inr ⟨i.1, ?_⟩)⟩
+      exact CMRA.incN_of_incExtN ⟨c, He'⟩
+  | some p =>
+    rcases Hincl with e | i
+    · obtain ⟨Hv', He'⟩ := Hup n (some p.2) Hval.2 e.2.symm
+      exact ⟨⟨Hval.1, Hv'⟩, Option.some_incN_some_iff.mpr (.inl ⟨e.1, He'.symm⟩)⟩
+    · obtain ⟨c, hc⟩ := hsub i.2
+      have hc' := hc.trans (assoc.symm.dist (α := V))
+      obtain ⟨Hv', He'⟩ := Hup n (some (p.2 • c)) Hval.2 hc'
+      refine ⟨⟨Hval.1, Hv'⟩, Option.some_incN_some_iff.mpr (.inr ⟨i.1, ?_⟩)⟩
+      exact CMRA.incN_of_incExtN ⟨c, He'.trans assoc.dist⟩
 
 @[rocq_alias gmap_view_replace]
 theorem update_replace (Hval' : ✓ v2) :
     Auth (.own one) m1 • Frag k (.own one) v1 ~~>
     Auth (.own one) (Std.PartialMap.insert m1 k v2) • Frag k (.own one) v2 := by
-  refine update_auth_op_frag fun n mv f Hlookup Hval Hincl => ?_
-  cases _ : f <;> simp only [Option.map_eq_map, Option.map_none]
-  · simp_all only [op?, Dist.rfl, and_true]
-    exact ⟨Hval.1, Valid.validN Hval'⟩
-  · simp_all [CMRA.op?, CMRA.op, Prod.op]
-    exact (own_whole_exclusive.exclusive0_l _ (valid0_of_validN Hval.1)).elim
+  refine update_auth_op_frag fun n dq₁ mv f Hlookup Hval Hincl => ?_
+  match f with
+  | none => exact ⟨.own one, ⟨valid_own_one, Hval'.validN⟩, incN_refl _⟩
+  | some p =>
+    have := Option.validN_of_incN_validN (Hv := Hval) (Hinc := Hincl)
+    exact (own_whole_exclusive.exclusive0_l _ (valid0_of_validN this.1)).elim
 
 @[rocq_alias gmap_view_auth_persist]
 theorem auth_dfrac_discard : Auth dq m1 ~~> Auth .discard m1 := auth_discard
@@ -524,22 +507,39 @@ theorem update_of_dfrac_update P (Hdq : dq ~~>: P) :
       simp only [CMRA.op, Heap.op, get?_merge, get?_singleton_eq rfl, op?]
       cases _ : Std.PartialMap.get? bf k <;> simp
     obtain ⟨v', dq', Hlookup, Hval, Hincl⟩ := Hrel'
-    obtain ⟨f', Hincl⟩ := Option.some_incN_some_iff_opM.mp Hincl
-    replace Hincl := Hincl.trans Option.opM_opM_assoc.dist
-    replace Hdq := Hdq n (Option.map Prod.fst (Std.PartialMap.get? bf k • f')) ?G
-    case G => cases h : Std.PartialMap.get? bf k • f' <;> exact validN_ne (h ▸ Hincl).1 Hval.1
-    obtain ⟨dq'', HPdq'', Hvdq''⟩ := Hdq
+    -- Extract a fraction frame `w`, the updated fraction `dq''`, and the new authoritative
+    -- pair — in each of the four frame/order cases (`bf k` absent or present × dist or
+    -- order-inclusion).
+    obtain ⟨dq'', HPdq'', dq₀, Hv₀, Hi₀⟩ :
+        ∃ dq'', P dq'' ∧ ∃ dq₀, ✓{n} (dq₀, v') ∧
+          some ((dq'', v1) •? Std.PartialMap.get? bf k) ≼{n} some (dq₀, v') := by
+      rcases hbf : Std.PartialMap.get? bf k with _ | p <;> rw [hbf] at Hincl
+      · rcases Hincl with e | i
+        · obtain ⟨dq'', HP, Hv''⟩ := Hdq n none (validN_ne e.1.symm Hval.1)
+          exact ⟨dq'', HP, dq'', ⟨Hv'', Hval.2⟩,
+            Option.some_incN_some_iff.mpr (.inl ⟨.rfl, e.2⟩)⟩
+        · obtain ⟨w, hw⟩ := i.1
+          obtain ⟨dq'', HP, Hv''⟩ := Hdq n (some w) (validN_ne hw Hval.1)
+          exact ⟨dq'', HP, dq'' • w, ⟨Hv'', Hval.2⟩,
+            Option.some_incN_some_iff.mpr (.inr ⟨⟨w, .rfl⟩, i.2⟩)⟩
+      · rcases Hincl with e | i
+        · obtain ⟨dq'', HP, Hv''⟩ := Hdq n (some p.1) (validN_ne e.1.symm Hval.1)
+          exact ⟨dq'', HP, dq'' • p.1, ⟨Hv'', Hval.2⟩,
+            Option.some_incN_some_iff.mpr (.inl ⟨.rfl, e.2⟩)⟩
+        · obtain ⟨w, hw⟩ := i.1
+          obtain ⟨dq'', HP, Hv''⟩ := Hdq n (some (p.1 • w))
+            (validN_ne (hw.trans assoc.symm.dist) Hval.1)
+          refine ⟨dq'', HP, (dq'' • p.1) • w, ⟨validN_ne assoc.dist Hv'', Hval.2⟩,
+            Option.some_incN_some_iff.mpr (.inr ⟨⟨w, .rfl⟩, i.2⟩)⟩
     exists Std.PartialMap.singleton k (dq'', v1)
     refine ⟨⟨dq'', rfl, HPdq''⟩, fun j ⟨df, va⟩ Heq => ?_⟩
     by_cases h : k = j
-    · simp [CMRA.op, get?_merge, get?_singleton_eq h] at Heq
-      refine ⟨v', dq'' •? (Option.map Prod.fst <| (Std.PartialMap.get? bf k) • f'), ?_⟩
-      refine ⟨h ▸ Hlookup, ⟨Hvdq'', Hval.2⟩, f', ?_⟩
-      cases _ : f' <;> cases _ : Std.PartialMap.get? bf k <;>
-        simp [Dist, Option.Forall₂, CMRA.op?] <;>
-        simp_all [CMRA.op, op?, Prod.op] <;>
-        try exact Hincl.2
-      exact ⟨Heq.1.symm ▸ assoc_L, Heq.2.symm ▸ Hincl.2.trans op_assocN⟩
+    · subst h
+      simp only [CMRA.op, Heap.op, get?_merge, get?_singleton_eq rfl] at Heq
+      refine ⟨v', dq₀, Hlookup, Hv₀, ?_⟩
+      refine CMRA.incN_of_dist_of_incN (Dist.of_eq ?_) Hi₀
+      rw [← Heq]
+      cases Std.PartialMap.get? bf k <;> rfl
     · apply Hrel
       simp [CMRA.op, get?_merge, get?_singleton_ne h] at Heq ⊢
       exact Heq
@@ -582,24 +582,16 @@ theorem heapR_map_eq [COFE A] [COFE B] [COFE A'] [COFE B'] [RFunctor T] (f : A' 
   constructor
   · constructor <;> simp_all
     exact (Hom.validN _ hv2)
-  · rw [Option.incN_iff] at ho ⊢
-    rcases ho with _ | he <;> simp_all
-    rcases he with ⟨he1, he2⟩ | he
-    · left
-      constructor <;> simp_all
-      exact (NonExpansive.ne he2)
-    · right
-      rw [Prod.mk_incN_mk] at *
-      rcases he with ⟨_ , he⟩
-      constructor
-      · simp_all
-      · exact (Hom.monoN _ _ he)
+  · rcases ho with he | he
+    · exact Option.some_incN_some_iff.mpr <| .inl (dist_prod_ext he.1 (NonExpansive.ne he.2))
+    · exact Option.some_incN_some_iff.mpr <| .inr ⟨he.1, (RFunctor.map f g).monoN he.2⟩
 
 @[rocq_alias gmap_viewURF]
 abbrev HeapViewURF T [RFunctor T] : COFE.OFunctorPre :=
   fun A B _ _ => HeapView K (T A B) H
 
-instance {T} [RFunctor T] : URFunctor (HeapViewURF (H := H) T) where
+instance {T} [RFunctor T] [RFunctorAffine T] :
+    URFunctor (HeapViewURF (H := H) T) where
   map {A A'} {B B'} _ _ _ _ f g :=
     View.mapC
       (PartialMap.mapO H (RFunctor.map f g).toHom)
@@ -632,8 +624,13 @@ instance {T} [RFunctor T] : URFunctor (HeapViewURF (H := H) T) where
       refine funext fun p => ?_
       exact Prod.ext rfl (RFunctor.map_comp _ _ _ _ p.2)
 
+instance {T} [RFunctor T] [RFunctorAffine T] :
+    RFunctorAffine (HeapViewURF (H := H) T) where
+  affine := inferInstance
+
 @[rocq_alias gmap_viewURF_contractive]
-instance {T} [RFunctorContractive T] : URFunctorContractive (HeapViewURF (H := H) T) where
+instance {T} [RFunctorContractive T] [RFunctorAffine T] :
+    URFunctorContractive (HeapViewURF (H := H) T) where
   map_contractive.1 H _ := by
     apply View.map_ne <;> intros <;> apply PartialMap.map_ne
     · exact (RFunctorContractive.map_contractive.1 H)
@@ -651,6 +648,7 @@ open Std PartialMap Heap OFE CMRA HeapView
 open One DFrac LawfulPartialMap Algebra
 
 variable {K V : Type _} {H : Type _ → Type _} [DecidableEq K] [LawfulFiniteMap H K] [CMRA V]
+  [CMRA.Affine V]
 
 omit [DecidableEq K] in
 private theorem bigOpM_frag_empty (dq : DFrac) :
@@ -729,6 +727,7 @@ theorem update_big_alloc (m1 m2 : H V) dq
       rw [bigOpM_frag_empty]
       refine Update.included ?_
       rw [union_empty_left, CMRA.unit_right_id]
+      exact CMRA.inc_refl _
     | hins k v m2 Hm2 IH =>
       have Hall' : all (fun k v => ✓ v) m2 := by exact all_of_all_insert _ Hm2 Hall
       have Hdisj' : m2 ##ₘ m1 := by

--- a/Iris/Iris/Algebra/IProp.lean
+++ b/Iris/Iris/Algebra/IProp.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 Markus de Medeiros. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Markus de Medeiros
+Authors: Markus de Medeiros, Janine Lohse
 -/
 module
 
@@ -21,14 +21,18 @@ open COFE
 abbrev GType := Nat
 
 set_option linter.checkUnivs false in
+/-- A resource functor admissible in the global ghost state: contractive, with affine algebras. -/
 @[rocq_alias gFunctor]
-abbrev GFunctor := Σ F : OFunctorPre, RFunctorContractive F
+structure GFunctor.{u, v, w} where
+  F : OFunctorPre.{u, v, w}
+  [contractive : RFunctorContractive F]
+  [affine : RFunctorAffine F]
 
 set_option linter.checkUnivs false in
 @[rocq_alias gFunctors]
 def BundledGFunctors := GType → GFunctor
 
-def BundledGFunctors.default : BundledGFunctors := fun _ => ⟨constOF Unit, by infer_instance⟩
+def BundledGFunctors.default : BundledGFunctors := fun _ => ⟨constOF Unit⟩
 
 def BundledGFunctors.set (GF : BundledGFunctors) (i : Nat) (FB : GFunctor) :
     BundledGFunctors :=
@@ -46,7 +50,7 @@ abbrev GName := Nat
 
 @[rocq_alias iResF]
 abbrev IResF (GF : BundledGFunctors) : OFunctorPre :=
-  DiscreteFunOF (fun i => GenMapOF (GF i).fst)
+  DiscreteFunOF (fun i => GenMapOF (GF i).F)
 
 #rocq_ignore subG "Superseded by `ElemG`."
 #rocq_ignore subG_inv "Lemma about `subG`; obsolete with `ElemG`."
@@ -54,7 +58,9 @@ abbrev IResF (GF : BundledGFunctors) : OFunctorPre :=
 #rocq_ignore subG_app_l "Lemma about `subG`; obsolete with `ElemG`."
 #rocq_ignore subG_app_r "Lemma about `subG`; obsolete with `ElemG`."
 
-instance (GF : BundledGFunctors) (i : GName) : RFunctorContractive ((GF i).fst) := (GF i).snd
+instance (GF : BundledGFunctors) (i : GType) : RFunctorContractive (GF i).F := (GF i).contractive
+
+instance (GF : BundledGFunctors) (i : GType) : RFunctorAffine (GF i).F := (GF i).affine
 
 section IProp
 
@@ -67,12 +73,15 @@ def IPre : Type _ := OFunctor.Fix (UPredOF (IResF GF))
 instance : COFE (IPre GF) := inferInstanceAs (COFE (OFunctor.Fix _))
 
 @[rocq_alias iProp_solution.iResUR]
-def IResUR.{u} : Type u := (i : GType) → GenMap (GF i |>.fst (IPre GF) (IPre GF))
+def IResUR.{u} : Type u := (i : GType) → GenMap ((GF i).F (IPre GF) (IPre GF))
 
 #rocq_ignore iResUR "Sealed copy of `iProp_solution.iResUR`; not needed since Lean does not seal it."
 
 instance : UCMRA (IResUR GF) :=
-  ucmraDiscreteFunO (β := fun (i : GType) => GenMap (GF i |>.fst (IPre GF) (IPre GF)))
+  ucmraDiscreteFunO (β := fun (i : GType) => GenMap ((GF i).F (IPre GF) (IPre GF)))
+
+instance : CMRA.Affine (IResUR GF) :=
+  inferInstanceAs (CMRA.Affine ((i : GType) → GenMap ((GF i).F (IPre GF) (IPre GF))))
 
 abbrev IProp.{u} : Type u := UPred (IResUR GF)
 

--- a/Iris/Iris/Algebra/LeibnizMultiSet.lean
+++ b/Iris/Iris/Algebra/LeibnizMultiSet.lean
@@ -37,7 +37,7 @@ variable {MS : Type _} [LawfulMultiSet MS A]
 
 open MultiSet
 
-instance : CMRA (LeibnizMultiSet MS) where
+instance : RABase (LeibnizMultiSet MS) where
   pcore _ := some (ofSet ∅)
   op | ofSet X, ofSet Y => ofSet (X ⊎ Y)
   ValidN _ _ := True
@@ -52,22 +52,27 @@ instance : CMRA (LeibnizMultiSet MS) where
   comm := by grind
   pcore_op_left {_ X} := by cases X; rintro ⟨rfl⟩; exact congrArg ofSet disjUnion_empty_left
   pcore_idem := id
-  pcore_op_mono {_ X} := by
-    rintro ⟨rfl⟩ _
-    exists .ofSet ∅
-    grind
   extend {_ _ _ _} _ h := ⟨_, _, h, .rfl, .rfl⟩
 
-instance : UCMRA (LeibnizMultiSet MS) where
+instance : RABase.ExtensionLaws (LeibnizMultiSet MS) where
+  pcore_op_mono h _ :=
+    ⟨.ofSet ∅, by cases h; exact congrArg (some ∘ ofSet) disjUnion_empty_left.symm⟩
+
+instance : CMRA (LeibnizMultiSet MS) := CMRA.withExtensionOrder
+
+instance : Unital (LeibnizMultiSet MS) where
   unit := .ofSet ∅
   unit_valid := trivial
   unit_left_id {X} := by cases X; exact congrArg ofSet disjUnion_empty_left
   pcore_unit := rfl
 
+instance : UCMRA (LeibnizMultiSet MS) := UCMRA.withExtensionOrder
+
 @[rocq_alias gmultiset_cmra_discrete]
 instance : CMRA.Discrete (LeibnizMultiSet MS) where
   discrete_0 h := h
   discrete_valid := id
+  discrete_inc | ⟨z, hz⟩ => ⟨z, hz⟩
 
 instance : CMRA.IsTotal (LeibnizMultiSet MS) where
   total _ := ⟨.ofSet ∅, rfl⟩
@@ -112,8 +117,9 @@ theorem localUpdate_alloc {X Y X' : MS} :
 theorem localUpdate_dealloc {X Y X' : MS} (h : X' ⊆ Y) :
     (ofSet X, ofSet Y) ~l~> (ofSet (X \ X'), ofSet (Y \ X')) := by
   refine LocalUpdate.total_valid fun _ _ inc => localUpdate (LawfulMultiSet.ext fun a => ?_)
+  have hYX := included_iff_subset.mp inc
   simp only [multiplicity_disjUnion, multiplicity_difference]
-  grind [subset_iff, included_iff_subset]
+  grind [subset_iff]
 
 end LeibnizMultiSet
 

--- a/Iris/Iris/Algebra/LeibnizSet.lean
+++ b/Iris/Iris/Algebra/LeibnizSet.lean
@@ -68,7 +68,7 @@ namespace DisjointLeibnizSet
 
 variable {S : Type _} [LawfulSet S A] [DecidableDisj S]
 
-instance : CMRA (DisjointLeibnizSet S) where
+instance : RABase (DisjointLeibnizSet S) where
   pcore _ := some (.valid ∅)
   op
     | valid x, valid y => if x ## y then valid (x ∪ y) else error
@@ -107,21 +107,25 @@ instance : CMRA (DisjointLeibnizSet S) where
     rintro ⟨⟩
     simp [disjoint_empty_left]
   pcore_idem {x cx} := by grind only []
-  pcore_op_mono {_ x} := by
-    rcases x with (x|_) <;> rintro ⟨⟩ y
-    exists (.valid ∅)
-    simp [disjoint_empty_left]
   extend {_ _ y₁ y₂} _ h := ⟨y₁, y₂, ⟨h, .rfl, .rfl⟩⟩
+
+instance : RABase.ExtensionLaws (DisjointLeibnizSet S) where
+  pcore_op_mono h _ := ⟨.valid ∅, by cases h; simp [CMRA.pcore, CMRA.op, disjoint_empty_left]⟩
+
+instance : CMRA (DisjointLeibnizSet S) := CMRA.withExtensionOrder
 
 instance instDiscreteDisjointLeibnizSet : CMRA.Discrete (DisjointLeibnizSet S) where
   discrete_0 := fun h => h
   discrete_valid := id
+  discrete_inc | ⟨z, hz⟩ => ⟨z, hz⟩
 
-instance instUCMRADisjointLeibnizSet : UCMRA (DisjointLeibnizSet S) where
+instance instUnitalDisjointLeibnizSet : Unital (DisjointLeibnizSet S) where
   unit := .valid ∅
-  unit_valid := by simp [Valid]
+  unit_valid := trivial
   unit_left_id {x} := by rcases x <;> simp [disjoint_empty_left, op]
   pcore_unit := by simp [pcore]
+
+instance instUCMRADisjointLeibnizSet : UCMRA (DisjointLeibnizSet S) := UCMRA.withExtensionOrder
 
 theorem valid_set {s : S} : ✓ valid s := ⟨⟩
 theorem validN_set {s : S}: ✓{n} valid s := ⟨⟩
@@ -168,12 +172,12 @@ theorem disj_op_union {X Y : S} (Hdisj : X ## Y) :
 
 @[rocq_alias coPset_disj_valid_op, rocq_alias gset_disj_valid_op]
 theorem valid_op_iff_disj {X Y : S} : ✓ ((valid X) • (valid Y)) ↔ X ## Y := by
-  by_cases H : X ## Y <;> simp [H, op, Valid]
+  by_cases H : X ## Y <;> simp [H, op, CMRA.Valid]
 
 @[rocq_alias coPset_disj_valid_inv_l, rocq_alias gset_disj_valid_inv_l]
 theorem valid_inv_l {X : S} {Y : DisjointLeibnizSet S} :
     ✓ (valid X) • Y → ∃ Y', Y = valid Y' ∧ X ## Y' := by
-  simp only [op, Valid]
+  simp only [op, CMRA.Valid]
   rcases Y with (Y|_) <;> try (· simp)
   by_cases H : X ## Y <;> simp [H]
 
@@ -316,7 +320,7 @@ namespace LeibnizSet
 
 variable {S : Type _} [LawfulSet S A]
 
-instance : CMRA (LeibnizSet S) where
+instance : RABase (LeibnizSet S) where
   pcore := some
   op | .valid x, valid y => valid (x ∪ y)
   ValidN _ _ := True
@@ -331,18 +335,25 @@ instance : CMRA (LeibnizSet S) where
   comm := by simp [union_comm]
   pcore_op_left {_ _} := by rintro ⟨rfl⟩; simp [union_idem]
   pcore_idem := by simp
-  pcore_op_mono {_ _} := by rintro ⟨rfl⟩ y; exists y
   extend {_ _ _ _} _ h := ⟨_, _, h, .rfl, .rfl⟩
 
-instance : UCMRA (LeibnizSet S) where
+instance : RABase.ExtensionLaws (LeibnizSet S) where
+  pcore_op_mono {_ _} := by rintro ⟨rfl⟩ y; exists y
+
+instance : CMRA (LeibnizSet S) := CMRA.withExtensionOrder
+
+instance : Unital (LeibnizSet S) where
   unit := valid ∅
-  unit_valid := by simp [Valid]
+  unit_valid := trivial
   unit_left_id := by simp [op, union_empty_left]
   pcore_unit := by simp [pcore, pcore]
+
+instance : UCMRA (LeibnizSet S) := UCMRA.withExtensionOrder
 
 instance instDiscreteLeibnizSet : CMRA.Discrete (LeibnizSet S) where
   discrete_0 := fun h => h
   discrete_valid := id
+  discrete_inc | ⟨z, hz⟩ => ⟨z, hz⟩
 
 @[rocq_alias gset_core_id]
 instance instCoreIdLeibnizSet (X : LeibnizSet S) : CMRA.CoreId X := ⟨rfl⟩
@@ -357,7 +368,7 @@ theorem core_equiv (X : LeibnizSet S) : core X = X := by
 
 @[rocq_alias coPset_included, rocq_alias gset_included]
 theorem included_iff_subset (X Y : S) : valid X ≼ valid Y ↔ X ⊆ Y := by
-  simp only [Included, op]
+  simp only [Included, RABase.IncExt, op]
   refine ⟨fun ⟨_, H⟩ => ?_, fun Hsub => ?_⟩
   · obtain ⟨rfl⟩ := H
     exact fun _ Hp => mem_union.mpr (.inl Hp)

--- a/Iris/Iris/Algebra/Lib/DFracAgree.lean
+++ b/Iris/Iris/Algebra/Lib/DFracAgree.lean
@@ -64,7 +64,7 @@ theorem mk_op {d₁ d₂ : DFrac} {a : A} : mk (d₁ • d₂) a = mk d₁ a •
 
 @[rocq_alias dfrac_agree_op_valid]
 theorem op_valid {d₁ d₂ : DFrac} {a₁ a₂ : A} : ✓ (mk d₁ a₁ • mk d₂ a₂) ↔ ✓ (d₁ • d₂) ∧ a₁ = a₂ := by
-  simp only [Valid, Prod.Valid, Prod.op, CMRA.op, mk]
+  simp only [Prod.op, CMRA.op, mk]
   exact and_congr_right fun _ => toAgree_op_valid_iff_eq
 
 #rocq_ignore dfrac_agree_op_valid_L "Use op_valid"
@@ -79,28 +79,15 @@ theorem op_validN {d₁ d₂ : DFrac} {a₁ a₂ : A} :
 
 @[rocq_alias dfrac_agree_included]
 theorem included {d₁ d₂ : DFrac} {a₁ a₂ : A} :
-    mk d₁ a₁ ≼ mk d₂ a₂ ↔ (d₁ ≼ d₂) ∧ a₁ = a₂ := by
-  simp only [mk, Included]
-  constructor
-  · rintro ⟨⟨zd, za⟩, H⟩
-    exact ⟨⟨zd, congrArg Prod.fst H⟩,
-      Agree.toAgree_included.mp ⟨za, congrArg Prod.snd H⟩⟩
-  · rintro ⟨⟨zd, hd⟩, ha⟩
-    refine ⟨(zd, toAgree a₁), equiv_prod_ext hd ?_⟩
-    exact (congrArg toAgree ha.symm).trans Agree.idemp.symm
+    mk d₁ a₁ ≼ mk d₂ a₂ ↔ (d₁ ≼ d₂) ∧ a₁ = a₂ :=
+  and_congr_right' Agree.toAgree_included
 
 #rocq_ignore dfrac_agree_included_L "Use included"
 
 @[rocq_alias dfrac_agree_includedN]
 theorem includedN {d₁ d₂ : DFrac} {a₁ a₂ : A} :
-    mk d₁ a₁ ≼{n} mk d₂ a₂ ↔ (d₁ ≼ d₂) ∧ a₁ ≡{n}≡ a₂ := by
-  simp only [mk, IncludedN]
-  constructor
-  · rintro ⟨⟨zd, za⟩, hd, ha⟩
-    exact ⟨(inc_iff_incN (α := DFrac) n).mpr ⟨zd, hd⟩, Agree.toAgree_includedN.mp ⟨za, ha⟩⟩
-  · rintro ⟨hdinc, ha⟩
-    obtain ⟨zd, hd⟩ := (inc_iff_incN (α := DFrac) n).mp hdinc
-    exact ⟨(zd, toAgree a₁), hd, (toAgree.ne.ne ha.symm).trans Agree.idemp.symm.dist⟩
+    mk d₁ a₁ ≼{n} mk d₂ a₂ ↔ (d₁ ≼ d₂) ∧ a₁ ≡{n}≡ a₂ :=
+  and_congr (inc_iff_incN (α := DFrac) n).symm Agree.toAgree_includedN
 
 @[rocq_alias dfrac_agree_update_2]
 theorem update₂ {d₁ d₂ : DFrac} {a₁ a₂ a' : A} (hd : d₁ • d₂ = .own 1) :

--- a/Iris/Iris/Algebra/Lib/ExclAuth.lean
+++ b/Iris/Iris/Algebra/Lib/ExclAuth.lean
@@ -72,8 +72,10 @@ theorem valid {a : A} : ✓ (●E a) • ◯E a :=
   Auth.auth_both_valid_2 trivial .rfl
 
 @[rocq_alias excl_auth_agreeN]
-theorem agreeN {a b : A} (h : ✓{n} (●E a) • ◯E b) : a ≡{n}≡ b :=
-  dist_of_inc_exclusive (Auth.both_validN.mp h).1 trivial |>.symm
+theorem agreeN {a b : A} (h : ✓{n} (●E a) • ◯E b) : a ≡{n}≡ b := by
+  rcases (Auth.both_validN.mp h).1 with e | i
+  · exact (Excl.excl_dist_inj (OFE.some_dist_some.mpr e)).symm
+  · exact nomatch (Excl.incN_iff _).mp i
 
 @[rocq_alias excl_auth_agree]
 theorem agree {a b : A} (h : ✓ (●E a) • ◯E b) : a = b :=
@@ -101,7 +103,8 @@ theorem frag_op_valid {a b : A} : (✓ (◯E a) • ◯E b) ↔ False := by
 
 @[rocq_alias excl_auth_update]
 theorem update {a b a' : A} : ((●E a) • ◯E b) ~~> ((●E a') • ◯E a') :=
-  Auth.auth_update (.option (.exclusive trivial))
+  Auth.auth_update_of_localUpdate (Option.incExtN_of_incN fun h => h)
+    (.option (.exclusive trivial))
 
 /-! ## Functors -/
 

--- a/Iris/Iris/Algebra/Lib/FracAuth.lean
+++ b/Iris/Iris/Algebra/Lib/FracAuth.lean
@@ -29,7 +29,7 @@ public abbrev FracAuth [CMRA A] := Auth (Option (Qp × A))
 
 namespace FracAuth
 
-variable [CMRA A]
+variable [CMRA A] [CMRA.Affine A]
 
 @[rocq_alias frac_auth_auth]
 public abbrev auth (dq : DFrac) (a : A) : FracAuth (A := A) := Auth.auth dq (some (1, a))
@@ -84,7 +84,7 @@ instance frag_discrete {q : Qp} {a : A} [ha : DiscreteE a] : DiscreteE (◯F{q} 
 @[rocq_alias frac_auth_dfrac_validN]
 theorem dfrac_validN {dq : DFrac} {n : Nat} {a : A} (hdq : ✓ dq) (ha : ✓{n} a) :
     ✓{n} (●F{dq} a) • ◯F a := by
-  simpa only [both_dfrac_validN] using ⟨hdq, ⟨none, .rfl⟩, Qp.valid_one, ha⟩
+  simpa only [both_dfrac_validN] using ⟨hdq, incN_refl _, Qp.valid_one, ha⟩
 
 @[rocq_alias frac_auth_validN]
 theorem validN {n : Nat} {a : A} (ha : ✓{n} a) : ✓{n} (●F a : FracAuth) • ◯F a :=
@@ -92,7 +92,7 @@ theorem validN {n : Nat} {a : A} (ha : ✓{n} a) : ✓{n} (●F a : FracAuth) �
 
 @[rocq_alias frac_auth_dfrac_valid]
 theorem dfrac_valid {dq : DFrac} {a : A} (hdq : ✓ dq) (ha : ✓ a) : ✓ (●F{dq} a) • ◯F a :=
-  auth_both_dfrac_valid_2 hdq ⟨valid_iff_validN.mpr fun _ => Qp.valid_one, ha⟩ ⟨none, rfl⟩
+  auth_both_dfrac_valid_2 hdq ⟨valid_iff_validN.mpr fun _ => Qp.valid_one, ha⟩ (CMRA.inc_refl _)
 
 @[rocq_alias frac_auth_valid]
 theorem valid {a : A} (ha : ✓ a) : ✓ (●F a : FracAuth) • ◯F a :=
@@ -103,7 +103,9 @@ theorem valid {a : A} (ha : ✓ a) : ✓ (●F a : FracAuth) • ◯F a :=
 @[rocq_alias frac_auth_agreeN]
 theorem agreeN {dq : DFrac} {a b : A} (h : ✓{n} (●F{dq} a) • ◯F b) : a ≡{n}≡ b := by
   rw [both_dfrac_validN] at h
-  exact (dist_of_inc_exclusive h.2.1 h.2.2).2.symm
+  rcases h.2.1 with e | i
+  · exact e.2.symm
+  · exact absurd h.2.2.1 (RABase.not_valid_of_exclN_incExt (x := (1 : Qp)) i.1)
 
 @[rocq_alias frac_auth_agree]
 theorem agree {dq : DFrac} {a b : A} (h : ✓ (●F{dq} a) • ◯F b) : a = b :=
@@ -117,29 +119,27 @@ theorem agree {dq : DFrac} {a b : A} (h : ✓ (●F{dq} a) • ◯F b) : a = b :
 theorem includedN {n : Nat} {dq : DFrac} {q : Qp} {a b : A} (h : ✓{n} (●F{dq} a) • ◯F{q} b) :
     some b ≼{n} some a := by
   rw [both_dfrac_validN] at h
-  obtain ⟨_, ⟨mc, hmc⟩, hv⟩ := h
-  match mc with
-  | none => exact ⟨none, hmc.2⟩
-  | some (_, cr) => exact ⟨some cr, hmc.2⟩
+  rcases h.2.1 with e | i
+  · exact Option.some_incN_some_iff.mpr (.inl e.2)
+  · exact Option.some_incN_some_iff.mpr (.inr i.2)
 
 @[rocq_alias frac_auth_included]
 theorem included [CMRA.Discrete A] {dq : DFrac} {a b : A} (h : ✓ (●F{dq} a) • ◯F{q} b) :
       some b ≼ some a := by
   rw [both_dfrac_valid_discrete] at h
-  obtain ⟨_, ⟨mc, hmc⟩, hv⟩ := h
-  match mc with
-  | none => exact ⟨none, congrArg (fun p => some p.snd) (some_eqv_some.mp hmc)⟩
-  | some (_, cr) => exact ⟨some cr, congrArg (fun p => some p.snd) (some_eqv_some.mp hmc)⟩
+  rcases h.2.1 with e | i
+  · exact Option.some_inc_some_iff.mpr (.inl (congrArg Prod.snd e))
+  · exact Option.some_inc_some_iff.mpr (.inr i.2)
 
 @[rocq_alias frac_auth_includedN_total]
-theorem includedN_total [IsTotal A] {dq : DFrac} {a b : A} (h : ✓{n} (●F{dq} a) • ◯F{q} b) :
+theorem includedN_total [IncRefl A] {dq : DFrac} {a b : A} (h : ✓{n} (●F{dq} a) • ◯F{q} b) :
     b ≼{n} a :=
-  some_incN_some_iff_is_total.mp (includedN h)
+  (Option.some_incN_some_iff.mp (includedN h)).elim (·.to_incN) id
 
 @[rocq_alias frac_auth_included_total]
-theorem included_total [CMRA.Discrete A] [IsTotal A] {dq : DFrac} {a b : A}
+theorem included_total [CMRA.Discrete A] [IncRefl A] {dq : DFrac} {a b : A}
     (h : ✓ (●F{dq} a) • ◯F{q} b) : b ≼ a :=
-  inc_of_some_inc_some (included h)
+  (Option.some_inc_some_iff.mp (included h)).elim (· ▸ CMRA.inc_refl b) id
 
 /-! ## Auth-only validity -/
 
@@ -245,15 +245,28 @@ instance isOp_frac_auth_core_id {q q1 q2 : Qp} {a : A}
 
 /-! ## Updates -/
 
+omit [CMRA.Affine A] in
+/-- The order of the fragment algebra `Option (Qp × A)` embeds into the extension
+inclusion, given that the order of `A` does. -/
+private theorem incExtN_of_incN (hsub : ∀ {n : Nat} {x y : A}, x ≼{n} y → x ≼ₑ{n} y)
+    {n : Nat} {x y : Option (Qp × A)} (h : x ≼{n} y) : x ≼ₑ{n} y :=
+  Option.incExtN_of_incN (Prod.incExtN_of_incN (fun h => h) hsub) h
+
 @[rocq_alias frac_auth_update]
-theorem update {q : Qp} {a b a' b' : A} (h : (a, b) ~l~> (a', b')) :
+theorem update {q : Qp} {a b a' b' : A}
+    (hsub : ∀ {n : Nat} {x y : A}, x ≼{n} y → x ≼ₑ{n} y) (h : (a, b) ~l~> (a', b')) :
     ((●F a : FracAuth) • ◯F{q} b) ~~> (●F a') • ◯F{q} b' :=
-  auth_update (.option (.prod_2 _ q h))
+  auth_update_of_localUpdate
+    (incExtN_of_incN hsub)
+    (.option (.prod_2 _ q h))
 
 @[rocq_alias frac_auth_update_1]
-theorem update_full {a b a' : A} (ha' : ✓ a') :
+theorem update_full {a b a' : A}
+    (hsub : ∀ {n : Nat} {x y : A}, x ≼{n} y → x ≼ₑ{n} y) (ha' : ✓ a') :
     ((●F a : FracAuth) • ◯F b) ~~> (●F a') • ◯F a' :=
-   auth_update (.option (.exclusive ⟨Qp.valid_one, ha'⟩))
+  auth_update_of_localUpdate
+    (incExtN_of_incN hsub)
+    (.option (.exclusive ⟨Qp.valid_one, ha'⟩))
 
 @[rocq_alias frac_auth_update_auth_persist]
 theorem update_auth_persist {dq : DFrac} {a : A} : (●F{dq} a) ~~> ●F{.discard} a :=

--- a/Iris/Iris/Algebra/Lib/MonoList.lean
+++ b/Iris/Iris/Algebra/Lib/MonoList.lean
@@ -131,6 +131,10 @@ instance {dq dq1 dq2 : DFrac} {l : List α} [h : IsOp d dq dq1 dq2] :
 
 /-! ## Validity -/
 
+/-- On `MaxPrefixList` — a map of `Agree` — the order and the extension inclusion agree. -/
+private theorem incExtN_of_incN {n} {x y : MaxPrefixList α} (h : x ≼{n} y) : x ≼ₑ{n} y :=
+  Heap.lookup_incN.mpr fun i => Option.incExtN_of_incN (fun h => h) (h i)
+
 @[rocq_alias mono_list_auth_dfrac_validN]
 theorem auth_dfrac_validN {n} (dq : DFrac) (l : List α) : ✓{n} (●ML{dq} l) ↔ ✓ dq := by
   unfold auth MonoList
@@ -187,8 +191,9 @@ theorem both_dfrac_validN {n} (dq : DFrac) (l1 l2 : List α) :
   unfold auth lb MonoList
   rw [← assoc', ← Auth.frag_op, Auth.both_dfrac_validN]
   refine ⟨fun ⟨hdq, hinc, _⟩ => ⟨hdq, ?_⟩, fun ⟨hdq, hl⟩ => ⟨hdq, ?_, ?_⟩⟩
-  · exact toMaxPrefixList_incN_iff.mp (incN_trans (incN_op_right ..) hinc)
-  · have hinc := op_monoN_right (toMaxPrefixList l1) (toMaxPrefixList_incN_iff.mpr hl)
+  · refine toMaxPrefixList_incExtN_iff.mp (incExtN_of_incN ((CMRA.incN_op_right ..).trans hinc))
+  · have hinc := CMRA.op_monoN_right (toMaxPrefixList l1)
+      (CMRA.incN_of_incExtN (toMaxPrefixList_incExtN_iff.mpr hl))
     rwa [op_self] at hinc
   · exact toMaxPrefixList_validN _
 
@@ -202,10 +207,13 @@ theorem both_validN {n} (l1 l2 : List α) :
 theorem both_dfrac_valid (dq : DFrac) (l1 l2 : List α) :
     ✓ (●ML{dq} l1 • ◯ML l2) ↔ ✓ dq ∧ l2 <+: l1 := by
   unfold auth lb MonoList
-  rw [← assoc', ← Auth.frag_op, Auth.both_dfrac_valid, ← inc_iff_forall_incN]
+  rw [← assoc', ← Auth.frag_op, Auth.both_dfrac_valid]
   refine ⟨fun ⟨hdq, hinc, _⟩ => ⟨hdq, ?_⟩, fun ⟨hdq, hl⟩ => ⟨hdq, ?_, ?_⟩⟩
-  · exact toMaxPrefixList_inc_iff.mp (inc_trans (inc_op_right ..) hinc)
-  · have hinc := op_mono_right (toMaxPrefixList l1) (toMaxPrefixList_inc_iff.mpr hl)
+  · refine toMaxPrefixList_incExt_iff.mp (incExt_iff_forall_incExtN.mpr fun n => ?_)
+    exact incExtN_of_incN ((CMRA.incN_op_right ..).trans (hinc n))
+  · intro n
+    have hinc := CMRA.op_monoN_right (toMaxPrefixList l1) (CMRA.incN_of_incExtN
+      (RABase.incExtN_of_incExt n (toMaxPrefixList_incExt_iff.mpr hl)))
     rwa [op_self] at hinc
   · exact toMaxPrefixList_valid _
 
@@ -235,17 +243,17 @@ theorem lb_op_valid (l1 l2 : List α) :
 #rocq_ignore mono_list_lb_op_valid_2_L "Use lb_op_valid.mpr"
 
 @[rocq_alias mono_list_lb_mono]
-theorem lb_mono {l1 l2 : List α} (h : l1 <+: l2) : ◯ML l1 ≼ ◯ML l2 :=
+theorem lb_mono {l1 l2 : List α} (h : l1 <+: l2) : ◯ML l1 ≼ₑ ◯ML l2 :=
   ⟨◯ML l2, (lb_op_left h).symm⟩
 
 @[rocq_alias mono_list_included]
-theorem included (dq : DFrac) (l : List α) : ◯ML l ≼ ●ML{dq} l := inc_op_right ..
+theorem included (dq : DFrac) (l : List α) : ◯ML l ≼ₑ ●ML{dq} l := RABase.incExt_op_right ..
 
 /-! ## Updates -/
 
 @[rocq_alias mono_list_update]
 theorem update {l1 : List α} (l2 : List α) (h : l1 <+: l2) : ●ML l1 ~~> ●ML l2 :=
-  Auth.auth_update (local_update h)
+  Auth.auth_update_of_localUpdate incExtN_of_incN (local_update h)
 
 @[rocq_alias mono_list_auth_persist]
 theorem auth_persist (dq : DFrac) (l : List α) : ●ML{dq} l ~~> ●ML□ l :=

--- a/Iris/Iris/Algebra/Lib/MonoNat.lean
+++ b/Iris/Iris/Algebra/Lib/MonoNat.lean
@@ -52,7 +52,7 @@ instance {l : MaxNat} : CMRA.CoreId (●MN□ l : MonoNat) := by
 theorem auth_dfrac_op (dq1 dq2 : DFrac) (n : MaxNat) :
   (●MN{dq1 • dq2} n : MonoNat) = (●MN{dq1} n) • (●MN{dq2} n) := by
   unfold auth
-  rw [← CMRA.assoc', CMRA.op_core_right_of_inc (CMRA.inc_op_right ..), CMRA.assoc',
+  rw [← CMRA.assoc', RABase.op_core_right_of_incExt (RABase.incExt_op_right ..), CMRA.assoc',
     ← Auth.auth_dfrac_op]
 
 @[rocq_alias mono_nat_lb_op]
@@ -63,7 +63,7 @@ theorem lb_op (n1 n2 : MaxNat) :
 @[rocq_alias mono_nat_auth_lb_op]
 theorem auth_lb_op (dq : DFrac) (n : MaxNat) :
   (●MN{dq} n : MonoNat) = (●MN{dq} n) • (◯MN n) :=
-  (CMRA.op_core_left_of_inc (CMRA.inc_op_right ..)).symm
+  (RABase.op_core_left_of_incExt (RABase.incExt_op_right ..)).symm
 
 @[rocq_alias mono_nat_lb_op_le_l]
 theorem lb_op_le_l (n n' : MaxNat) (h : n' ≤ n) :
@@ -73,7 +73,7 @@ theorem lb_op_le_l (n n' : MaxNat) (h : n' ≤ n) :
 @[rocq_alias mono_nat_auth_dfrac_valid]
 theorem auth_dfrac_valid (dq : DFrac) (n : MaxNat) :
   (✓ (●MN{dq} n : MonoNat)) ↔ ✓ dq :=
-  Auth.both_dfrac_valid_discrete.trans ⟨And.left, fun h => ⟨h, CMRA.inc_refl _, trivial⟩⟩
+  Auth.both_dfrac_valid_discrete.trans ⟨And.left, fun h => ⟨h, RABase.incExt_refl _, trivial⟩⟩
 
 @[rocq_alias mono_nat_auth_valid]
 theorem auth_valid (n : MaxNat) :
@@ -87,7 +87,8 @@ theorem auth_dfrac_op_valid (dq1 dq2 : DFrac) (n1 n2 : MaxNat) :
   · intro h
     unfold auth at h
     have ⟨hdq, heq, _⟩ := Auth.auth_dfrac_op_valid.mp <|
-      CMRA.valid_of_inc (CMRA.op_mono (CMRA.inc_op_left ..) (CMRA.inc_op_left ..)) h
+      RABase.valid_of_incExt
+        (RABase.op_mono_ext (RABase.incExt_op_left ..) (RABase.incExt_op_left ..)) h
     exact ⟨hdq, heq⟩
   · rintro ⟨hdq, rfl⟩
     exact auth_dfrac_op dq1 dq2 n1 ▸ (auth_dfrac_valid _ n1).mpr hdq
@@ -112,18 +113,19 @@ theorem both_valid (n m : MaxNat) :
 
 @[rocq_alias mono_nat_lb_mono]
 theorem lb_mono (n1 n2 : MaxNat) (h : n1 ≤ n2) :
-  (◯MN n1 : MonoNat) ≼ ◯MN n2 :=
-  Auth.frag_inc_of_inc (MaxNat.inc_iff.mpr h)
+  (◯MN n1 : MonoNat) ≼ₑ ◯MN n2 :=
+  Auth.frag_incExt_of_incExt (MaxNat.inc_iff.mpr h)
 
 @[rocq_alias mono_nat_included]
 theorem included (dq : DFrac) (n : MaxNat) :
-  (◯MN n : MonoNat) ≼ ●MN{dq} n :=
-  CMRA.inc_op_right ..
+  (◯MN n : MonoNat) ≼ₑ ●MN{dq} n :=
+  RABase.incExt_op_right ..
 
 @[rocq_alias mono_nat_update]
 theorem update {n : MaxNat} (n' : MaxNat) (h : n ≤ n') :
-  (●MN n : MonoNat) ~~> ●MN n' :=
-  Auth.auth_update (MaxNat.local_update h)
+  (●MN n : MonoNat) ~~> ●MN n' := by
+  unfold auth
+  exact Auth.auth_update_of_localUpdate (fun h => h) (MaxNat.local_update h)
 
 @[rocq_alias mono_nat_auth_persist]
 theorem auth_persist (n : MaxNat) (dq : DFrac) :

--- a/Iris/Iris/Algebra/Lib/MonoZ.lean
+++ b/Iris/Iris/Algebra/Lib/MonoZ.lean
@@ -49,7 +49,7 @@ instance {l : MaxInt} : CMRA.CoreId (●MZ□ l : MonoZ) := by
 theorem auth_dfrac_op (dq1 dq2 : DFrac) (n : MaxInt) :
     (●MZ{dq1 • dq2} n : MonoZ) = (●MZ{dq1} n) • (●MZ{dq2} n) := by
   unfold auth
-  rw [← CMRA.assoc', CMRA.op_core_right_of_inc (CMRA.inc_op_right ..), CMRA.assoc',
+  rw [← CMRA.assoc', RABase.op_core_right_of_incExt (RABase.incExt_op_right ..), CMRA.assoc',
     ← Auth.auth_dfrac_op]
 
 @[rocq_alias mono_Z_lb_op]
@@ -58,7 +58,7 @@ theorem lb_op (n1 n2 : MaxInt) : (◯MZ (n1 + n2) : MonoZ) = ((◯MZ n1) • (�
 
 @[rocq_alias mono_Z_auth_lb_op]
 theorem auth_lb_op (dq : DFrac) (n : MaxInt) : (●MZ{dq} n : MonoZ) = (●MZ{dq} n) • (◯MZ n) :=
-  (CMRA.op_core_left_of_inc (CMRA.inc_op_right ..)).symm
+  (RABase.op_core_left_of_incExt (RABase.incExt_op_right ..)).symm
 
 @[rocq_alias mono_Z_lb_op_le_l]
 theorem lb_op_le_l (n n' : MaxInt) (h : n' ≤ n) :
@@ -80,7 +80,8 @@ theorem auth_dfrac_op_valid (dq1 dq2 : DFrac) (n1 n2 : MaxInt) :
   · intro h
     unfold auth at h
     have ⟨hdq, heq, _⟩ := Auth.auth_dfrac_op_valid.mp <|
-      CMRA.valid_of_inc (CMRA.op_mono (CMRA.inc_op_left ..) (CMRA.inc_op_left ..)) h
+      RABase.valid_of_incExt
+        (RABase.op_mono_ext (RABase.incExt_op_left ..) (RABase.incExt_op_left ..)) h
     exact ⟨hdq, Option.some_inj.mp heq⟩
   · rintro ⟨hdq, rfl⟩
     exact auth_dfrac_op dq1 dq2 n1 ▸ (auth_dfrac_valid _ n1).mpr hdq
@@ -95,7 +96,7 @@ theorem both_dfrac_valid (dq : DFrac) (n m : MaxInt) :
     (✓ ((●MZ{dq} n) • (◯MZ m) : MonoZ)) ↔ ✓ dq ∧ m ≤ n := by
   unfold auth lb
   rw [CMRA.assoc'.symm, ← Auth.frag_op, Auth.both_dfrac_valid_discrete, ← Option.some_op,
-    Option.some_inc_some_iff_is_total, MaxInt.inc_iff]
+    Option.some_inc_some_iff_incRefl, MaxInt.inc_iff]
   exact ⟨fun ⟨hdq, hle, _⟩ => ⟨hdq, by grind⟩, fun ⟨hdq, hle⟩ => ⟨hdq, by grind, trivial⟩⟩
 
 @[rocq_alias mono_Z_both_valid]
@@ -103,16 +104,17 @@ theorem both_valid (n m : MaxInt) : (✓ ((●MZ n) • (◯MZ m) : MonoZ)) ↔ 
   (both_dfrac_valid ..).trans ⟨And.right, fun h => ⟨DFrac.valid_own_one, h⟩⟩
 
 @[rocq_alias mono_Z_lb_mono]
-theorem lb_mono (n1 n2 : MaxInt) (h : n1 ≤ n2) : (◯MZ n1 : MonoZ) ≼ ◯MZ n2 :=
-  Auth.frag_inc_of_inc <| Option.some_inc_some_iff_is_total.mpr <| MaxInt.inc_iff.mpr h
+theorem lb_mono (n1 n2 : MaxInt) (h : n1 ≤ n2) : (◯MZ n1 : MonoZ) ≼ₑ ◯MZ n2 :=
+  Auth.frag_incExt_of_incExt <| Option.some_incExt_some_iff_is_total.mpr <| MaxInt.inc_iff.mpr h
 
 @[rocq_alias mono_Z_included]
-theorem included (dq : DFrac) (n : MaxInt) : (◯MZ n : MonoZ) ≼ ●MZ{dq} n :=
-  CMRA.inc_op_right ..
+theorem included (dq : DFrac) (n : MaxInt) : (◯MZ n : MonoZ) ≼ₑ ●MZ{dq} n :=
+  RABase.incExt_op_right ..
 
 @[rocq_alias mono_Z_update]
 theorem update {n : MaxInt} (n' : MaxInt) (h : n ≤ n') : (●MZ n : MonoZ) ~~> ●MZ n' :=
-  Auth.auth_update (LocalUpdate.option (MaxInt.local_update h))
+  Auth.auth_update_of_localUpdate (Option.incExtN_of_incN fun h => h)
+    (LocalUpdate.option (MaxInt.local_update h))
 
 @[rocq_alias mono_Z_auth_persist]
 theorem auth_persist (n : MaxInt) (dq : DFrac) : (●MZ{dq} n : MonoZ) ~~> ●MZ□ n :=

--- a/Iris/Iris/Algebra/Lib/SetBij.lean
+++ b/Iris/Iris/Algebra/Lib/SetBij.lean
@@ -63,12 +63,14 @@ theorem viewRel_iff {n} : viewRel n (valid L') (valid L) ↔ L ⊆ L' ∧ SetBij
 
 @[rocq_alias gset_bij_view_rel_raw_mono, rocq_alias gset_bij_view_rel_raw_valid,
   rocq_alias gset_bij_view_rel_raw_unit]
-instance : IsViewRel (viewRel (S := S)) where
-  mono {_ x₁ y₁ n₂ x₂ y₂} h hx hy _ := by
+instance : IsViewRel (viewRel (S := S)) := .ofMonoOrd
+  (mono_ord := by
+    intro _ x₁ y₁ n₂ x₂ y₂ h hx hy _
     obtain ⟨_⟩ := x₁; obtain ⟨_⟩ := y₁; obtain ⟨_⟩ := y₂; obtain rfl := (hx : _ = _)
-    exact ⟨subset_trans ((included_iff_subset ..).mp ((inc_iff_incN n₂).mpr hy)) h.1, h.2⟩
-  rel_validN _ _ _ _ := trivial
-  rel_unit _ := ⟨valid ∅, subset_refl, SetBijective.empty⟩
+    refine ⟨subset_trans ((included_iff_subset ..).mp ?_) h.1, h.2⟩
+    exact (RABase.incExt_iff_incExtN n₂).mpr hy)
+  (rel_validN := fun _ _ _ _ => trivial)
+  (rel_unit := fun _ => ⟨valid ∅, subset_refl, SetBijective.empty⟩)
 
 @[rocq_alias gset_bij_view_rel_discrete]
 instance : IsViewRelDiscrete (viewRel (S := S)) where
@@ -154,9 +156,10 @@ theorem elem_agree (h : ✓ ((elem a₁ b₁ • elem a₂ b₂) : SetBij S)) : 
     (mem_union.mpr (.inr (mem_singleton.mpr rfl)))
 
 @[rocq_alias bij_view_included]
-theorem elem_inc_auth (h : (a, b) ∈ L) : elem a b ≼ auth dq L :=
-  inc_trans (frag_inc_of_inc <| (included_iff_subset ..).mpr fun _ hx => mem_singleton.mp hx ▸ h)
-    (inc_op_right ..)
+theorem elem_incExt_auth (h : (a, b) ∈ L) : elem a b ≼ₑ auth dq L :=
+  RABase.incExt_trans
+    (frag_incExt_of_incExt <| (included_iff_subset ..).mpr fun _ hx => mem_singleton.mp hx ▸ h)
+    (RABase.incExt_op_right ..)
 
 @[rocq_alias gset_bij_auth_extend]
 theorem auth_extend (ha : ∀ b', (a, b') ∉ L) (hb : ∀ a', (a', b) ∉ L) :

--- a/Iris/Iris/Algebra/Lib/UFracAuth.lean
+++ b/Iris/Iris/Algebra/Lib/UFracAuth.lean
@@ -31,7 +31,7 @@ abbrev UFracAuth [CMRA A] := Auth (Option (UFrac × A))
 
 namespace UFracAuth
 
-variable [CMRA A]
+variable [CMRA A] [CMRA.Affine A]
 
 @[rocq_alias ufrac_auth_auth]
 nonrec abbrev auth (q : Qp) (a : A) : UFracAuth (A := A) :=
@@ -77,17 +77,16 @@ theorem validN {n : Nat} {a : A} {p : Qp} (ha : ✓{n} a) : ✓{n} (●U{p} a) �
 
 @[rocq_alias ufrac_auth_valid]
 theorem valid {p : Qp} {a : A} (ha : ✓ a) : ✓ (●U{p} a) • ◯U{p} a :=
-  auth_both_valid_2 ⟨trivial, ha⟩ ⟨none, rfl⟩
+  auth_both_valid_2 ⟨trivial, ha⟩ (CMRA.inc_refl _)
 
 /-! ## Agreement -/
 
 @[rocq_alias ufrac_auth_agreeN]
 theorem agreeN {n : Nat} {p : Qp} {a b : A} (h : ✓{n} (●U{p} a) • ◯U{p} b) : a ≡{n}≡ b := by
-  obtain ⟨mc, hmc⟩ := (both_validN.mp h).1
-  match mc with
-  | none => exact hmc.2
-  | some (r, _) =>
-    have hp : p = p + r.frac := ext_iff.mp hmc.1
+  rcases (both_validN.mp h).1 with e | i
+  · exact e.2.symm
+  · obtain ⟨r, hr⟩ := i.1
+    have hp : p = p + r.frac := ext_iff.mp hr
     grind
 
 @[rocq_alias ufrac_auth_agree]
@@ -102,28 +101,26 @@ theorem agree {p : Qp} {a b : A} (h : ✓ (●U{p} a) • ◯U{p} b) : a = b :=
 theorem includedN {n : Nat} {p q : Qp} {a b : A}
     (h : ✓{n} (●U{p} a) • ◯U{q} b) : some b ≼{n} some a := by
   rw [both_validN] at h
-  obtain ⟨⟨mc, hmc⟩, _⟩ := h
-  match mc with
-  | none => exact ⟨none, hmc.2⟩
-  | some (_, cr) => exact ⟨some cr, hmc.2⟩
+  rcases h.1 with e | i
+  · exact Option.some_incN_some_iff.mpr (.inl e.2)
+  · exact Option.some_incN_some_iff.mpr (.inr i.2)
 
 @[rocq_alias ufrac_auth_included]
 theorem included [CMRA.Discrete A] {q p : Qp} {a b : A} (h : ✓ (●U{p} a) • ◯U{q} b) :
     some b ≼ some a := by
   rw [auth_both_valid_discrete] at h
-  obtain ⟨⟨mc, hmc⟩, _⟩ := h
-  match mc with
-  | none => exact ⟨none, congrArg (some ·.snd) (some_eqv_some.mp hmc)⟩
-  | some (_, cr) => exact ⟨some cr, congrArg (some ·.snd) (some_eqv_some.mp hmc)⟩
+  rcases h.1 with e | i
+  · exact Option.some_inc_some_iff.mpr (.inl (congrArg Prod.snd e))
+  · exact Option.some_inc_some_iff.mpr (.inr i.2)
 
 @[rocq_alias ufrac_auth_includedN_total]
-theorem includedN_total [IsTotal A] {n : Nat} {q p : Qp} {a b : A} (h : ✓{n} (●U{p} a) • ◯U{q} b) :
-    b ≼{n} a := some_incN_some_iff_is_total.mp <| includedN h
+theorem includedN_total [IncRefl A] {n : Nat} {q p : Qp} {a b : A} (h : ✓{n} (●U{p} a) • ◯U{q} b) :
+    b ≼{n} a := (Option.some_incN_some_iff.mp (includedN h)).elim (·.to_incN) id
 
 @[rocq_alias ufrac_auth_included_total]
-theorem included_total [CMRA.Discrete A] [IsTotal A] {q p : Qp} {a b : A}
+theorem included_total [CMRA.Discrete A] [IncRefl A] {q p : Qp} {a b : A}
     (h : ✓ (●U{p} a) • ◯U{q} b) : b ≼ a :=
-  inc_of_some_inc_some <| included h
+  (Option.some_inc_some_iff.mp (included h)).elim (· ▸ CMRA.inc_refl b) id
 
 /-! ## Auth-only validity -/
 
@@ -182,23 +179,39 @@ instance isOp_ufrac_auth_core_id {q q1 q2 : Qp} {a : A} [h1 : CoreId a] [h2 : Is
 
 /-! ## Updates -/
 
+omit [CMRA.Affine A] in
+/-- The order of the fragment algebra `Option (UFrac × A)` embeds into the extension
+inclusion, given that the order of `A` does. -/
+private theorem incExtN_of_incN (hsub : ∀ {n : Nat} {x y : A}, x ≼{n} y → x ≼ₑ{n} y)
+    {n : Nat} {x y : Option (UFrac × A)} (h : x ≼{n} y) : x ≼ₑ{n} y :=
+  Option.incExtN_of_incN (Prod.incExtN_of_incN (fun h => h) hsub) h
+
 @[rocq_alias ufrac_auth_update]
-theorem update {p q : Qp} {a b a' b' : A} (h : (a, b) ~l~> (a', b')) :
+theorem update {p q : Qp} {a b a' b' : A}
+    (hsub : ∀ {n : Nat} {x y : A}, x ≼{n} y → x ≼ₑ{n} y) (h : (a, b) ~l~> (a', b')) :
     ((●U{p} a) • ◯U{q} b) ~~> (●U{p} a') • ◯U{q} b' :=
-  auth_update <| .option (.prod_2 _ _ h)
+  auth_update_of_localUpdate
+    (incExtN_of_incN hsub)
+    (.option (.prod_2 _ _ h))
 
 @[rocq_alias ufrac_auth_update_surplus]
-theorem update_surplus {p q : Qp} {a b : A} (h : ✓ (a • b)) :
+theorem update_surplus {p q : Qp} {a b : A}
+    (hsub : ∀ {n : Nat} {x y : A}, x ≼{n} y → x ≼ₑ{n} y) (h : ✓ (a • b)) :
     (●U{p} a) ~~> (●U{p + q} (a • b)) • ◯U{q} b := by
-  refine auth_update_alloc (local_update_unital.mpr fun n mpa _ heq => ?_)
+  refine auth_update_alloc_of_localUpdate
+    (incExtN_of_incN hsub)
+    (local_update_unital.mpr fun n mpa _ heq => ?_)
   refine ⟨⟨trivial, h.validN⟩, ?_⟩
   refine .trans ?_ (heq.trans (unit_left_id_dist mpa)).op_r
   exact ⟨comm.dist, op_commN⟩
 
 @[rocq_alias ufrac_auth_update_surplus_cancel]
-theorem update_surplus_cancel {p q : Qp} {a b : A} [CMRA.Cancelable b] :
+theorem update_surplus_cancel {p q : Qp} {a b : A} [CMRA.Cancelable b]
+    (hsub : ∀ {n : Nat} {x y : A}, x ≼{n} y → x ≼ₑ{n} y) :
     ((●U{p + q} (a • b)) • ◯U{q} b) ~~> ●U{p} a := by
-  refine auth_update_dealloc (local_update_unital.mpr fun n mpa hv heq => ?_)
+  refine auth_update_dealloc_of_localUpdate
+    (incExtN_of_incN hsub)
+    (local_update_unital.mpr fun n mpa hv heq => ?_)
   match mpa with
   | none =>
     grind [show p + q = q from ext_iff.mp heq.1]

--- a/Iris/Iris/Algebra/LocalUpdates.lean
+++ b/Iris/Iris/Algebra/LocalUpdates.lean
@@ -79,9 +79,10 @@ theorem LocalUpdate.replace (x y : α) [CMRA.IdFree x] (h : ✓ y) : (x, x) ~l~>
   | some _ => cases CMRA.id_freeN_r vx e.symm
 
 @[rocq_alias core_id_local_update]
-theorem LocalUpdate.core_id (x y z : α) [CMRA.CoreId y] (inc : y ≼ x) : (x, z) ~l~> (x, z • y) := by
+theorem LocalUpdate.core_id (x y z : α) [CMRA.CoreId y] (inc : y ≼ₑ x) :
+    (x, z) ~l~> (x, z • y) := by
   refine fun n mz vx e => ⟨vx, ?_⟩
-  refine (CMRA.op_core_right_of_inc inc).symm.dist.trans ?_
+  refine (RABase.op_core_right_of_incExt inc).symm.dist.trans ?_
   match mz with
   | none => calc
     y • x ≡{n}≡ y • z := e.op_r
@@ -102,28 +103,28 @@ theorem LocalUpdate.discrete [CMRA.Discrete α] (x y x' y' : α) :
 
 @[rocq_alias local_update_valid0]
 theorem LocalUpdate.valid0 {x y x' y' : α}
-    (h : ✓{0} x → ✓{0} y → some y ≼{0} some x → (x, y) ~l~> (x', y')) :
+    (h : ✓{0} x → ✓{0} y → some y ≼ₑ{0} some x → (x, y) ~l~> (x', y')) :
     (x, y) ~l~> (x', y') := by
   intro n mz vx e
   have v0y : ✓{0} y := CMRA.valid0_of_validN <| CMRA.validN_opM ((OFE.Dist.validN e).mp vx)
-  have : some y ≼{0} some x := CMRA.inc0_of_incN (Option.some_inc_some_of_dist_opM e)
+  have : some y ≼ₑ{0} some x := RABase.incExt0_of_incExtN (Option.some_incExt_some_of_dist_opM e)
   exact h (CMRA.valid0_of_validN vx) v0y this n mz vx e
 
 @[rocq_alias local_update_valid]
 theorem LocalUpdate.valid [CMRA.Discrete α] {x y x' y' : α}
-    (h : ✓ x → ✓ y → some y ≼ some x → (x, y) ~l~> (x', y')) : (x, y) ~l~> (x', y') :=
+    (h : ✓ x → ✓ y → some y ≼ₑ some x → (x, y) ~l~> (x', y')) : (x, y) ~l~> (x', y') :=
   .valid0 fun vx0 vy0 mz =>
-    h (CMRA.discrete_valid vx0) (CMRA.discrete_valid vy0) ((CMRA.inc_iff_incN 0).mpr mz)
+    h (CMRA.discrete_valid vx0) (CMRA.discrete_valid vy0) (RABase.incExt_of_incExt0 mz)
 
 @[rocq_alias local_update_total_valid0]
 theorem LocalUpdate.total_valid0 [CMRA.IsTotal α] {x y x' y' : α}
-    (h : ✓{0} x → ✓{0} y → y ≼{0} x → (x, y) ~l~> (x', y')) : (x, y) ~l~> (x', y') :=
-  .valid0 fun vx0 vy0 mz => h vx0 vy0 (Option.some_incN_some_iff_is_total.mp mz)
+    (h : ✓{0} x → ✓{0} y → y ≼ₑ{0} x → (x, y) ~l~> (x', y')) : (x, y) ~l~> (x', y') :=
+  .valid0 fun vx0 vy0 mz => h vx0 vy0 (Option.some_incExtN_some_iff_is_total.mp mz)
 
 @[rocq_alias local_update_total_valid]
 theorem LocalUpdate.total_valid [CMRA.IsTotal α] [CMRA.Discrete α] {x y x' y' : α}
-    (h : ✓ x → ✓ y → y ≼ x → (x, y) ~l~> (x', y')) : (x, y) ~l~> (x', y') :=
-  .valid fun vx vy inc => h vx vy (Option.inc_of_some_inc_some inc)
+    (h : ✓ x → ✓ y → y ≼ₑ x → (x, y) ~l~> (x', y')) : (x, y) ~l~> (x', y') :=
+  .valid fun vx vy inc => h vx vy (Option.incExt_of_some_incExt_some inc)
 
 end CMRA
 

--- a/Iris/Iris/Algebra/MaxPrefixList.lean
+++ b/Iris/Iris/Algebra/MaxPrefixList.lean
@@ -47,9 +47,13 @@ instance instOFE : OFE (MaxPrefixList α) :=
 instance instCMRA : CMRA (MaxPrefixList α) :=
   Heap.instStoreCMRA (M:= MaxPrefixListMap) (V := Agree α)
 
-/-- UCMRA instance on [MaxPrefixList], inherited from the UCMRA on the underlying map. -/
+/-- UCMRA instance on `MaxPrefixList`, inherited from the UCMRA on the underlying map. -/
 instance instUCMRA : UCMRA (MaxPrefixList α) :=
   Heap.instStoreUCMRA  (M:= MaxPrefixListMap) (V := Agree α)
+
+/-- Affineness of `MaxPrefixList`, inherited from the underlying map. -/
+instance instAffine : CMRA.Affine (MaxPrefixList α) :=
+  inferInstanceAs (CMRA.Affine (MaxPrefixListMap (Agree α)))
 
 instance instCoreId (x : MaxPrefixList α) : CoreId x :=
   Heap.instCoreId (M:= MaxPrefixListMap) (V := Agree α)
@@ -57,6 +61,7 @@ instance instCoreId (x : MaxPrefixList α) : CoreId x :=
 instance instDiscrete [OFE.Discrete α] : CMRA.Discrete (MaxPrefixList α) where
   discrete_0 := OFE.discrete_0 (α := MaxPrefixListMap (Agree α))
   discrete_valid := CMRA.discrete_valid (α := MaxPrefixListMap (Agree α))
+  discrete_inc := CMRA.discrete_inc (α := MaxPrefixListMap (Agree α))
 
 end Instances
 
@@ -145,9 +150,9 @@ theorem toMaxPrefixList_op_right {l1 l2 : List α} (h : l1 <+: l2) :
   comm'.trans (toMaxPrefixList_op_left h)
 
 @[rocq_alias max_prefix_list_included_includedN]
-theorem inc_iff_forall_incN {ml1 ml2 : MaxPrefixList α} :
-    ml1 ≼ ml2 ↔ ∀ n, ml1 ≼{n} ml2 := by
-  refine ⟨fun h n => incN_of_inc n h, fun h => ⟨ml2, eq_dist_2 fun n => ?_⟩⟩
+theorem incExt_iff_forall_incExtN {ml1 ml2 : MaxPrefixList α} :
+    ml1 ≼ₑ ml2 ↔ ∀ n, ml1 ≼ₑ{n} ml2 := by
+  refine ⟨fun h n => RABase.incExtN_of_incExt n h, fun h => ⟨ml2, eq_dist_2 fun n => ?_⟩⟩
   obtain ⟨l, hl⟩ := h n
   calc ml2 ≡{n}≡ ml1 • l := hl
     _ ≡{n}≡ (ml1 • ml1) • l := (congrArg (· • l) (op_self ml1)).symm.dist
@@ -155,12 +160,12 @@ theorem inc_iff_forall_incN {ml1 ml2 : MaxPrefixList α} :
     _ ≡{n}≡ ml1 • ml2 := hl.symm.op_r
 
 @[rocq_alias to_max_prefix_list_includedN_aux]
-theorem toMaxPrefixList_incN_aux {n} {l1 l2 : List α}
-    (h : toMaxPrefixList l1 ≼{n} toMaxPrefixList l2) : l2 ≡{n}≡ l1 ++ l2.drop l1.length := by
+theorem toMaxPrefixList_incExtN_aux {n} {l1 l2 : List α}
+    (h : toMaxPrefixList l1 ≼ₑ{n} toMaxPrefixList l2) : l2 ≡{n}≡ l1 ++ l2.drop l1.length := by
   refine list_dist_lookup.mpr fun i => ?_
   have hi := Heap.lookup_incN (M := MaxPrefixListMap).mp h i
   rw [get?_toMaxPrefixList, get?_toMaxPrefixList] at hi
-  rcases Option.incN_iff_is_total.mp hi with hnone | ⟨a1, a2, ha1, ha2, ha⟩
+  rcases Option.incExtN_iff_is_total.mp hi with hnone | ⟨a1, a2, ha1, ha2, ha⟩
   · refine .of_eq (by grind)
   · obtain ⟨x1, hx1, rfl⟩ := Option.map_eq_some_iff.mp ha1
     obtain ⟨x2, hx2, rfl⟩ := Option.map_eq_some_iff.mp ha2
@@ -168,20 +173,20 @@ theorem toMaxPrefixList_incN_aux {n} {l1 l2 : List α}
     exact some_dist_some.mpr (Agree.toAgree_includedN.mp ha).symm
 
 @[rocq_alias to_max_prefix_list_includedN]
-theorem toMaxPrefixList_incN_iff {n} {l1 l2 : List α} :
-    toMaxPrefixList l1 ≼{n} toMaxPrefixList l2 ↔ ∃ l, l2 ≡{n}≡ l1 ++ l := by
-  refine ⟨fun h => ⟨_, toMaxPrefixList_incN_aux h⟩, fun ⟨l, hl⟩ => ?_⟩
-  refine incN_of_incN_of_dist ?_ (toMaxPrefixList_ne.ne hl).symm
-  grind [incN_of_inc, inc_op_left]
+theorem toMaxPrefixList_incExtN_iff {n} {l1 l2 : List α} :
+    toMaxPrefixList l1 ≼ₑ{n} toMaxPrefixList l2 ↔ ∃ l, l2 ≡{n}≡ l1 ++ l := by
+  refine ⟨fun h => ⟨_, toMaxPrefixList_incExtN_aux h⟩, fun ⟨l, hl⟩ => ?_⟩
+  refine RABase.incExtN_of_incExtN_of_dist ?_ (toMaxPrefixList_ne.ne hl).symm
+  grind [RABase.incExtN_of_incExt, RABase.incExt_op_left]
 
 @[rocq_alias to_max_prefix_list_included]
-theorem toMaxPrefixList_inc_iff {l1 l2 : List α} :
-    toMaxPrefixList l1 ≼ toMaxPrefixList l2 ↔ l1 <+: l2 := by
+theorem toMaxPrefixList_incExt_iff {l1 l2 : List α} :
+    toMaxPrefixList l1 ≼ₑ toMaxPrefixList l2 ↔ l1 <+: l2 := by
   refine ⟨fun h => ⟨_, eq_dist_2 fun n =>
-    (toMaxPrefixList_incN_aux (incN_of_inc n h)).symm⟩, ?_⟩
-  grind [inc_op_left]
+    (toMaxPrefixList_incExtN_aux (RABase.incExtN_of_incExt n h)).symm⟩, ?_⟩
+  grind [RABase.incExt_op_left]
 
-#rocq_ignore to_max_prefix_list_included_L "Use toMaxPrefixList_inc_iff"
+#rocq_ignore to_max_prefix_list_included_L "Use toMaxPrefixList_incExt_iff"
 
 @[rocq_alias to_max_prefix_list_op_validN_aux]
 theorem toMaxPrefixList_op_validN_aux {n} {l1 l2 : List α} (hlen : l1.length ≤ l2.length)

--- a/Iris/Iris/Algebra/Mra.lean
+++ b/Iris/Iris/Algebra/Mra.lean
@@ -112,7 +112,7 @@ theorem append_idem (x : Mra R) : append x x = x := by
 #rocq_ignore mra_pcore "Replaced by the `pcore` field of the CMRA instance."
 
 @[rocq_alias mra_cmra_mixin]
-instance (R : α → α → Prop) : CMRA (Mra R) where
+instance (R : α → α → Prop) : RABase (Mra R) where
   pcore := some
   op := append
   ValidN _ _ := True
@@ -132,9 +132,13 @@ instance (R : α → α → Prop) : CMRA (Mra R) where
   pcore_op_left h :=
     (congrArg (append · _) (Option.some.inj h).symm).trans (append_idem _)
   pcore_idem _ := rfl
+  extend _ h := ⟨_, _, h, .rfl, .rfl⟩
+
+instance (R : α → α → Prop) : RABase.ExtensionLaws (Mra R) where
   pcore_op_mono h y :=
     ⟨y, congrArg (fun z ↦ some (append z y)) (Option.some.inj h)⟩
-  extend _ h := ⟨_, _, h, .rfl, .rfl⟩
+
+instance (R : α → α → Prop) : CMRA (Mra R) := CMRA.withExtensionOrder
 
 #rocq_ignore mraR "Use Mra."
 
@@ -150,19 +154,22 @@ instance (x : Mra R) : CMRA.CoreId x where
 instance : CMRA.Discrete (Mra R) where
   discrete_0 := id
   discrete_valid := id
+  discrete_inc | ⟨z, hz⟩ => ⟨z, hz⟩
 
 #rocq_ignore mra_unit "Replaced by the `unit` field of UCMRA instance."
 #rocq_ignore mraUR "Use Mra."
 
 -- FIXME: upstream name `auth_ucmra_mixin` should be `mra_ucmra_mixin`
 @[rocq_alias auth_ucmra_mixin]
-instance (R : α → α → Prop) : UCMRA (Mra R) where
+instance (R : α → α → Prop) : Unital (Mra R) where
   unit := mk []
   unit_valid := trivial
   unit_left_id {x} := by
     induction x using ind with
     | mk xs => rfl
   pcore_unit := rfl
+
+instance (R : α → α → Prop) : UCMRA (Mra R) := UCMRA.withExtensionOrder
 
 theorem eq_of_below_iff {x y : Mra R} (h : ∀ a, below a x ↔ below a y) : x = y := by
   induction x, y using ind₂ with
@@ -177,7 +184,7 @@ theorem idem (x : Mra R) : x • x = x := append_idem x
 
 @[rocq_alias mra_included]
 theorem inc_iff (x y : Mra R) : x ≼ y ↔ y = x • y :=
-  ⟨fun h ↦ (CMRA.op_core_right_of_inc h).symm, fun h ↦ ⟨y, h⟩⟩
+  ⟨fun h ↦ (RABase.op_core_right_of_incExt h).symm, fun h ↦ ⟨y, h⟩⟩
 
 @[rocq_alias to_mra_R_op]
 theorem toMra_op_of_rel [hR : Trans R R R] (a b : α) (h : R a b) :

--- a/Iris/Iris/Algebra/Numbers.lean
+++ b/Iris/Iris/Algebra/Numbers.lean
@@ -54,14 +54,21 @@ variable [Add α] [Associative (α := α) (· + ·)] [Commutative (α := α) (·
 variable [Zero α] [LawfulLeftIdentity (α := α) (· + ·) zero]
 variable {x y x' y' : α}
 
-scoped instance instCMRA : CMRA α :=
-  CMRA.ofDiscreteTotal (fun _ => zero) add (fun _ => True)
+scoped instance instRABase : RABase α :=
+  RABase.ofDiscreteTotal (fun _ => zero) add (fun _ => True)
     (fun x y z => (Associative.assoc (op := add) x y z).symm)
     (Commutative.comm (op := add))
     (fun _ => left_id (op := add) _)
     (fun _ => rfl)
-    (fun _ _ _ => ⟨zero, (left_id (op := add) _).symm⟩)
     (fun _ _ _ => trivial)
+
+scoped instance instIsTotal : CMRA.IsTotal α where
+  total _ := ⟨zero, rfl⟩
+
+scoped instance instExtensionLaws : RABase.ExtensionLaws α :=
+  .ofCoreMono fun _ _ _ => ⟨zero, (left_id (op := add) zero).symm⟩
+
+scoped instance instCMRA : CMRA α := CMRA.withExtensionOrder
 
 #rocq_ignore natR "Use the (ℕ, +) Constant Core CMRA."
 #rocq_ignore nat_ra_mixin "Use the (ℕ, +) Constant Core CMRA."
@@ -76,15 +83,19 @@ scoped instance instCMRA : CMRA α :=
 #rocq_ignore Z_valid_instance "Use the (ℤ, +) Constant Core CMRA"
 #rocq_ignore Z_validN_instance "Use the (ℤ, +) Constant Core CMRA"
 
-scoped instance instDiscrete : CMRA.Discrete α where discrete_valid := id
+scoped instance instDiscrete : CMRA.Discrete α where
+  discrete_valid := id
+  discrete_inc := RABase.incExt_of_incExt0
 #rocq_ignore nat_cmra_discrete "Use the (ℕ, +) Constant Core instance."
 #rocq_ignore Z_cmra_discrete "Use the (ℤ, +) Constant Core instance."
 
-scoped instance instUCMRA : UCMRA α where
+scoped instance instUnital : Unital α where
   unit := zero
   unit_valid := trivial
   unit_left_id := pcore_op_left rfl
   pcore_unit := rfl
+
+scoped instance instUCMRA : UCMRA α := UCMRA.withExtensionOrder
 
 #rocq_ignore natUR "Use the (ℕ, +) Constant Core UCMRA."
 #rocq_ignore nat_ucmra_mixin "Use the (ℕ, +) Constant Core UCMRA."
@@ -143,14 +154,20 @@ variable [IdempotentOp (α := α) (· + ·)]
 variable [Zero α]
 variable {x y x' y' : α}
 
-scoped instance instCMRA : CMRA α :=
-  CMRA.ofDiscreteTotal id add (fun _ => True)
+scoped instance instRABase : RABase α :=
+  RABase.ofDiscreteTotal id add (fun _ => True)
     (fun x y z => (Associative.assoc (op := add) x y z).symm)
     (Commutative.comm (op := add))
     (fun _ => idempotent _)
     (fun _ => rfl)
-    (fun _ _ h => h)
     (fun _ _ _ => trivial)
+
+scoped instance instIsTotal : CMRA.IsTotal α where
+  total x := ⟨x, rfl⟩
+
+scoped instance instExtensionLaws : RABase.ExtensionLaws α := .ofCoreMono fun _ _ h => h
+
+scoped instance instCMRA : CMRA α := CMRA.withExtensionOrder
 
 #rocq_ignore max_natO "Use the (ℕ, max) Universal Core CMRA."
 #rocq_ignore max_natR "Use the (ℕ, max) Universal Core CMRA."
@@ -178,12 +195,11 @@ scoped instance instCMRA : CMRA α :=
 
 scoped instance : CMRA.Discrete α where
   discrete_valid := id
+  discrete_inc := RABase.incExt_of_incExt0
 #rocq_ignore max_nat_cmra_discrete "Use the (ℕ, max) Universal Core instance."
 #rocq_ignore max_Z_cmra_discrete "Use the (ℤ, max) Universal Core instance."
 #rocq_ignore min_nat_cmra_discrete "Use the (ℕ, min) Universal Core instance."
 
-scoped instance instIsTotal : CMRA.IsTotal α where
-  total x := ⟨x, rfl⟩
 #rocq_ignore max_Z_cmra_total "Use the (ℤ, max) Universal Core instance."
 
 scoped instance instCoreId (a : α) : CMRA.CoreId a where
@@ -192,11 +208,14 @@ scoped instance instCoreId (a : α) : CMRA.CoreId a where
 #rocq_ignore max_Z_core_id "Use the (ℤ, max) Universal Core instance."
 #rocq_ignore min_nat_core_id "Use the (ℕ, min) Universal Core instance."
 
-scoped instance instUCMRA [LawfulLeftIdentity (α := α) (· + ·) zero] : UCMRA α where
+scoped instance instUnital [LawfulLeftIdentity (α := α) (· + ·) zero] : Unital α where
   unit := zero
   unit_valid := trivial
   unit_left_id := left_id _
   pcore_unit := rfl
+
+scoped instance instUCMRA [LawfulLeftIdentity (α := α) (· + ·) zero] : UCMRA α :=
+  UCMRA.withExtensionOrder
 #rocq_ignore max_Z_unit_instance "Rocq has no `max_Z_UCMRA`."
 #rocq_ignore max_natUR "Use the (ℕ, max) Universal Core instance."
 #rocq_ignore max_nat_ucmra_mixin "Use the (ℕ, max) Universal Core instance."
@@ -211,7 +230,7 @@ theorem op_eq {x y : α} : x • y = x + y := rfl
 
 omit [Zero α] in
 theorem inc_iff {x y : α} : x ≼ y ↔ x • y = y :=
-  ⟨CMRA.op_core_right_of_inc, fun h => ⟨y, h.symm⟩⟩
+  ⟨RABase.op_core_right_of_incExt, fun h => ⟨y, h.symm⟩⟩
 
 omit [Zero α] in
 /-- Sufficient condition for a local update on an idempotent structure. -/
@@ -219,7 +238,7 @@ theorem idem_local_update {x y x' : α} (h : x ≼ x') : (x, y) ~l~> (x', x') :=
   refine fun _ mz _ hn => ⟨trivial, OFE.Dist.of_eq ?_⟩
   cases mz with | none => rfl | some z =>
   replace hn : x = y • z := discrete hn
-  exact (CMRA.op_core_left_of_inc <| .trans ⟨y, hn.trans CMRA.comm'⟩ h).symm
+  exact (RABase.op_core_left_of_incExt <| .trans ⟨y, hn.trans CMRA.comm'⟩ h).symm
 
 scoped instance instDiscreteE {a : α} : DiscreteE a := ⟨fun H => discrete H⟩
 
@@ -235,14 +254,17 @@ variable [Add α] [Associative (α := α) (· + ·)] [Commutative (α := α) (·
 
 variable {x y x' y' : α}
 
-scoped instance instCMRA : CMRA α :=
-  CMRA.ofDiscrete (fun _ => none) add (fun _ => True)
+scoped instance instRABase : RABase α :=
+  RABase.ofDiscrete (fun _ => none) add (fun _ => True)
     (fun x y z => (Associative.assoc (op := add) x y z).symm)
     (Commutative.comm (op := add))
     (by rintro _ _ ⟨⟩)
     (by rintro _ _ ⟨⟩)
-    (by rintro _ _ _ _ ⟨⟩)
     (fun _ _ _ => trivial)
+
+scoped instance instExtensionLaws : RABase.ExtensionLaws α := .ofPCoreMono nofun
+
+scoped instance instCMRA : CMRA α := CMRA.withExtensionOrder
 
 #rocq_ignore positiveR "Use (PNat, +) No Core CMRA."
 #rocq_ignore pos_ra_mixin "Use (PNat, +) No Core CMRA."
@@ -253,6 +275,7 @@ scoped instance instCMRA : CMRA α :=
 
 scoped instance instDiscrete : CMRA.Discrete α where
   discrete_valid := id
+  discrete_inc := RABase.incExt_of_incExt0
 #rocq_ignore pos_cmra_discrete "Use (PNat, +) No Core instance."
 
 scoped instance instCancelable [LeftCancelAdd α] {a : α} : Cancelable a where
@@ -333,6 +356,7 @@ scoped instance : Std.IdempotentOp (α := MaxNat) (· + ·) where idempotent x :
 scoped instance : COFE MaxNat := COFE.ofDiscrete _
 scoped instance : OFE.Discrete MaxNat := ⟨fun h => h⟩
 scoped instance : UCMRA MaxNat := OrdCommMonoidLike.instUCMRA
+scoped instance : RABase.ExtensionLaws MaxNat := OrdCommMonoidLike.instExtensionLaws
 scoped instance : CMRA.Discrete MaxNat := OrdCommMonoidLike.instDiscrete
 scoped instance : CMRA.CoreId (a : MaxNat) := OrdCommMonoidLike.instCoreId _
 
@@ -387,6 +411,7 @@ scoped instance : IdempotentOp (α := MaxInt) (· + ·) where idempotent x := by
 scoped instance : COFE MaxInt := COFE.ofDiscrete _
 scoped instance : OFE.Discrete MaxInt := ⟨fun h => h⟩
 scoped instance : CMRA MaxInt := OrdCommMonoidLike.instCMRA
+scoped instance : RABase.ExtensionLaws MaxInt := OrdCommMonoidLike.instExtensionLaws
 scoped instance : CMRA.Discrete MaxInt := OrdCommMonoidLike.instDiscrete
 scoped instance : CMRA.IsTotal MaxInt := OrdCommMonoidLike.instIsTotal
 scoped instance : CMRA.CoreId (a : MaxInt) := OrdCommMonoidLike.instCoreId _
@@ -445,6 +470,7 @@ scoped instance : IdempotentOp (α := MinNat) (· + ·) where idempotent _ := by
 scoped instance : COFE MinNat := COFE.ofDiscrete _
 scoped instance : OFE.Discrete MinNat := ⟨fun h => h⟩
 scoped instance : CMRA MinNat := OrdCommMonoidLike.instCMRA
+scoped instance : RABase.ExtensionLaws MinNat := OrdCommMonoidLike.instExtensionLaws
 scoped instance : CMRA.Discrete MinNat := OrdCommMonoidLike.instDiscrete
 scoped instance : CMRA.IsTotal MinNat := OrdCommMonoidLike.instIsTotal
 scoped instance : CMRA.CoreId (a : MinNat) := OrdCommMonoidLike.instCoreId _

--- a/Iris/Iris/Algebra/ReservationMap.lean
+++ b/Iris/Iris/Algebra/ReservationMap.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Сухарик. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Сухарик (@suhr), Markus de Medeiros, Janine Lohse
+-/
 module
 
 import Iris.Std.Positives
@@ -217,8 +222,7 @@ theorem op_token' (x y : ReservationMap A H) : (x.op y).token = x.token • y.to
 #rocq_ignore reservation_map_ucmra_mixin "Not needed"
 #rocq_ignore reservation_mapR "Derivable using UCMRA"
 
-@[rocq_alias reservation_mapUR]
-instance : UCMRA (ReservationMap A H) where
+instance : RABase (ReservationMap A H) where
   pcore := some ∘ core
   Valid := Valid
   ValidN := ValidN
@@ -280,23 +284,98 @@ instance : UCMRA (ReservationMap A H) where
     refine fun n => ⟨?_, ?_⟩
     · simp only [←Option.some_inj.mp h, core_data]; exact (core_idem x.data).dist
     · simp [←Option.some_inj.mp h, core_token, core_idem_L]
-  pcore_op_mono {x cx} h y := by
-    obtain ⟨z, hz⟩ := core_op_mono x.data y.data
-    obtain ⟨w, hw⟩ := core_op_mono x.token y.token
-    refine ⟨mk z w, OFE.eq_dist_2 ?_⟩
-    refine fun n => ⟨?_, ?_⟩
-    · simp only [op_data', core_data, (Option.some_inj.mp h.symm)]; exact hz.dist
-    · simp only [core_token, op_token', (Option.some_inj.mp h.symm)]; exact hw.dist
   extend {n x y₁ y₂} v exy := by
     obtain ⟨z₁, z₂, xzz, zy₁, zy₂⟩ := CMRA.extend (validN_data_of_validN v) exy.left
     refine ⟨mk z₁ y₁.token, mk z₂ y₂.token, OFE.eq_dist_2 ?_, ⟨zy₁, rfl⟩, ⟨zy₂, rfl⟩⟩
     exact fun m => ⟨xzz.dist, exy.right⟩
+
+/-- The order on `ReservationMap A H`, inherited componentwise. -/
+@[reducible] def ReservationMap.orderN : OrderN (ReservationMap A H) where
+  IncludedN n x y := x.data ≼{n} y.data ∧ x.token ≼{n} y.token
+  Included x y := x.data ≼ y.data ∧ x.token ≼ y.token
+  incN_ne ex ey h := ⟨CMRA.incN_ne ex.1 ey.1 h.1, CMRA.incN_ne ex.2 ey.2 h.2⟩
+  incN_succ h := ⟨CMRA.incN_succ h.1, CMRA.incN_succ h.2⟩
+  incN_trans h1 h2 := ⟨CMRA.incN_trans h1.1 h2.1, CMRA.incN_trans h1.2 h2.2⟩
+  inc_trans h1 h2 := ⟨CMRA.inc_trans h1.1 h2.1, CMRA.inc_trans h1.2 h2.2⟩
+  incN_of_inc n h := ⟨CMRA.incN_of_inc n h.1, CMRA.incN_of_inc n h.2⟩
+
+section
+attribute [local instance] ReservationMap.orderN
+
+theorem ReservationMap.increasing_data {v : ReservationMap A H}
+    (h : CMRA.Increasing v) : CMRA.Increasing v.data where
+  increasing w := (h.increasing (mk w ∅)).1
+
+theorem ReservationMap.increasing_token {v : ReservationMap A H}
+    (h : CMRA.Increasing v) : CMRA.Increasing v.token where
+  increasing w := (h.increasing (mk ∅ w)).2
+
+theorem ReservationMap.increasing_mk {v : ReservationMap A H}
+    (hd : CMRA.Increasing v.data) (ht : CMRA.Increasing v.token) : CMRA.Increasing v where
+  increasing w := ⟨hd.increasing w.data, ht.increasing w.token⟩
+
+open ReservationMap in
+instance instCMRAReservationMap : CMRA (ReservationMap A H) where
+  toOrderN := ReservationMap.orderN
+  op_monoN_left z h := ⟨CMRA.op_monoN_left z.data h.1, CMRA.op_monoN_left z.token h.2⟩
+  op_mono_left z h := ⟨CMRA.op_mono_left z.data h.1, CMRA.op_mono_left z.token h.2⟩
+  validN_of_incN {n x y} h v := by
+    refine validN_iff.mpr ⟨?_, ?_, fun i => ?_⟩
+    · exact CMRA.validN_of_incN h.1 (validN_data_of_validN v)
+    · exact CMRA.validN_of_incN h.2 (validN_token_of_validN v)
+    · rcases validN_disj v i with hd | ht
+      · refine .inl ?_
+        have hi := h.1 i
+        rw [hd] at hi
+        match hx : get? x.data i with
+        | none => rfl
+        | some _ => exact absurd (hx ▸ hi) Option.not_some_incN_none
+      · refine .inr fun hc => ht ?_
+        obtain ⟨w, hw⟩ := h.2
+        rw [(hw : y.token = x.token • w)]
+        exact (mem_iff_of_validN_union
+          ((hw : y.token = x.token • w) ▸ validN_token_of_validN v) i).mpr (.inl hc)
+  pcore_monoN {_ x y _} h e := by
+    cases Option.some_inj.mp e
+    exact ⟨_, rfl, CMRA.core_incN_core h.1, CMRA.core_incN_core h.2⟩
+  pcore_mono {x y _} h e := by
+    cases Option.some_inj.mp e
+    exact ⟨_, rfl, CMRA.core_mono h.1, CMRA.core_mono h.2⟩
+  pcore_order_op {x _} e y := by
+    cases Option.some_inj.mp e
+    exact ⟨_, rfl, CMRA.core_op_mono x.data y.data, CMRA.core_op_mono x.token y.token⟩
+  pcore_increasing {x _} e := by
+    cases Option.some_inj.mp e
+    refine increasing_mk ?_ ?_
+    · rw [core_data]; exact inferInstance
+    · rw [core_token]; exact inferInstance
+  increasing_closed {n x y} h h' :=
+    increasing_mk
+      (CMRA.increasing_closed (increasing_data h) (Or.imp (·.1) (·.1) h'))
+      (CMRA.increasing_closed (increasing_token h) (Or.imp (·.2) (·.2) h'))
+  incN_extend {n x y} v h := by
+    obtain ⟨zd, hzd, ed⟩ := CMRA.incN_extend (validN_data_of_validN v) h.1
+    obtain ⟨zt, hzt, et⟩ := CMRA.incN_extend (validN_token_of_validN v) h.2
+    exact ⟨mk zd zt, ⟨hzd, hzt⟩, ed, et⟩
+
+end
+
+/-- A reservation map over an affine algebra is affine. -/
+instance [CMRA.Affine A] : CMRA.Affine (ReservationMap A H) where
+  increasing v :=
+    ReservationMap.increasing_mk (CMRA.Affine.increasing v.data)
+      (CMRA.Affine.increasing v.token)
+
+@[rocq_alias reservation_mapUR]
+instance : UCMRA (ReservationMap A H) where
+  toCMRA := instCMRAReservationMap
   unit := mk ∅ ∅
   unit_valid := ⟨Heap.valid_empty, fun _ => .inr CoPset.mem_empty⟩
   unit_left_id {x} := OFE.eq_dist_2 <| by
     refine fun n => ⟨?_, (pcore_op_left' rfl).dist⟩
     exact (Algebra.MonoidOps.op_left_id : (∅ : H A) • x.data = x.data).dist
   pcore_unit := OFE.eq_dist_2 <| by exact fun n => ⟨Heap.core_empty.dist, .rfl⟩
+  inc_refl x := ⟨CMRA.inc_refl x.data, CMRA.inc_refl x.token⟩
 
 @[simp]
 theorem op_data (x y : ReservationMap A H): (x • y).data = x.data • y.data := rfl
@@ -305,8 +384,8 @@ theorem op_data (x y : ReservationMap A H): (x • y).data = x.data • y.data :
 theorem op_token (x y : ReservationMap A H): (x • y).token = x.token • y.token := rfl
 
 @[rocq_alias reservation_map_included]
-theorem included_iff {x y : ReservationMap A H} :
-    x ≼ y ↔ x.data ≼ y.data ∧ x.token ≼ y.token := by
+theorem incExt_iff {x y : ReservationMap A H} :
+    x ≼ₑ y ↔ x.data ≼ₑ y.data ∧ x.token ≼ₑ y.token := by
   constructor
   · exact fun ⟨z, H⟩ => ⟨⟨z.data, H ▸ rfl⟩, ⟨z.token, H ▸ rfl⟩⟩
   · obtain ⟨yd, yt⟩ := y
@@ -320,6 +399,7 @@ instance [CMRA.Discrete A] : CMRA.Discrete (ReservationMap A H) where
     · exact discrete_valid (validN_data_of_validN v)
     · exact validN_token_of_validN v
     · exact validN_disj v
+  discrete_inc h := ⟨fun k => CMRA.discrete_inc (h.1 k), CMRA.discrete_inc h.2⟩
 
 #rocq_ignore reservation_map_empty_instance "Part of UCMRA instance"
 
@@ -437,7 +517,8 @@ theorem valid_data_op_token (a : H A) (b : CoPset) (vd : ✓ mkData a)
     | inr h => simpa only [eo] using .inr h
 
 @[rocq_alias reservation_map_data_mono]
-theorem singleton_mono {k} {a b : A} (Hab : a ≼ b) : singleton (H := H) k a ≼ singleton k b :=
+theorem singleton_mono_ext {k} {a b : A} (Hab : a ≼ₑ b) :
+    singleton (H := H) k a ≼ₑ singleton k b :=
   let ⟨z, hz⟩ := Hab
   ⟨singleton k z, (congrArg (singleton k) hz).trans (singleton_op k a z)⟩
 
@@ -499,7 +580,8 @@ theorem valid_singleton_op_of_valid_op? {a : A} {x : H A} (vx : ✓{n} x) (h : �
   · simp only [LawfulPartialMap.get?_singleton, ki, ↓reduceIte]; exact Heap.validN_get? vx
 
 @[rocq_alias reservation_map_alloc]
-theorem alloc {e k} {a : A} (hke : k ∈ e) (va : ✓ a) : mkToken (H := H) e ~~> singleton k a := by
+theorem alloc {e k} {a : A} (hke : k ∈ e) (va : ✓ a) :
+    mkToken (H := H) e ~~> singleton k a := by
   intro n mz vo
   match mz with
   | none => exact Valid.validN <| (valid_singleton k a).mpr va

--- a/Iris/Iris/Algebra/UFrac.lean
+++ b/Iris/Iris/Algebra/UFrac.lean
@@ -42,8 +42,7 @@ instance : OFE.Discrete UFrac := ⟨fun h => h⟩
 
 #rocq_ignore ufrac_ra_mixin "Use CMRA instance"
 
-@[rocq_alias ufracR]
-instance : CMRA UFrac where
+instance : RABase UFrac where
   pcore _ := none
   op x y := ⟨x.frac + y.frac⟩
   Valid _ := True
@@ -58,8 +57,13 @@ instance : CMRA UFrac where
   comm := ext_iff.mpr <| Subtype.ext (Rat.add_comm ..)
   pcore_op_left H := by rcases H
   pcore_idem H := by rcases H
-  pcore_op_mono H := by rcases H
   extend {_ x y z} := by rintro _ rfl; exists y; exists z
+
+instance : RABase.ExtensionLaws UFrac where
+  pcore_op_mono H := by rcases H
+
+@[rocq_alias ufracR]
+instance : CMRA UFrac := CMRA.withExtensionOrder
 
 @[simp, grind =] theorem frac_op (x y : UFrac) : (x • y).frac = x.frac + y.frac := rfl
 @[simp, grind =] theorem valid_iff {x : UFrac} : ✓ x ↔ True := Iff.rfl
@@ -83,6 +87,7 @@ theorem le_of_inc {x y : UFrac} (H : x ≼ y) : x.frac ≤ y.frac := by
 instance : CMRA.Discrete UFrac where
   discrete_0 := fun h => h
   discrete_valid := id
+  discrete_inc | ⟨z, hz⟩ => ⟨z, hz⟩
 
 @[rocq_alias ufrac_cancelable]
 instance {q : UFrac} : CMRA.Cancelable q where

--- a/Iris/Iris/Algebra/UPred.lean
+++ b/Iris/Iris/Algebra/UPred.lean
@@ -134,7 +134,7 @@ abbrev UPredOF (F : COFE.OFunctorPre) [URFunctor F] : COFE.OFunctorPre :=
 def uPred_map [UCMRA α] [UCMRA β] (f : β -C> α) : UPred α -n> UPred β := by
   refine ⟨fun P => ⟨fun n x => P n ⟨(f x.val), f.validN x.property⟩, ?_⟩, ⟨?_⟩⟩
   · intro n1 n2 x1 x2 HP Hm Hn
-    exact P.mono HP (f.monoN _ Hm) Hn
+    exact P.mono HP (f.monoN Hm) Hn
   · intro n x1 x2 Hx1x2 n' y Hn' Hv
     exact Hx1x2 _ _ Hn' (f.validN Hv)
 

--- a/Iris/Iris/Algebra/Updates.lean
+++ b/Iris/Iris/Algebra/Updates.lean
@@ -108,8 +108,13 @@ theorem Update.op_l {x y : α} : x • y ~~> x := fun _ _ => CMRA.validN_op_opM_
 @[rocq_alias cmra_update_op_r]
 theorem Update.op_r {x y : α} : x • y ~~> y := fun _ _ => CMRA.validN_op_opM_right
 
+/-- An update may descend in the order. New relative to Rocq, where the order is `≼ₑ`. -/
+theorem Update.included {x y : α} (h : x ≼ y) : y ~~> x :=
+  fun _ mz => (CMRA.op?_mono_left mz h).validN
+
+/-- An update may discard a summand — `~~>` is affine whatever the order. -/
 @[rocq_alias cmra_update_included]
-theorem Update.included {x y : α} : x ≼ y → y ~~> x :=
+theorem Update.included_ext {x y : α} : x ≼ₑ y → y ~~> x :=
   fun ⟨_, ez⟩ => ez.symm ▸ Update.op_l
 
 @[rocq_alias cmra_update_valid0]

--- a/Iris/Iris/Algebra/View.lean
+++ b/Iris/Iris/Algebra/View.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 Markus de Medeiros. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Markus de Medeiros, Puming Liu
+Authors: Markus de Medeiros, Puming Liu, Janine Lohse
 -/
 module
 
@@ -22,9 +22,25 @@ abbrev ViewRel (A B : Type _) := Nat → A → B → Prop
 
 @[rocq_alias view_rel]
 class IsViewRel [OFE A] [UCMRA B] (R : ViewRel A B) where
-  mono : R n1 a1 b1 → a1 ≡{n2}≡ a2 → b2 ≼{n2} b1 → n2 ≤ n1 → R n2 a2 b2
+  /-- The relation only shrinks when a summand of the fragment is dropped. -/
+  mono : R n1 a1 b1 → a1 ≡{n2}≡ a2 → b2 ≼ₑ{n2} b1 → n2 ≤ n1 → R n2 a2 b2
+  /-- The relation is down-closed for the fragment order. Independent of `mono` in general;
+  for an affine fragment algebra `mono` follows from it. -/
+  mono_ord : R n1 a1 b1 → a1 ≡{n2}≡ a2 → b2 ≼{n2} b1 → n2 ≤ n1 → R n2 a2 b2
   rel_validN n a b : R n a b → ✓{n} b
   rel_unit n : ∃ a, R n a UCMRA.unit
+
+/-- Build an `IsViewRel` from order-closure alone: over an affine fragment algebra the
+`≼ₑ`-closure `mono` follows from `mono_ord`. -/
+theorem IsViewRel.ofMonoOrd [OFE A] [UCMRA B] [CMRA.Affine B] {R : ViewRel A B}
+    (mono_ord : ∀ {n1 a1 b1 n2 a2 b2},
+      R n1 a1 b1 → a1 ≡{n2}≡ a2 → b2 ≼{n2} b1 → n2 ≤ n1 → R n2 a2 b2)
+    (rel_validN : ∀ n a b, R n a b → ✓{n} b)
+    (rel_unit : ∀ n, ∃ a, R n a UCMRA.unit) : IsViewRel R where
+  mono h ha hb hn := mono_ord h ha (CMRA.incN_of_incExtN hb) hn
+  mono_ord := mono_ord
+  rel_validN := rel_validN
+  rel_unit := rel_unit
 
 @[rocq_alias ViewRelDiscrete]
 class IsViewRelDiscrete [OFE A] [UCMRA B] (R : ViewRel A B) extends IsViewRel R where
@@ -37,7 +53,7 @@ variable [OFE A] [UCMRA B] {R : ViewRel A B} [IsViewRel R]
 
 @[rocq_alias view_rel_ne]
 theorem iff_of_dist (Ha : a1 ≡{n}≡ a2) (Hb : b1 ≡{n}≡ b2) : R n a1 b1 ↔ R n a2 b2 :=
-  ⟨(mono · Ha Hb.symm.to_incN n.le_refl), (mono · Ha.symm Hb.to_incN n.le_refl)⟩
+  ⟨(mono · Ha Hb.symm.to_incExtN n.le_refl), (mono · Ha.symm Hb.to_incExtN n.le_refl)⟩
 
 #rocq_ignore view_rel_proper "OFE is Leibniz; use equality"
 
@@ -157,8 +173,8 @@ theorem IsViewRel.of_agree_dist_iff (Hb : b' ≡{n}≡ b) :
     (∃ a', toAgree a ≡{n}≡ toAgree a' ∧ R n a' b') ↔ R n a b := by
   refine ⟨fun H => ?_, fun H => ?_⟩
   · rcases H with ⟨_, HA, HR⟩
-    exact mono HR (inj HA.symm) Hb.symm.to_incN n.le_refl
-  · exact ⟨a, .rfl, mono H .rfl Hb.to_incN n.le_refl⟩
+    exact mono HR (inj HA.symm) Hb.symm.to_incExtN n.le_refl
+  · exact ⟨a, .rfl, mono H .rfl Hb.to_incExtN n.le_refl⟩
 
 @[rocq_alias view_auth_ne]
 instance auth_ne {dq : DFrac} : NonExpansive (Auth dq : A → View R) where
@@ -203,8 +219,17 @@ def Pcore (v : View R) : Option (View R) :=
 def Op (v1 v2 : View R) : View R :=
   mk (v1.auth • v2.auth) (v1.frag • v2.frag)
 
+/-- A valid view has a valid authority part and a valid fragment. -/
+theorem ValidN.pair {n} {x : View R} (Hv : ValidN n x) :
+    ✓{n} ((x.auth, x.frag) : Option ((DFrac) × Agree A) × B) := by
+  rcases x with ⟨_|⟨q, ag⟩, b⟩
+  · obtain ⟨a, Ha⟩ := Hv
+    exact ⟨trivial, IsViewRel.rel_validN _ _ _ Ha⟩
+  · obtain ⟨Hq, a, Ha1, Ha2⟩ := Hv
+    exact ⟨⟨Hq, Agree.validN_ne Ha1.symm trivial⟩, IsViewRel.rel_validN _ _ _ Ha2⟩
+
 @[rocq_alias view_cmra_mixin]
-instance : CMRA (View R) where
+instance instRABase : RABase (View R) where
   pcore := Pcore
   op := Op
   ValidN := ValidN
@@ -223,12 +248,12 @@ instance : CMRA (View R) where
     rcases x1 with ⟨_|⟨q1, ag1⟩, b1⟩ <;>
     rcases x2 with ⟨_|⟨q2, ag2⟩, b2⟩ <;>
     simp_all
-    · exact fun x H => ⟨x, mono H .rfl Hr.symm.to_incN n.le_refl⟩
+    · exact fun x H => ⟨x, mono H .rfl Hr.symm.to_incExtN n.le_refl⟩
     intro Hq a Hag HR
     refine ⟨CMRA.validN_ne Hl.1 Hq, ?_⟩
     refine ⟨a, ?_⟩
     refine ⟨Hl.2.symm.trans Hag, ?_⟩
-    exact mono HR .rfl Hr.symm.to_incN n.le_refl
+    exact mono HR .rfl Hr.symm.to_incExtN n.le_refl
   valid_iff_validN {x} := by
     simp only [Valid, ValidN]; split
     · exact ⟨fun H n => ⟨H.1, H.2 n⟩, fun H => ⟨(H 0).1, fun n => (H n).2⟩⟩
@@ -239,20 +264,20 @@ instance : CMRA (View R) where
     · refine fun H => ⟨H.1, ?_⟩
       rcases H.2 with ⟨ag, Ha⟩; exists ag
       refine ⟨Dist.le Ha.1 n.le_succ, ?_⟩
-      exact mono Ha.2 .rfl (CMRA.incN_refl x.frag) n.le_succ
-    · exact fun ⟨z, HR⟩ => ⟨z, mono HR .rfl (CMRA.incN_refl _) n.le_succ⟩
+      exact mono Ha.2 .rfl (RABase.incExtN_refl x.frag) n.le_succ
+    · exact fun ⟨z, HR⟩ => ⟨z, mono HR .rfl (RABase.incExtN_refl _) n.le_succ⟩
   validN_op_left {n x y} := by
     rcases x with ⟨_|⟨q1, ag1⟩, b1⟩ <;>
     rcases y with ⟨_|⟨q2, ag2⟩, b2⟩ <;>
     simp [CMRA.op, optionOp]
-    · exact fun a Hr => ⟨a, mono Hr .rfl (CMRA.incN_op_left n b1 b2) n.le_refl⟩
-    · exact fun _ a _ Hr => ⟨a, mono Hr .rfl (CMRA.incN_op_left n b1 b2) n.le_refl⟩
-    · exact fun Hq a H Hr => ⟨Hq, ⟨a, ⟨H, mono Hr .rfl (CMRA.incN_op_left n b1 b2) n.le_refl⟩⟩⟩
+    · exact fun a Hr => ⟨a, mono Hr .rfl (RABase.incExtN_op_left n b1 b2) n.le_refl⟩
+    · exact fun _ a _ Hr => ⟨a, mono Hr .rfl (RABase.incExtN_op_left n b1 b2) n.le_refl⟩
+    · exact fun Hq a H Hr => ⟨Hq, ⟨a, ⟨H, mono Hr .rfl (RABase.incExtN_op_left n b1 b2) n.le_refl⟩⟩⟩
     · refine fun Hq a H Hr => ⟨CMRA.validN_op_left Hq, ⟨a, ?_, ?_⟩⟩
       · refine .trans ?_ H
         refine .trans Agree.idemp.symm.dist ?_
         exact CMRA.op_ne.ne <| Agree.op_invN (Agree.validN_ne H.symm trivial)
-      · exact mono Hr .rfl (CMRA.incN_op_left n b1 b2) n.le_refl
+      · exact mono Hr .rfl (RABase.incExtN_op_left n b1 b2) n.le_refl
   assoc := by simp only [Op, View.mk.injEq]; exact ⟨CMRA.assoc', CMRA.assoc'⟩
   comm := by simp only [Op, View.mk.injEq]; exact ⟨CMRA.comm', CMRA.comm'⟩
   pcore_op_left {x _} := by
@@ -267,37 +292,91 @@ instance : CMRA (View R) where
     simp only [mk.injEq, and_imp]
     rintro rfl rfl
     exact ⟨CMRA.core_idem _, CMRA.core_idem _⟩
-  pcore_op_mono := by
-    let f : (Option ((DFrac) × Agree A) × B) → View R := fun x => ⟨x.1, x.2⟩
-    let g : View R → (Option ((DFrac) × Agree A) × B) := fun x => (x.auth, x.frag)
-    have Hg_eqv {y : View R} : CMRA.pcore (g y) = g <$> Pcore y := by
-      rcases y with ⟨x, b⟩
-      simp [Option.map_eq_map, Option.map, g, CMRA.pcore, Prod.pcore, optionCore, CMRA.pcore_eq_core]
-      rfl
-    have Hg_core {y cy : View R} : Pcore y = some cy ↔ CMRA.pcore (g y) = some (g cy) := by
-      rw [Hg_eqv]
-      cases cy; simp [g]
-    apply pcore_op_mono_of_core_op_mono
-    rintro y1 cy y2 ⟨z, Hy2⟩ Hy1
-    have Hle : g y1 ≼ g y2 := ⟨g z, congrArg g Hy2⟩
-    obtain ⟨_, Hcgy2, x, Hcx⟩ :=
-      CMRA.pcore_mono' Hle (Hg_core.mp Hy1)
-    exact ⟨_, rfl, f x, Option.some.inj (Hg_core.mpr (Hcgy2 ▸ (congrArg some Hcx)))⟩
   extend {n x y1 y2} Hv He := by
-    let g : View R → (Option ((DFrac) × Agree A) × B) := fun x => (x.auth, x.frag)
-    obtain H1 : ✓{n} g x := by
-      simp_all [ValidN, CMRA.ValidN, Prod.ValidN, g, optionValidN]
-      rcases x with ⟨_|⟨q1, ag1⟩, b1⟩ <;> simp_all only
-      · refine ⟨trivial, ?_⟩
-        rcases Hv with ⟨_, Ha⟩
-        apply IsViewRel.rel_validN _ _ _ Ha
-      · rcases Hv with ⟨Hq, ⟨a, ⟨Ha1, Ha2⟩⟩⟩
-        refine ⟨⟨trivial, ?_⟩, ?_⟩
-        · exact Agree.validN_ne Ha1.symm trivial
-        · exact IsViewRel.rel_validN _ _ _ Ha2
-    rcases @CMRA.extend _ _ _ _ (g y1) (g y2) H1 He with ⟨z1, z2, Hze, Hz1, Hz2⟩
+    rcases @CMRA.extend _ _ _ _ ((y1.auth, y1.frag) : _ × B) (y2.auth, y2.frag) Hv.pair He
+      with ⟨z1, z2, Hze, Hz1, Hz2⟩
     refine ⟨⟨z1.1, z1.2⟩, ⟨z2.1, z2.2⟩, ?_, Hz1, Hz2⟩
     exact congrArg (fun p => (⟨p.1, p.2⟩ : View R)) Hze
+
+/-- The order on `View R`, inherited componentwise from the authority and fragment parts. -/
+@[reducible] def orderN : OrderN (View R) where
+  IncludedN n x y := x.auth ≼{n} y.auth ∧ x.frag ≼{n} y.frag
+  Included x y := x.auth ≼ y.auth ∧ x.frag ≼ y.frag
+  incN_ne ex ey h := ⟨CMRA.incN_ne ex.1 ey.1 h.1, CMRA.incN_ne ex.2 ey.2 h.2⟩
+  incN_succ h := ⟨CMRA.incN_succ h.1, CMRA.incN_succ h.2⟩
+  incN_trans h1 h2 := ⟨CMRA.incN_trans h1.1 h2.1, CMRA.incN_trans h1.2 h2.2⟩
+  inc_trans h1 h2 := ⟨CMRA.inc_trans h1.1 h2.1, CMRA.inc_trans h1.2 h2.2⟩
+  incN_of_inc n h := ⟨CMRA.incN_of_inc n h.1, CMRA.incN_of_inc n h.2⟩
+
+section
+attribute [local instance] View.orderN
+
+theorem increasing_auth {v : View R} (h : CMRA.Increasing v) : CMRA.Increasing v.auth where
+  increasing w := (h.increasing ⟨w, UCMRA.unit⟩).1
+
+theorem increasing_frag {v : View R} (h : CMRA.Increasing v) : CMRA.Increasing v.frag where
+  increasing w := (h.increasing ⟨none, w⟩).2
+
+theorem increasing_mk {v : View R} (ha : CMRA.Increasing v.auth) (hb : CMRA.Increasing v.frag) :
+    CMRA.Increasing v where
+  increasing w := ⟨ha.increasing w.auth, hb.increasing w.frag⟩
+
+instance instCMRA : CMRA (View R) where
+  toRABase := instRABase
+  toOrderN := View.orderN
+  op_monoN_left z h := ⟨CMRA.op_monoN_left z.auth h.1, CMRA.op_monoN_left z.frag h.2⟩
+  op_mono_left z h := ⟨CMRA.op_mono_left z.auth h.1, CMRA.op_mono_left z.frag h.2⟩
+  validN_of_incN {n x y} h v := by
+    rcases x with ⟨_|⟨q1, ag1⟩, b1⟩ <;> rcases y with ⟨_|⟨q2, ag2⟩, b2⟩
+    · obtain ⟨a, Ha⟩ := v
+      exact ⟨a, mono_ord Ha .rfl h.2 n.le_refl⟩
+    · obtain ⟨_, a, _, Ha⟩ := v
+      exact ⟨a, mono_ord Ha .rfl h.2 n.le_refl⟩
+    · exact h.1.elim
+    · obtain ⟨Hq, a, Hag, Ha⟩ := v
+      rcases h.1 with e | i
+      · exact ⟨CMRA.validN_ne e.1.symm Hq, a, e.2.trans Hag, mono_ord Ha .rfl h.2 n.le_refl⟩
+      · refine ⟨CMRA.validN_of_incN i.1 Hq, a, ?_, mono_ord Ha .rfl h.2 n.le_refl⟩
+        exact (Agree.valid_includedN (Agree.validN_ne Hag.symm trivial) i.2).trans Hag
+  pcore_monoN {_ x y _} h e := by
+    obtain rfl := Option.some.inj e
+    exact ⟨_, rfl, CMRA.core_incN_core h.1, CMRA.core_incN_core h.2⟩
+  pcore_mono {x y _} h e := by
+    obtain rfl := Option.some.inj e
+    exact ⟨_, rfl, CMRA.core_mono h.1, CMRA.core_mono h.2⟩
+  pcore_order_op {x _} e y := by
+    obtain rfl := Option.some.inj e
+    exact ⟨_, rfl, CMRA.core_op_mono x.auth y.auth, CMRA.core_op_mono x.frag y.frag⟩
+  pcore_increasing {x _} e := by
+    obtain rfl := Option.some.inj e
+    exact increasing_mk inferInstance inferInstance
+  increasing_closed {n x y} h h' :=
+    increasing_mk
+      (CMRA.increasing_closed (increasing_auth h) (Or.imp (·.1) (·.1) h'))
+      (CMRA.increasing_closed (increasing_frag h) (Or.imp (·.2) (·.2) h'))
+  incN_extend {n x y} v h := by
+    obtain ⟨za, hza, ea⟩ := CMRA.incN_extend v.pair.1 h.1
+    obtain ⟨zf, hzf, ef⟩ := CMRA.incN_extend v.pair.2 h.2
+    exact ⟨⟨za, zf⟩, ⟨hza, hzf⟩, ea, ef⟩
+
+end
+
+@[rocq_alias viewUR]
+instance instUCMRA : UCMRA (View R) where
+  toCMRA := instCMRA
+  unit := ⟨UCMRA.unit, UCMRA.unit⟩
+  unit_valid := IsViewRel.rel_unit
+  unit_left_id := by
+    rintro ⟨xa, xf⟩
+    show (⟨UCMRA.unit • xa, UCMRA.unit • xf⟩ : View R) = ⟨xa, xf⟩
+    rw [CMRA.ucmra_unit_left_id, CMRA.ucmra_unit_left_id]
+  pcore_unit := congrArg some (congrArg (View.mk _) (CMRA.core_eqv_self UCMRA.unit))
+  inc_refl x := ⟨CMRA.inc_refl x.auth, CMRA.inc_refl x.frag⟩
+
+/-- A view over an affine fragment algebra is affine. -/
+instance [CMRA.Affine B] : CMRA.Affine (View R) where
+  increasing v :=
+    increasing_mk (CMRA.Affine.increasing v.auth) (CMRA.Affine.increasing v.frag)
 
 #rocq_ignore viewR "Use the plain View type"
 #rocq_ignore view_valid_instance "In the CMRA instance"
@@ -311,6 +390,7 @@ instance : CMRA (View R) where
 
 @[rocq_alias view_cmra_discrete]
 instance [Discrete A] [CMRA.Discrete B] [IsViewRelDiscrete R] : CMRA.Discrete (View R) where
+  discrete_inc h := ⟨CMRA.discrete_inc h.1, CMRA.discrete_inc h.2⟩
   discrete_valid {x} := by
     simp only [CMRA.ValidN, ValidN, CMRA.Valid, Valid]
     split
@@ -319,16 +399,6 @@ instance [Discrete A] [CMRA.Discrete B] [IsViewRelDiscrete R] : CMRA.Discrete (V
       · exact (OFE.Discrete.discrete_0 H2).dist
       · exact IsViewRelDiscrete.discrete _ _ _ H3
     · exact fun ⟨a, H⟩ _ => ⟨a, IsViewRelDiscrete.discrete _ _ _ H⟩
-
-@[rocq_alias viewUR]
-instance : UCMRA (View R) where
-  unit := ⟨UCMRA.unit, UCMRA.unit⟩
-  unit_valid := IsViewRel.rel_unit
-  unit_left_id := by
-    rintro ⟨xa, xf⟩
-    show (⟨UCMRA.unit • xa, UCMRA.unit • xf⟩ : View R) = ⟨xa, xf⟩
-    rw [CMRA.ucmra_unit_left_id, CMRA.ucmra_unit_left_id]
-  pcore_unit := congrArg some (congrArg (View.mk _) (CMRA.core_eqv_self UCMRA.unit))
 
 #rocq_ignore view_empty_instance "Inlined in the UCMRA instance"
 #rocq_ignore view_ucmra_mixin "Not needed"
@@ -351,10 +421,10 @@ instance isOp_view_auth_dfrac {dq dq1 dq2 : DFrac} {a : A}
 theorem frag_op_eq : (◯V (b1 • b2) : View R) = ((◯V b1) • ◯V b2 : View R) := rfl
 
 @[rocq_alias view_frag_mono]
-theorem frag_inc_of_inc (H : b1 ≼ b2) : (◯V b1 : View R) ≼ ◯V b2 := by
+theorem frag_incExt_of_incExt (H : b1 ≼ₑ b2) : (◯V b1 : View R) ≼ₑ ◯V b2 := by
   rcases H with ⟨c, H⟩
   rw [H, frag_op_eq]
-  exact CMRA.inc_op_left _ _
+  exact RABase.incExt_op_left _ _
 
 @[rocq_alias view_frag_core]
 theorem frag_core : CMRA.core (◯V b : View R) = ◯V (CMRA.core b) := rfl
@@ -450,7 +520,7 @@ theorem auth_op_auth_validN_iff :
   refine ⟨fun H => ?_, fun H => ?_⟩
   · let Ha' : a1 ≡{n}≡ a2 := dist_of_validN_auth H
     rcases H with ⟨Hq, _, Ha, HR⟩
-    refine ⟨Hq, Ha', mono HR ?_ CMRA.incN_unit n.le_refl⟩
+    refine ⟨Hq, Ha', mono HR ?_ RABase.incExtN_unit n.le_refl⟩
     refine .trans ?_ Ha'.symm
     refine toAgree.inj (Ha.symm.trans ?_)
     apply CMRA.op_commN.trans
@@ -460,7 +530,7 @@ theorem auth_op_auth_validN_iff :
     refine ⟨H.1, a1, ?_, ?_⟩
     · exact (CMRA.op_ne.ne <| toAgree.ne.ne H.2.1.symm).trans Agree.idemp.dist
     · refine mono H.2.2 .rfl ?_ n.le_refl
-      exact OFE.Dist.to_incN <| CMRA.unit_left_id_dist UCMRA.unit
+      exact OFE.Dist.to_incExtN <| CMRA.unit_left_id_dist UCMRA.unit
 
 @[rocq_alias view_auth_op_validN]
 theorem auth_one_op_auth_one_validN_iff : ✓{n} ((●V a1 : View R) • ●V a2) ↔ False := by
@@ -497,7 +567,7 @@ theorem auth_op_auth_valid_iff : ✓ ((●V{dq1} a1 : View R) • ●V{dq2} a2) 
     let Hn n := dist_of_validN_auth <| H n
     refine ⟨(H 0).1, OFE.eq_dist_2 Hn, fun n => ?_⟩
     · rcases (H n) with ⟨_, _, Hl, H⟩
-      apply mono H ?_ CMRA.incN_unit n.le_refl
+      apply mono H ?_ RABase.incExtN_unit n.le_refl
       apply toAgree.inj (Hl.symm.trans ?_)
       exact (CMRA.op_ne.ne <| toAgree.ne.ne (Hn _).symm).trans Agree.idemp.dist
   · exact auth_op_auth_validN_iff.mpr ⟨H.1, H.2.1.dist, H.2.2 n⟩
@@ -521,23 +591,23 @@ theorem auth_one_op_frag_valid_iff : ✓ ((●V a : View R) • ◯V b) ↔ ∀ 
 
 open CMRA in
 @[rocq_alias view_auth_dfrac_includedN]
-theorem auth_incN_auth_op_frag_iff : (●V{dq1} a1 : View R) ≼{n} ((●V{dq2} a2) • ◯V b) ↔ (dq1 ≼ dq2 ∨ dq1 = dq2) ∧ a1 ≡{n}≡ a2 := by
+theorem auth_incExtN_auth_op_frag_iff :
+    (●V{dq1} a1 : View R) ≼ₑ{n} ((●V{dq2} a2) • ◯V b) ↔
+      (dq1 ≼ dq2 ∨ dq1 = dq2) ∧ a1 ≡{n}≡ a2 := by
   refine ⟨?_, fun H => ?_⟩
-  · simp only [Auth, Frag, CMRA.IncludedN, CMRA.op]
+  · simp only [Auth, Frag, RABase.IncExtN, CMRA.op]
     rintro ⟨(_|⟨dqf, af⟩),⟨⟨x1, x2⟩, y⟩⟩
     · exact ⟨.inr x1.symm, toAgree.inj x2.symm⟩
     · exact ⟨.inl ⟨dqf, x1⟩, Agree.toAgree_includedN.mp ⟨af, x2⟩⟩
   · rcases H with ⟨(⟨z, HRz⟩| HRa2), HRb⟩
     · calc (●V{dq1} a1 : View R)
-             ≼{n} ((●V{dq1} a1) • ((◯V b) • ●V{z} a1)) := by exists ((◯V b) • ●V{z} a1)
-           _ ≼{n} ((◯V b) • ●V{z} a1) • ●V{dq1} a1 := incN_of_incN_of_dist .rfl op_commN.symm
-           _ ≼{n} (◯V b) • ((●V{z} a1) • ●V{dq1} a1) := incN_of_incN_of_dist .rfl op_assocN.symm
-           _ ≼{n} (◯V b) • ((●V{dq1} a1) • ●V{z} a1) := incN_of_incN_of_dist .rfl (op_ne.ne op_commN)
-           _ ≼{n} (◯V b) • ●V{dq1 • z} a1 :=
-              incN_of_incN_of_dist .rfl (op_ne.ne auth_op_auth_eqv.symm.dist)
-           _ ≼{n} (◯V b) • ●V{dq2} a2 :=
-             incN_of_incN_of_dist .rfl (op_ne.ne (NonExpansive₂.ne HRz.symm.dist HRb))
-           _ ≼{n} ((●V{dq2} a2) • ◯V b) := incN_of_incN_of_dist .rfl op_commN
+             ≼ₑ{n} ((●V{dq1} a1) • ((◯V b) • ●V{z} a1)) := by exists ((◯V b) • ●V{z} a1)
+           _ ≡{n}≡ ((◯V b) • ●V{z} a1) • ●V{dq1} a1 := op_commN
+           _ ≡{n}≡ (◯V b) • ((●V{z} a1) • ●V{dq1} a1) := op_assocN.symm
+           _ ≡{n}≡ (◯V b) • ((●V{dq1} a1) • ●V{z} a1) := op_ne.ne op_commN
+           _ ≡{n}≡ (◯V b) • ●V{dq1 • z} a1 := op_ne.ne auth_op_auth_eqv.symm.dist
+           _ ≡{n}≡ (◯V b) • ●V{dq2} a2 := op_ne.ne (NonExpansive₂.ne HRz.symm.dist HRb)
+           _ ≡{n}≡ ((●V{dq2} a2) • ◯V b) := op_commN
     · exists (◯V b)
       refine comm'.dist.trans ?_
       refine (.trans ?_ comm'.dist)
@@ -546,48 +616,54 @@ theorem auth_incN_auth_op_frag_iff : (●V{dq1} a1 : View R) ≼{n} ((●V{dq2} 
 
 open CMRA in
 @[rocq_alias view_auth_dfrac_included]
-theorem auth_inc_auth_op_frag_iff : ((●V{dq1} a1 : View R) ≼ (●V{dq2} a2 : View R) • ◯V b) ↔ (dq1 ≼ dq2 ∨ dq1 = dq2) ∧ a1 = a2 := by
+theorem auth_incExt_auth_op_frag_iff :
+    ((●V{dq1} a1 : View R) ≼ₑ (●V{dq2} a2 : View R) • ◯V b) ↔
+      (dq1 ≼ dq2 ∨ dq1 = dq2) ∧ a1 = a2 := by
   refine ⟨fun H => ⟨?_, ?_⟩, fun H => ?_⟩
-  · exact auth_incN_auth_op_frag_iff (n := 0) |>.mp (CMRA.incN_of_inc _ H) |>.1
+  · exact auth_incExtN_auth_op_frag_iff (n := 0) |>.mp (RABase.incExtN_of_incExt _ H) |>.1
   · refine OFE.eq_dist_2 (fun n => ?_)
-    exact auth_incN_auth_op_frag_iff |>.mp (CMRA.incN_of_inc _ H) |>.2
+    exact auth_incExtN_auth_op_frag_iff |>.mp (RABase.incExtN_of_incExt _ H) |>.2
   · rcases H with ⟨(⟨q, Hq⟩|Hq), Ha⟩
     · calc (●V{dq1} a1 : View R)
-           _ ≼ (●V{dq1} a1) • ((●V{q} a1) • ◯V b) := by exists ((●V{q} a1) • ◯V b)
-           _ ≼ ((●V{dq1} a1) • ●V{q} a1) • ◯V b := by rw [CMRA.assoc']
-           _ ≼ (◯V b) • ((●V{dq1} a1) • ●V{q} a1) := by rw [CMRA.comm']
-           _ ≼ (◯V b) • ●V{dq1 • q} a1 := by rw [View.auth_op_auth_eqv]
-           _ ≼ (●V{dq2} a2) • ◯V b := by rw [Hq, Ha, comm', View.auth_op_auth_eqv]
+           _ ≼ₑ (●V{dq1} a1) • ((●V{q} a1) • ◯V b) := by exists ((●V{q} a1) • ◯V b)
+           _ ≼ₑ ((●V{dq1} a1) • ●V{q} a1) • ◯V b := by rw [CMRA.assoc']
+           _ ≼ₑ (◯V b) • ((●V{dq1} a1) • ●V{q} a1) := by rw [CMRA.comm']
+           _ ≼ₑ (◯V b) • ●V{dq1 • q} a1 := by rw [View.auth_op_auth_eqv]
+           _ ≼ₑ (●V{dq2} a2) • ◯V b := by rw [Hq, Ha, comm', View.auth_op_auth_eqv]
     · exists (◯V b)
       rw [Hq, Ha]
 
 @[rocq_alias view_auth_includedN]
-theorem auth_one_incN_auth_one_op_frag_iff : (●V a1 : View R) ≼{n} ((●V a2) • ◯V b) ↔ a1 ≡{n}≡ a2 :=
-  auth_incN_auth_op_frag_iff.trans <| and_iff_right_iff_imp.mpr <| fun _ => .inr rfl
+theorem auth_one_incExtN_auth_one_op_frag_iff :
+    (●V a1 : View R) ≼ₑ{n} ((●V a2) • ◯V b) ↔ a1 ≡{n}≡ a2 :=
+  auth_incExtN_auth_op_frag_iff.trans <| and_iff_right_iff_imp.mpr <| fun _ => .inr rfl
 
 @[rocq_alias view_auth_included]
-theorem auth_one_inc_auth_one_op_frag_iff : (●V a1 : View R) ≼ ((●V a2) • ◯V b) ↔ a1 = a2 :=
-  auth_inc_auth_op_frag_iff.trans <| and_iff_right_iff_imp.mpr <| fun _ => .inr rfl
+theorem auth_one_incExt_auth_one_op_frag_iff :
+    (●V a1 : View R) ≼ₑ ((●V a2) • ◯V b) ↔ a1 = a2 :=
+  auth_incExt_auth_op_frag_iff.trans <| and_iff_right_iff_imp.mpr <| fun _ => .inr rfl
 
 open CMRA in
 @[rocq_alias view_frag_includedN]
-theorem frag_incN_auth_op_frag_iff : (◯V b1 : View R) ≼{n} ((●V{p} a) • ◯V b2) ↔ b1 ≼{n} b2 := by
+theorem frag_incExtN_auth_op_frag_iff :
+    (◯V b1 : View R) ≼ₑ{n} ((●V{p} a) • ◯V b2) ↔ b1 ≼ₑ{n} b2 := by
   refine ⟨?_, ?_⟩
   · rintro ⟨xf, ⟨_, Hb⟩⟩
     have Hb' : b2 ≡{n}≡ b1 • xf.frag := CMRA.ucmra_unit_left_id.dist.symm.trans Hb
-    refine (incN_iff_right <| Hb'.symm).mp ?_
+    refine (RABase.incExtN_iff_right <| Hb'.symm).mp ?_
     exists xf.frag
   · rintro ⟨bf, Hbf⟩
     calc (◯V b1 : View R)
-         _ ≼{n} (◯V b1) • ((◯V bf) • ●V{p} a) := by exists ((◯V bf) • ●V{p} a)
-         _ ≼{n} ((◯V b1) • ◯V bf) • ●V{p} a := incN_of_incN_of_dist .rfl op_assocN
-         _ ≼{n} (●V{p} a) • ((◯V b1) • ◯V bf) := incN_of_incN_of_dist .rfl op_commN
-         _ ≼{n} (●V{p} a) • ◯V b1 • bf := by rw [frag_op_eq]
-         _ ≼{n} (●V{p} a) • ◯V b2 := incN_of_incN_of_dist .rfl (op_ne.ne (NonExpansive.ne Hbf.symm))
+         _ ≼ₑ{n} (◯V b1) • ((◯V bf) • ●V{p} a) := by exists ((◯V bf) • ●V{p} a)
+         _ ≡{n}≡ ((◯V b1) • ◯V bf) • ●V{p} a := op_assocN
+         _ ≡{n}≡ (●V{p} a) • ((◯V b1) • ◯V bf) := op_commN
+         _ ≼ₑ{n} (●V{p} a) • ◯V b1 • bf := by rw [frag_op_eq]
+         _ ≡{n}≡ (●V{p} a) • ◯V b2 := op_ne.ne (NonExpansive.ne Hbf.symm)
 
 open CMRA in
 @[rocq_alias view_frag_included]
-theorem frag_inc_auth_op_frag_iff : (◯V b1 : View R) ≼ ((●V{p} a) • ◯V b2) ↔ b1 ≼ b2 := by
+theorem frag_incExt_auth_op_frag_iff :
+    (◯V b1 : View R) ≼ₑ ((●V{p} a) • ◯V b2) ↔ b1 ≼ₑ b2 := by
   constructor
   · rintro ⟨xf, HH⟩
     have Hb' : b2 = b1 • xf.frag :=
@@ -596,61 +672,62 @@ theorem frag_inc_auth_op_frag_iff : (◯V b1 : View R) ≼ ((●V{p} a) • ◯V
     exists xf.frag
   · rintro ⟨bf, Hbf⟩
     calc (◯V b1 : View R)
-         _ ≼ (◯V b1) • ((◯V bf) • ●V{p} a) := by exists ((◯V bf) • ●V{p} a)
-         _ ≼ ((◯V b1) • ◯V bf) • ●V{p} a := by rw [CMRA.assoc']
-         _ ≼ (●V{p} a) • ((◯V b1) • ◯V bf) := by rw [CMRA.comm']
-         _ ≼ (●V{p} a) • ◯V b1 • bf := by rw [frag_op_eq]
-         _ ≼ (●V{p} a) • ◯V b2 := by rw [Hbf]
+         _ ≼ₑ (◯V b1) • ((◯V bf) • ●V{p} a) := by exists ((◯V bf) • ●V{p} a)
+         _ ≼ₑ ((◯V b1) • ◯V bf) • ●V{p} a := by rw [CMRA.assoc']
+         _ ≼ₑ (●V{p} a) • ((◯V b1) • ◯V bf) := by rw [CMRA.comm']
+         _ ≼ₑ (●V{p} a) • ◯V b1 • bf := by rw [frag_op_eq]
+         _ ≼ₑ (●V{p} a) • ◯V b2 := by rw [Hbf]
 
 open CMRA in
 @[rocq_alias view_both_dfrac_includedN]
-theorem auth_op_frag_incN_auth_op_frag_iff :
-    ((●V{dq1} a1 : View R) • ◯V b1) ≼{n} ((●V{dq2} a2) • ◯V b2) ↔
-      (dq1 ≼ dq2 ∨ dq1 = dq2) ∧ a1 ≡{n}≡ a2 ∧ b1 ≼{n} b2 := by
+theorem auth_op_frag_incExtN_auth_op_frag_iff :
+    ((●V{dq1} a1 : View R) • ◯V b1) ≼ₑ{n} ((●V{dq2} a2) • ◯V b2) ↔
+      (dq1 ≼ dq2 ∨ dq1 = dq2) ∧ a1 ≡{n}≡ a2 ∧ b1 ≼ₑ{n} b2 := by
   refine ⟨fun H => ?_, fun ⟨H0, H1, ⟨bf, H2⟩⟩ => ?_⟩
   · rw [← and_assoc]
     refine ⟨?_, ?_⟩
-    · apply (auth_incN_auth_op_frag_iff (R := R)).mp
-      exact incN_trans (incN_op_left _ (●V{dq1} a1) (◯V b1)) H
-    · apply (frag_incN_auth_op_frag_iff (R := R)).mp
-      exact incN_trans (CMRA.incN_op_right _ _ _) H
+    · apply (auth_incExtN_auth_op_frag_iff (R := R)).mp
+      exact (RABase.incExtN_op_left _ _ _).trans H
+    · apply (frag_incExtN_auth_op_frag_iff (R := R)).mp
+      exact (RABase.incExtN_op_right _ _ _).trans H
   · calc ((●V{dq1} a1) • ◯V b1 : View R)
-         _ ≼{n} ((●V{dq2} a2) • ◯V bf) • ◯V b1 :=
-           op_monoN_left _ <| auth_incN_auth_op_frag_iff.mpr ⟨H0, H1⟩
-         _ ≼{n} (●V{dq2} a2) • ((◯V bf) • ◯V b1) := incN_of_incN_of_dist .rfl  op_assocN.symm
-         _ ≼{n} (●V{dq2} a2) • ◯V bf • b1 := by rw [frag_op_eq]
-         _ ≼{n} (●V{dq2} a2) • ◯V b2 := by
-           refine incN_of_incN_of_dist .rfl  ?_
-           refine CMRA.op_ne.ne (NonExpansive.ne ?_)
-           exact H2.trans comm'.dist |>.symm
+         _ ≼ₑ{n} ((●V{dq2} a2) • ◯V bf) • ◯V b1 :=
+           RABase.op_monoN_left_ext _ <| auth_incExtN_auth_op_frag_iff.mpr ⟨H0, H1⟩
+         _ ≡{n}≡ (●V{dq2} a2) • ((◯V bf) • ◯V b1) := op_assocN.symm
+         _ ≼ₑ{n} (●V{dq2} a2) • ◯V bf • b1 := by rw [frag_op_eq]
+         _ ≡{n}≡ (●V{dq2} a2) • ◯V b2 :=
+           CMRA.op_ne.ne (NonExpansive.ne (H2.trans comm'.dist |>.symm))
 
 open CMRA in
 @[rocq_alias view_both_dfrac_included]
-theorem auth_op_frag_inc_auth_op_frag_iff : ((●V{dq1} a1 : View R) • ◯V b1) ≼ ((●V{dq2} a2) • ◯V b2) ↔
-      (dq1 ≼ dq2 ∨ dq1 = dq2) ∧ a1 = a2 ∧ b1 ≼ b2 := by
+theorem auth_op_frag_incExt_auth_op_frag_iff :
+    ((●V{dq1} a1 : View R) • ◯V b1) ≼ₑ ((●V{dq2} a2) • ◯V b2) ↔
+      (dq1 ≼ dq2 ∨ dq1 = dq2) ∧ a1 = a2 ∧ b1 ≼ₑ b2 := by
   refine ⟨fun H => ?_, fun ⟨H0, H1, ⟨bf, H2⟩⟩ => ?_⟩
   · rw [← and_assoc]
     refine ⟨?_, ?_⟩
-    · apply (auth_inc_auth_op_frag_iff (R := R)).mp
-      apply CMRA.inc_trans ?_ H
-      exact CMRA.inc_op_left (●V{dq1} a1) (◯V b1)
-    · apply (frag_inc_auth_op_frag_iff (R := R)).mp
-      apply CMRA.inc_trans (CMRA.inc_op_right _ _)
-      apply H
+    · apply (auth_incExt_auth_op_frag_iff (R := R)).mp
+      exact (RABase.incExt_op_left (●V{dq1} a1) (◯V b1)).trans H
+    · apply (frag_incExt_auth_op_frag_iff (R := R)).mp
+      exact (RABase.incExt_op_right _ _).trans H
   · calc ((●V{dq1} a1) • ◯V b1 : View R)
-         _ ≼ ((●V{dq2} a2) • ◯V bf) • ◯V b1 :=
-           op_mono_left _ <| auth_inc_auth_op_frag_iff.mpr ⟨H0, H1⟩
-         _ ≼ (●V{dq2} a2) • ((◯V bf) • ◯V b1) := by rw [← CMRA.assoc']
-         _ ≼ (●V{dq2} a2) • ◯V bf • b1 := .rfl
-         _ ≼ (●V{dq2} a2) • ◯V b2 := by rw [← H2.trans comm]
+         _ ≼ₑ ((●V{dq2} a2) • ◯V bf) • ◯V b1 :=
+           RABase.op_mono_left_ext _ <| auth_incExt_auth_op_frag_iff.mpr ⟨H0, H1⟩
+         _ ≼ₑ (●V{dq2} a2) • ((◯V bf) • ◯V b1) := by rw [← CMRA.assoc']
+         _ ≼ₑ (●V{dq2} a2) • ◯V bf • b1 := .rfl
+         _ ≼ₑ (●V{dq2} a2) • ◯V b2 := by rw [← H2.trans comm]
 
 @[rocq_alias view_both_includedN]
-theorem auth_one_op_frag_incN_auth_one_op_frag_iff : ((●V a1 : View R) • ◯V b1) ≼{n} ((●V a2) • ◯V b2) ↔ (a1 ≡{n}≡ a2 ∧ b1 ≼{n} b2) :=
-  auth_op_frag_incN_auth_op_frag_iff.trans <| and_iff_right_iff_imp.mpr <| fun _ => .inr rfl
+theorem auth_one_op_frag_incExtN_auth_one_op_frag_iff :
+    ((●V a1 : View R) • ◯V b1) ≼ₑ{n} ((●V a2) • ◯V b2) ↔ (a1 ≡{n}≡ a2 ∧ b1 ≼ₑ{n} b2) :=
+  auth_op_frag_incExtN_auth_op_frag_iff.trans <|
+    and_iff_right_iff_imp.mpr <| fun _ => .inr rfl
 
 @[rocq_alias view_both_included]
-theorem auth_one_op_frag_inc_auth_one_op_frag_iff : ((●V a1 : View R) • ◯V b1) ≼ ((●V a2) • ◯V b2) ↔ a1 = a2 ∧ b1 ≼ b2 :=
-  auth_op_frag_inc_auth_op_frag_iff.trans <| and_iff_right_iff_imp.mpr <| fun _ => .inr rfl
+theorem auth_one_op_frag_incExt_auth_one_op_frag_iff :
+    ((●V a1 : View R) • ◯V b1) ≼ₑ ((●V a2) • ◯V b2) ↔ a1 = a2 ∧ b1 ≼ₑ b2 :=
+  auth_op_frag_incExt_auth_op_frag_iff.trans <|
+    and_iff_right_iff_imp.mpr <| fun _ => .inr rfl
 
 #rocq_ignore view_core_eq "Not needed"
 #rocq_ignore view_valid_eq "Not needed"
@@ -677,7 +754,7 @@ theorem auth_one_op_frag_updateP {Pab : A → B → Prop}
     obtain ⟨_, a0, He', Hrel'⟩ := H
     have Hrel : R n a (b • bf) := by
       apply IsViewRel.mono Hrel' (toAgree.inj He').symm _ n.le_refl
-      apply Iris.OFE.Dist.to_incN
+      apply Iris.OFE.Dist.to_incExtN
       refine CMRA.comm.dist.trans (.trans ?_ CMRA.comm.dist)
       refine CMRA.op_ne.ne ?_
       exact (CMRA.unit_left_id_dist b).symm
@@ -686,7 +763,7 @@ theorem auth_one_op_frag_updateP {Pab : A → B → Prop}
     · exists a'; exists b'
     · refine ⟨a', .rfl, ?_⟩
       apply IsViewRel.mono Hrel'' .rfl _ n.le_refl
-      apply Iris.OFE.Dist.to_incN
+      apply Iris.OFE.Dist.to_incExtN
       refine comm.dist.trans (.trans ?_ CMRA.comm.dist)
       refine op_ne.ne <| unit_left_id_dist b'
   · letI _ := own_whole_exclusive
@@ -707,7 +784,7 @@ theorem auth_one_alloc (Hup : ∀ n bf, R n a bf → R n a' (b' • bf)) :
     ((●V a) ~~> ((●V a' : View R) • ◯V b')) := by
   rw [← CMRA.unit_right_id (x := (●V{own 1} a))]
   refine auth_one_op_frag_update (fun n bf H => Hup n bf <| IsViewRel.mono H .rfl ?_ n.le_refl)
-  exact incN_op_right n unit bf
+  exact RABase.incExtN_op_right n unit bf
 
 @[rocq_alias view_update_dealloc]
 theorem auth_one_op_frag_dealloc (Hup : (∀ n bf, R n a (b • bf) → R n a' bf)) :
@@ -715,7 +792,7 @@ theorem auth_one_op_frag_dealloc (Hup : (∀ n bf, R n a (b • bf) → R n a' b
   rw [← CMRA.unit_right_id (x := (●V{own 1} a'))]
   refine auth_one_op_frag_update (fun n bf H => ?_)
   refine IsViewRel.mono (Hup n bf H) .rfl ?_ n.le_refl
-  exact (unit_left_id_dist bf).to_incN
+  exact (unit_left_id_dist bf).to_incExtN
 
 @[rocq_alias view_update_auth]
 theorem auth_one_update (Hup : ∀ n bf, R n a bf → R n a' bf) :
@@ -799,9 +876,9 @@ theorem auth_alloc (Hup : ∀ n bf, R n a bf → R n a (b • bf)) :
   · simp [CMRA.op, optionOp, CMRA.ValidN, ValidN]
     intro Hq a' Hag HR
     refine ⟨Hq, a', Hag, ?_⟩
-    have HR' := IsViewRel.mono HR (toAgree.inj Hag).symm (CMRA.incN_op_right n UCMRA.unit bf) n.le_refl
+    have HR' := IsViewRel.mono HR (toAgree.inj Hag).symm (RABase.incExtN_op_right n UCMRA.unit bf) n.le_refl
     apply IsViewRel.mono (Hup n bf HR') (toAgree.inj Hag) ?_ n.le_refl
-    apply Iris.OFE.Dist.to_incN
+    apply Iris.OFE.Dist.to_incExtN
     refine CMRA.comm.dist.trans (.trans ?_ CMRA.comm.dist)
     refine CMRA.op_ne.ne ?_
     exact (CMRA.unit_left_id_dist _)
@@ -810,9 +887,9 @@ theorem auth_alloc (Hup : ∀ n bf, R n a bf → R n a (b • bf)) :
     exists a0
     refine ⟨Hag, ?_⟩
     have Heq  := Agree.toAgree_includedN.mp ⟨ag, Hag.symm⟩
-    have HR' := IsViewRel.mono Hrel Heq.symm (CMRA.incN_op_right n UCMRA.unit bf) n.le_refl
+    have HR' := IsViewRel.mono Hrel Heq.symm (RABase.incExtN_op_right n UCMRA.unit bf) n.le_refl
     apply IsViewRel.mono (Hup _ _ HR') Heq ?_ n.le_refl
-    apply Iris.OFE.Dist.to_incN
+    apply Iris.OFE.Dist.to_incExtN
     refine CMRA.comm.dist.trans (.trans ?_ CMRA.comm.dist)
     refine CMRA.op_ne.ne ?_
     exact (CMRA.unit_left_id_dist _)
@@ -897,6 +974,16 @@ instance mapO_ne : OFE.NonExpansive₂ (mapO (R := R) (R' := R')) where
 
 end mapO
 
+/-- The action of `View.map` on the authority part, as a morphism. -/
+def mapAuthC [OFE A] [OFE A'] (f : A -n> A') :
+    Option ((DFrac) × Agree A) -C> Option ((DFrac) × Agree A') :=
+  Option.mapC (Prod.mapC CMRA.Hom.id (Agree.map f.f))
+
+theorem map_auth_eq [OFE A] [OFE B] [OFE A'] {R : ViewRel A B} {R' : ViewRel A' B'}
+    (f : A -n> A') (g : B → B') (v : View R) :
+    (map R' f.f g v).auth = (mapAuthC f).f v.auth := by
+  rcases v with ⟨_|⟨fr, a⟩, b⟩ <;> rfl
+
 @[rocq_alias view_map_cmra_morphism]
 def mapC [OFE A] [UCMRA B] [OFE A'] [UCMRA B']
     {R : ViewRel A B} [IsViewRel R] {R' : ViewRel A' B'} [IsViewRel R']
@@ -929,6 +1016,18 @@ def mapC [OFE A] [UCMRA B] [OFE A'] [UCMRA B']
     · cases xa <;> cases ya <;> simp [CMRA.op, optionOp, Prod.op]
       exact (Agree.map f.f).op _ _
     · exact CMRA.Hom.op g xf yf
+  monoN {n x y} h := by
+    refine ⟨?_, g.monoN h.2⟩
+    rw [map_auth_eq, map_auth_eq]
+    exact (mapAuthC f).monoN h.1
+  mono {x y} h := by
+    refine ⟨?_, g.mono h.2⟩
+    rw [map_auth_eq, map_auth_eq]
+    exact (mapAuthC f).mono h.1
+  increasing {v} h := by
+    refine increasing_mk ?_ (g.increasing (increasing_frag h))
+    rw [map_auth_eq]
+    exact (mapAuthC f).increasing (increasing_auth h)
 
 end ViewMap
 

--- a/Iris/Iris/BI/Algebra.lean
+++ b/Iris/Iris/BI/Algebra.lean
@@ -35,8 +35,8 @@ theorem prod_validI [Sbi PROP] [CMRA A] [CMRA B] (x : A × B) :
 
 @[rocq_alias prod_includedI]
 theorem prod_includedI [Sbi PROP] [CMRA A] [CMRA B] (x y : A × B) :
-    x ≼ y ⊣⊢@{PROP} x.1 ≼ y.1 ∧ x.2 ≼ y.2 := by
-  sbi_unfold; intro _; exact Prod.incN_def
+    x ≼ₑ y ⊣⊢@{PROP} x.1 ≼ₑ y.1 ∧ x.2 ≼ₑ y.2 := by
+  sbi_unfold; intro _; exact Prod.incExtN_def
 
 end prod
 
@@ -51,25 +51,33 @@ theorem option_validI [Sbi PROP] [CMRA A] {mx : Option A} :
 
 @[rocq_alias option_includedI]
 theorem option_includedI [Sbi PROP] [CMRA A] {mx my : Option A} :
-  mx ≼ my ⊣⊢@{PROP}
-    mx.elim iprop(True) fun x => my.elim iprop(False) fun y => iprop((x ≼ y) ∨ (x ≡ y)) := by
+  mx ≼ₑ my ⊣⊢@{PROP}
+    mx.elim iprop(True) fun x => my.elim iprop(False) fun y => iprop((x ≼ₑ y) ∨ (x ≡ y)) := by
   rcases mx with _ | x <;> rcases my with _ | y <;>
-    try exact internalCmraIncluded_pure fun _ => by simp [Option.incN_iff]
-  simp only [Option.elim]; sbi_unfold; intro _; exact Option.some_incN_some_iff.trans Or.comm
+    try exact internalCmraIncExt_pure fun _ => by simp [Option.incExtN_iff]
+  simp only [Option.elim]; sbi_unfold; intro _; exact Option.some_incExtN_some_iff.trans Or.comm
 
 @[rocq_alias option_included_totalI]
 theorem option_included_totalI [Sbi PROP] [CMRA A] [CMRA.IsTotal A] {mx my : Option A} :
-  mx ≼ my ⊣⊢@{PROP}
-    mx.elim iprop(True) fun x => my.elim iprop(False) fun y => iprop(x ≼ y) := by
+  mx ≼ₑ my ⊣⊢@{PROP}
+    mx.elim iprop(True) fun x => my.elim iprop(False) fun y => iprop(x ≼ₑ y) := by
   rcases mx with _ | x <;> rcases my with _ | y <;>
     first
-    | exact internalCmraIncluded_iff fun _ => by simp [Option.incN_iff_is_total]
-    | exact internalCmraIncluded_pure fun _ => by simp [Option.incN_iff_is_total]
+    | exact internalCmraIncExt_iff fun _ => by simp [Option.incExtN_iff_is_total]
+    | exact internalCmraIncExt_pure fun _ => by simp [Option.incExtN_iff_is_total]
 
 @[rocq_alias Some_included_totalI]
 theorem Some_included_totalI [Sbi PROP] [CMRA A] [CMRA.IsTotal A] {x y : A} :
-    some x ≼ some y ⊣⊢@{PROP} x ≼ y :=
+    some x ≼ₑ some y ⊣⊢@{PROP} x ≼ₑ y :=
   option_included_totalI
+
+theorem some_includedI [Sbi PROP] [CMRA A] [IncRefl A] {x y : A} :
+    some x ≼ some y ⊣⊢@{PROP} x ≼ y :=
+  internalCmraIncluded_iff fun _ => Option.some_incN_some_iff_incRefl
+
+theorem some_includedI_none [Sbi PROP] [CMRA A] {x : A} : some x ≼ none ⊢@{PROP} False :=
+  (internalCmraIncluded_pure fun _ => iff_false_intro Option.not_some_incN_none).mp.trans
+    (pure_elim' False.elim)
 
 end option
 
@@ -78,7 +86,7 @@ section heap_view
 open HeapView BI Std PartialMap LawfulPartialMap BIBase.BiEntails
 
 variable {F K V : Type _} {H : Type _ → Type _}
-variable [LawfulPartialMap H K] [CMRA V]
+variable [LawfulPartialMap H K] [CMRA V] [CMRA.Affine V]
 
 @[rocq_alias gmap_view_both_dfrac_validI]
 theorem auth_op_frag_validI [Sbi PROP] (dp : DFrac) (m : H V) k dq v :
@@ -94,7 +102,7 @@ theorem auth_op_frag_one_validI [Sbi PROP] (dp : DFrac) (m : H V) k v :
   sbi_unfold; intro _; exact auth_op_frag_one_validN_iff
 
 @[rocq_alias gmap_view_both_validI_total]
-theorem auth_op_frag_validI_total [Sbi PROP] [CMRA.IsTotal V] (dp : DFrac) (m : H V) k dq v :
+theorem auth_op_frag_validI_total [Sbi PROP] [IncRefl V] (dp : DFrac) (m : H V) k dq v :
   ✓ (Auth dp m • Frag k dq v) ⊢@{PROP}
     ∃ v', ⌜✓ dp⌝ ∧ ⌜✓ dq⌝ ∧ ⌜get? m k = .some v'⌝ ∧
       ✓ v' ∧ v ≼ v' := by
@@ -146,7 +154,7 @@ theorem agree_op_equiv_toAgreeI (x y : Agree A) (a : A) :
 
 @[rocq_alias agree_includedI]
 theorem agree_includedI (x y : Agree A) :
-    x ≼ y ⊣⊢@{PROP} y ≡ x • y := by
+    x ≼ₑ y ⊣⊢@{PROP} y ≡ x • y := by
   sbi_unfold; intro _
   exact includedN.trans ⟨(·.trans op_commN), (·.trans op_commN)⟩
 
@@ -160,7 +168,7 @@ end agree_inclusion
 section auth
 open Iris BI Auth
 
-variable [Sbi PROP] [UCMRA A]
+variable [Sbi PROP] [UCMRA A] [CMRA.Affine A]
 
 @[rocq_alias auth_auth_dfrac_validI]
 theorem auth_dfrac_validI (dq : DFrac) (a : A) :
@@ -239,7 +247,7 @@ theorem cmra_morphism_validI [CMRA A] [CMRA B] (f : A -C> B) (x : A) :
 @[rocq_alias f_homom_includedI]
 theorem f_homom_includedI [CMRA A] [CMRA B] (x y : A) (f : A → B) [NonExpansive f]
     (Hf : ∀ c n, f x • f c ≡{n}≡ f (x • c)) :
-    x ≼ y ⊢@{PROP} f x ≼ f y :=
+    x ≼ₑ y ⊢@{PROP} f x ≼ₑ f y :=
   siPure_mono <| BI.exists_elim fun c => BI.exists_intro_trans (f c) <|
     internalEq_entails.mpr fun n heq => (NonExpansive.ne heq).trans (Hf c n).symm
 
@@ -303,8 +311,8 @@ theorem excl_validI (x : Excl A) :
 
 @[rocq_alias excl_includedI]
 theorem excl_includedI (x y : Excl A) :
-    x ≼ y ⊣⊢@{PROP} ⌜y = Excl.invalid⌝ :=
-  internalCmraIncluded_pure incN_iff
+    x ≼ₑ y ⊣⊢@{PROP} ⌜y = Excl.invalid⌝ :=
+  internalCmraIncExt_pure incN_iff
 
 end excl
 
@@ -333,16 +341,16 @@ theorem csum_validI [CMRA A] [CMRA B] (x : Csum A B) :
 
 @[rocq_alias csum_includedI]
 theorem csum_includedI [CMRA A] [CMRA B] (x y : Csum A B) :
-    x ≼ y ⊣⊢@{PROP}
+    x ≼ₑ y ⊣⊢@{PROP}
       match x, y with
-      | inl a, inl b => iprop(a ≼ b)
-      | inr a, inr b => iprop(a ≼ b)
+      | inl a, inl b => iprop(a ≼ₑ b)
+      | inr a, inr b => iprop(a ≼ₑ b)
       | _, invalid => iprop(True)
       | _, _ => iprop(False) := by
   cases x <;> cases y <;>
     first
-    | exact internalCmraIncluded_iff fun _ => by simp [Csum.includedN]
-    | exact internalCmraIncluded_pure fun _ => by simp [Csum.includedN]
+    | exact internalCmraIncExt_iff fun _ => by simp [Csum.includedN_ext]
+    | exact internalCmraIncExt_pure fun _ => by simp [Csum.includedN_ext]
 
 end csum
 

--- a/Iris/Iris/BI/Cmra.lean
+++ b/Iris/Iris/BI/Cmra.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Michael Sammler. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Markus de Medeiros
+Authors: Markus de Medeiros, Janine Lohse
 -/
 module
 
@@ -41,7 +41,7 @@ instance internalCmraValid_ne : NonExpansive (internalCmraValid (PROP := PROP) (
 #rocq_ignore internal_cmra_valid_proper "Derivable from internalCmraValid_ne with NonExpansive.eqv"
 
 @[rocq_alias internal_cmra_valid_intro]
-theorem internalCmraValid_intro {P : PROP} {a : A} (h : Valid a) :
+theorem internalCmraValid_intro {P : PROP} {a : A} (h : ✓ a) :
     P ⊢ ✓ a :=
   calc (P : PROP)
     _ ⊢ True := true_intro
@@ -115,88 +115,93 @@ section CmraIncluded
 
 variable [Sbi PROP] [CMRA A]
 
+/-! ### The internal extension inclusion -/
+
+/-- The internal extension inclusion `∃ c, b ≡ a • c`, the relation frame-based
+constructions (views, local updates) are stated with; see `internalCmraIncluded` for the
+internal order. -/
 @[rocq_alias internal_included]
-def internalCmraIncluded (a b : A) : PROP := siPure (∃ c, iprop(b ≡ (a • c)))
+def internalCmraIncExt (a b : A) : PROP := siPure (∃ c, iprop(b ≡ (a • c)))
 
 macro_rules
-  | `(iprop($a ≼ $b)) => ``(internalCmraIncluded $a $b)
+  | `(iprop($a ≼ₑ $b)) => ``(internalCmraIncExt $a $b)
 
-delab_rule internalCmraIncluded
-  | `($_ $a $b) => ``(iprop($a ≼ $b))
+delab_rule internalCmraIncExt
+  | `($_ $a $b) => ``(iprop($a ≼ₑ $b))
 
 @[rocq_alias internal_included_nonexpansive]
-instance internalCmraIncluded_ne :
-    NonExpansive₂ (internalCmraIncluded (PROP := PROP) (A := A)) where
+instance internalCmraIncExt_ne :
+    NonExpansive₂ (internalCmraIncExt (PROP := PROP) (A := A)) where
   ne n _ _ hx _ _ hy := by
     refine siPure_ne.ne ?_
     apply (exists_ne (fun a => NonExpansive₂.ne hy (op_commN.trans ((op_ne.ne hx).trans op_commN))))
 
-#rocq_ignore internal_included_proper "Derivable from internalCmraIncluded_ne with NonExpansive.eqv"
+#rocq_ignore internal_included_proper "Derivable from internalCmraIncExt_ne with NonExpansive.eqv"
 
 @[rocq_alias internal_included_intro]
-theorem internalCmraIncluded_intro {P : PROP} {a b : A} (h : a ≼ b) :
-    P ⊢ a ≼ b := by
+theorem internalCmraIncExt_intro {P : PROP} {a b : A} (h : a ≼ₑ b) :
+    P ⊢ a ≼ₑ b := by
   obtain ⟨c, hc⟩ := h
   calc (P : PROP)
     _ ⊢ True := true_intro
     _ ⊢ <si_pure> True := siPure_pure.mpr
-    _ ⊢ a ≼ b := siPure_mono (BI.exists_intro_trans c (internalEq.of_equiv hc))
+    _ ⊢ a ≼ₑ b := siPure_mono (BI.exists_intro_trans c (internalEq.of_equiv hc))
 
-/-- The `SiProp` underlying the internal `≼` holds at `n` exactly when `a ≼{n} b`. -/
-private theorem included_holds {a b : A} {n : Nat} :
-    ((∃ c, iprop(b ≡ (a • c))) : SiProp).holds n ↔ a ≼{n} b := SiProp.exists_holds
+/-- The `SiProp` underlying the internal `≼ₑ` holds at `n` exactly when `a ≼ₑ{n} b`. -/
+private theorem incExt_holds {a b : A} {n : Nat} :
+    ((∃ c, iprop(b ≡ (a • c))) : SiProp).holds n ↔ a ≼ₑ{n} b := SiProp.exists_holds
 
-/-- Two internal inclusions agree when they agree at every step index. -/
-theorem internalCmraIncluded_iff [CMRA B] {a b : A} {a' b' : B}
-    (h : ∀ n, a ≼{n} b ↔ a' ≼{n} b') : a ≼ b ⊣⊢@{PROP} a' ≼ b' :=
-  siPure_mono_bi ⟨fun n hn => included_holds.mpr ((h n).mp (included_holds.mp hn)),
-    fun n hn => included_holds.mpr ((h n).mpr (included_holds.mp hn))⟩
+/-- Two internal extension inclusions agree when they agree at every step index. -/
+theorem internalCmraIncExt_iff [CMRA B] {a b : A} {a' b' : B}
+    (h : ∀ n, a ≼ₑ{n} b ↔ a' ≼ₑ{n} b') : a ≼ₑ b ⊣⊢@{PROP} a' ≼ₑ b' :=
+  siPure_mono_bi ⟨fun n hn => incExt_holds.mpr ((h n).mp (incExt_holds.mp hn)),
+    fun n hn => incExt_holds.mpr ((h n).mpr (incExt_holds.mp hn))⟩
 
-/-- An internal inclusion that is step-index independent is a pure proposition. -/
-theorem internalCmraIncluded_pure {a b : A} {φ : Prop} (h : ∀ n, a ≼{n} b ↔ φ) :
-    a ≼ b ⊣⊢@{PROP} ⌜φ⌝ :=
-  ⟨.trans (siPure_mono fun n hn => (h n).mp (included_holds.mp hn)) siPure_pure.mp,
-   .trans siPure_pure.mpr (siPure_mono fun n hφ => included_holds.mpr ((h n).mpr hφ))⟩
+/-- An internal extension inclusion that is step-index independent is a pure proposition. -/
+theorem internalCmraIncExt_pure {a b : A} {φ : Prop} (h : ∀ n, a ≼ₑ{n} b ↔ φ) :
+    a ≼ₑ b ⊣⊢@{PROP} ⌜φ⌝ :=
+  ⟨.trans (siPure_mono fun n hn => (h n).mp (incExt_holds.mp hn)) siPure_pure.mp,
+   .trans siPure_pure.mpr (siPure_mono fun n hφ => incExt_holds.mpr ((h n).mpr hφ))⟩
 
 @[rocq_alias si_pure_internal_included]
-theorem siPure_internalCmraIncluded {a b : A} :
-    <si_pure> a ≼ b ⊣⊢@{PROP} a ≼ b :=
+theorem siPure_internalCmraIncExt {a b : A} :
+    <si_pure> a ≼ₑ b ⊣⊢@{PROP} a ≼ₑ b :=
   persistently_iff.symm.trans persistently_siPure
 
 @[rocq_alias persistently_internal_included]
-theorem persistently_internalCmraIncluded {a b : A} :
-    <pers> a ≼ b ⊣⊢@{PROP} a ≼ b :=
+theorem persistently_internalCmraIncExt {a b : A} :
+    <pers> a ≼ₑ b ⊣⊢@{PROP} a ≼ₑ b :=
   persistently_siPure
 
 @[rocq_alias plainly_internal_included]
-theorem plainly_internalCmraIncluded {a b : A} :
-    ■ a ≼ b ⊣⊢@{PROP} a ≼ b :=
+theorem plainly_internalCmraIncExt {a b : A} :
+    ■ a ≼ₑ b ⊣⊢@{PROP} a ≼ₑ b :=
   plainly_siPure
 
 @[rocq_alias intuitionistically_internal_included]
-theorem intuitionistically_internalCmraIncluded [BIAffine PROP] {a b : A} :
-    □ a ≼ b ⊣⊢@{PROP} a ≼ b :=
-  intuitionistically_iff_persistently.trans persistently_internalCmraIncluded
+theorem intuitionistically_internalCmraIncExt [BIAffine PROP] {a b : A} :
+    □ a ≼ₑ b ⊣⊢@{PROP} a ≼ₑ b :=
+  intuitionistically_iff_persistently.trans persistently_internalCmraIncExt
 
 @[rocq_alias internal_included_discrete]
-theorem internalCmraIncluded_discrete {a b : A} [CMRA.Discrete A] :
-    a ≼ b ⊣⊢@{PROP} ⌜a ≼ b⌝ := by
+theorem internalCmraIncExt_discrete {a b : A} [CMRA.Discrete A] :
+    a ≼ₑ b ⊣⊢@{PROP} ⌜a ≼ₑ b⌝ := by
   haveI : ∀ x : A, DiscreteE x := fun x => ⟨OFE.Discrete.discrete⟩
-  refine ⟨?_, pure_elim' internalCmraIncluded_intro⟩
-  calc internalCmraIncluded a b
-    _ ⊢ <si_pure> (∃ c, b ≡ (a • c)) := siPure_internalCmraIncluded.mp
+  refine ⟨?_, pure_elim' internalCmraIncExt_intro⟩
+  calc internalCmraIncExt a b
+    _ ⊢ <si_pure> (∃ c, b ≡ (a • c)) := siPure_internalCmraIncExt.mp
     _ ⊢ <si_pure> (∃ c, ⌜b = a • c⌝) := siPure_mono <| exists_mono fun _ => discrete_eq_mp
     _ ⊢ <si_pure> ⌜∃ c, b = a • c⌝ := siPure_mono pure_exists.mp
     _ ⊢ ⌜∃ c, b = a • c⌝ := siPure_pure.mp
-    _ ⊢ ⌜a ≼ b⌝ := pure_mono fun ⟨c, h⟩ => ⟨c, h⟩
+    _ ⊢ ⌜a ≼ₑ b⌝ := pure_mono fun ⟨c, h⟩ => ⟨c, h⟩
 
 @[rocq_alias internal_included_refl]
-theorem internalCmraIncluded_refl {a : A} [IsTotal A] : ⊢@{PROP} a ≼ a :=
-  internalCmraIncluded_intro .rfl
+theorem internalCmraIncExt_refl {a : A} [IsTotal A] : ⊢@{PROP} a ≼ₑ a :=
+  internalCmraIncExt_intro .rfl
 
 @[rocq_alias internal_included_trans]
-theorem internalCmraIncluded_trans {a b c : A} :
-    ⊢@{PROP} a ≼ b -∗ b ≼ c -∗ a ≼ c := by
+theorem internalCmraIncExt_trans {a b c : A} :
+    ⊢@{PROP} a ≼ₑ b -∗ b ≼ₑ c -∗ a ≼ₑ c := by
   refine BI.entails_wand (siPure_exist.mp.trans ?_)
   refine BI.exists_elim (fun a' => ?_)
   refine BI.wand_intro ((BI.sep_mono_right siPure_exist.mp).trans (BI.sep_exists_left.mp.trans ?_))
@@ -208,33 +213,125 @@ theorem internalCmraIncluded_trans {a b c : A} :
   refine Entails.trans ?_ (internalEq.trans (b := (b • b')))
   exact and_intro and_elim_r (and_elim_left_trans (BI.internalEq_entails.mpr (fun n heq => op_left_dist _ heq)))
 
-/-- The internal `≼` is monotone under any nonexpansive map commuting with `•`. -/
-theorem internalCmraIncluded_map {B : Type _} [CMRA B] (g : A → B) [NonExpansive g]
+/-- The internal `≼ₑ` is monotone under any nonexpansive map commuting with `•`. -/
+theorem internalCmraIncExt_map {B : Type _} [CMRA B] (g : A → B) [NonExpansive g]
     (hg : ∀ x y : A, g (x • y) = g x • g y) {a b : A} :
-    a ≼ b ⊢@{PROP} g a ≼ g b :=
+    a ≼ₑ b ⊢@{PROP} g a ≼ₑ g b :=
   siPure_mono <| BI.exists_elim fun c => BI.exists_intro_trans (g c) <| by
     rw [← hg]; exact internalEq.of_internalEquiv_ne g
 
 @[rocq_alias internal_included_timeless]
-instance internalCmraIncluded_timeless {a b : A} [CMRA.Discrete A] :
-    Timeless (PROP := PROP) iprop(a ≼ b) := by
+instance internalCmraIncExt_timeless {a b : A} [CMRA.Discrete A] :
+    Timeless (PROP := PROP) iprop(a ≼ₑ b) := by
   haveI : ∀ x : A, DiscreteE x := fun x => ⟨OFE.Discrete.discrete⟩
-  unfold internalCmraIncluded
+  unfold internalCmraIncExt
   infer_instance
 
 @[rocq_alias internal_included_plain]
-instance internalCmraIncluded_plain {a b : A} :
-    Plain (PROP := PROP) iprop(a ≼ b) where
-  plain := plainly_internalCmraIncluded.mpr
+instance internalCmraIncExt_plain {a b : A} :
+    Plain (PROP := PROP) iprop(a ≼ₑ b) where
+  plain := plainly_internalCmraIncExt.mpr
 
 @[rocq_alias internal_included_persistent]
-instance internalCmraIncluded_persistent {a b : A} :
-    Persistent (PROP := PROP) iprop(a ≼ b) where
-  persistent := persistently_internalCmraIncluded.mpr
+instance internalCmraIncExt_persistent {a b : A} :
+    Persistent (PROP := PROP) iprop(a ≼ₑ b) where
+  persistent := persistently_internalCmraIncExt.mpr
 
 @[rocq_alias internal_included_absorbing]
-instance internalCmraIncluded_absorbing {a b : A} :
-    Absorbing (PROP := PROP) iprop(a ≼ b) :=
+instance internalCmraIncExt_absorbing {a b : A} :
+    Absorbing (PROP := PROP) iprop(a ≼ₑ b) :=
+  siPure_absorbing _
+
+/-! ### The internal order -/
+
+/-- The step-indexed order as a step-indexed proposition. -/
+def _root_.SiProp.cmraIncluded (a b : A) : SiProp where
+  holds n := a ≼{n} b
+  closed h hle := h.le hle
+
+instance _root_.SiProp.cmraIncluded_timeless [CMRA.Discrete A] {a b : A} :
+    Timeless (SiProp.cmraIncluded a b) where
+  timeless := fun n h => by
+    cases n with
+    | zero => left; trivial
+    | succ n => right; exact incN_of_inc _ (CMRA.discrete_inc (inc0_of_incN h))
+
+/-- The internal order `a ≼ b`, holding at step index `n` when `a ≼{n} b`; ownership is
+monotone along it (`ownM_mono`). -/
+def internalCmraIncluded (a b : A) : PROP := siPure (SiProp.cmraIncluded a b)
+
+macro_rules
+  | `(iprop($a ≼ $b)) => ``(internalCmraIncluded $a $b)
+
+delab_rule internalCmraIncluded
+  | `($_ $a $b) => ``(iprop($a ≼ $b))
+
+instance internalCmraIncluded_ne :
+    NonExpansive₂ (internalCmraIncluded (PROP := PROP) (A := A)) where
+  ne _ _ _ hx _ _ hy := siPure_ne.ne fun hm => incN_dist_iff (hx.le hm) (hy.le hm)
+
+theorem internalCmraIncluded_intro {P : PROP} {a b : A} (h : a ≼ b) : P ⊢ a ≼ b :=
+  calc (P : PROP)
+    _ ⊢ True := true_intro
+    _ ⊢ <si_pure> True := siPure_pure.mpr
+    _ ⊢ a ≼ b := siPure_mono fun n _ => incN_of_inc n h
+
+/-- Two internal orders agree when they agree at every step index. -/
+theorem internalCmraIncluded_iff [CMRA B] {a b : A} {a' b' : B}
+    (h : ∀ n, a ≼{n} b ↔ a' ≼{n} b') : a ≼ b ⊣⊢@{PROP} a' ≼ b' :=
+  siPure_mono_bi ⟨fun n => (h n).mp, fun n => (h n).mpr⟩
+
+/-- An internal order that is step-index independent is a pure proposition. -/
+theorem internalCmraIncluded_pure {a b : A} {φ : Prop} (h : ∀ n, a ≼{n} b ↔ φ) :
+    a ≼ b ⊣⊢@{PROP} ⌜φ⌝ :=
+  ⟨.trans (siPure_mono (Qi := SiProp.pure φ) fun n => (h n).mp) siPure_pure.mp,
+   .trans siPure_pure.mpr (siPure_mono (Pi := SiProp.pure φ) fun n => (h n).mpr)⟩
+
+theorem siPure_internalCmraIncluded {a b : A} : <si_pure> a ≼ b ⊣⊢@{PROP} a ≼ b :=
+  persistently_iff.symm.trans persistently_siPure
+
+theorem persistently_internalCmraIncluded {a b : A} : <pers> a ≼ b ⊣⊢@{PROP} a ≼ b :=
+  persistently_siPure
+
+theorem plainly_internalCmraIncluded {a b : A} : ■ a ≼ b ⊣⊢@{PROP} a ≼ b :=
+  plainly_siPure
+
+theorem intuitionistically_internalCmraIncluded [BIAffine PROP] {a b : A} :
+    □ a ≼ b ⊣⊢@{PROP} a ≼ b :=
+  intuitionistically_iff_persistently.trans persistently_internalCmraIncluded
+
+theorem internalCmraIncluded_discrete {a b : A} [CMRA.Discrete A] :
+    a ≼ b ⊣⊢@{PROP} ⌜a ≼ b⌝ :=
+  internalCmraIncluded_pure fun n => (inc_iff_incN n).symm
+
+theorem internalCmraIncluded_refl {a : A} [IncRefl A] : ⊢@{PROP} a ≼ a :=
+  internalCmraIncluded_intro (inc_refl a)
+
+theorem internalCmraIncluded_trans {a b c : A} : ⊢@{PROP} a ≼ b -∗ b ≼ c -∗ a ≼ c :=
+  BI.entails_wand <| BI.wand_intro <| siPure_and_sep.mpr.trans <|
+    siPure_mono fun _ h => incN_trans h.1 h.2
+
+/-- The internal order is monotone under morphisms. -/
+theorem internalCmraIncluded_map {B : Type _} [CMRA B] (g : A -C> B) {a b : A} :
+    a ≼ b ⊢@{PROP} g a ≼ g b :=
+  siPure_mono fun _ => g.monoN
+
+/-- In an affine algebra the internal extension inclusion implies the internal order. -/
+theorem internalCmraIncluded_of_incExt [Affine A] {a b : A} : a ≼ₑ b ⊢@{PROP} a ≼ b :=
+  siPure_mono fun _ h => incN_of_incExtN (incExt_holds.mp h)
+
+instance internalCmraIncluded_timeless {a b : A} [CMRA.Discrete A] :
+    Timeless (PROP := PROP) iprop(a ≼ b) := by
+  unfold internalCmraIncluded
+  infer_instance
+
+instance internalCmraIncluded_plain {a b : A} : Plain (PROP := PROP) iprop(a ≼ b) where
+  plain := plainly_internalCmraIncluded.mpr
+
+instance internalCmraIncluded_persistent {a b : A} : Persistent (PROP := PROP) iprop(a ≼ b) where
+  persistent := persistently_internalCmraIncluded.mpr
+
+instance internalCmraIncluded_absorbing {a b : A} : Absorbing (PROP := PROP) iprop(a ≼ b) :=
   siPure_absorbing _
 
 end CmraIncluded

--- a/Iris/Iris/BI/Lib/InvHeap.lean
+++ b/Iris/Iris/BI/Lib/InvHeap.lean
@@ -52,15 +52,25 @@ theorem get?_toInvHeap_some {h : H (V × (V → Prop))} {l : L}
   rw [toInvHeap, get?_map] at hl
   rcases hh : get? h l with _ | ⟨v, I⟩ <;> rw [hh] at hl <;> simp_all
 
+/-- The invariant-heap store is classical: its order is its extension inclusion. -/
+private theorem invHeap_incExtN_of_incN {n} {x y : InvHeapMapUR V H} (h : x ≼{n} y) :
+    x ≼ₑ{n} y :=
+  Heap.lookup_incN.mpr fun i =>
+    Option.incExtN_of_incN
+      (Prod.incExtN_of_incN (Option.incExtN_of_incN fun h => h) fun h => h) (h i)
+
 private theorem singleton_inc_toInvHeap {h : H (V × (V → Prop))} {l : L} {I : V → Prop}
     {mv : Option (Excl (DiscreteO V))}
     (hinc : ({[l := (mv, toAgree ⟨I⟩)]} : InvHeapMapUR V H) ≼ toInvHeap h) :
     ∃ v, get? h l = some (v, I) ∧ mv ≼ some (excl ⟨v⟩) := by
-  obtain ⟨⟨_, _⟩, hy, hinc⟩ := singleton_inc_iff.mp hinc
+  replace hinc := Heap.lookup_inc.mpr fun i =>
+    Option.incExt_of_inc
+      (Prod.incExt_of_inc (Option.incExt_of_inc fun h => h) fun h => h) (hinc i)
+  obtain ⟨⟨_, _⟩, hy, hinc⟩ := singleton_incExt_iff.mp hinc
   obtain ⟨v, I', rfl, rfl, hh⟩ := get?_toInvHeap_some hy
-  obtain ⟨hv, hI⟩ := Prod.inc_def.mp (Option.some_inc_some_iff_is_total.mp hinc)
+  obtain ⟨hv, hI⟩ := Prod.incExt_def.mp (Option.some_incExt_some_iff_is_total.mp hinc)
   cases DiscreteO.eqv_inj (toAgree_included.mp hI)
-  exact ⟨v, hh, hv⟩
+  exact ⟨v, hh, CMRA.inc_of_incExt hv⟩
 
 @[rocq_alias to_inv_heap_valid]
 theorem toInvHeap_valid (h : H (V × (V → Prop))) : ✓ toInvHeap h := fun l => by
@@ -186,7 +196,7 @@ theorem invPointsToOwn_inv (l : L) (v : V) (I : V → Prop) :
   iintro Hl
   unfold invPointsToOwn invPointsTo
   iapply iOwn_mono $$ Hl
-  refine (frag_inc_of_inc (singleton_inc_singleton_mono ?_))
+  refine CMRA.inc_of_incExt (frag_incExt_of_incExt (singleton_incExt_singleton_mono ?_))
   exact ⟨(some (.excl ⟨v⟩), toAgree ⟨I⟩), Prod.ext rfl Agree.idemp.symm⟩
 
 variable [genHeapGS L V GF H]
@@ -225,7 +235,7 @@ theorem make_invPointsTo {l : L} {v : V} {I : V → Prop} {E : CoPset} (hN : ↑
   imod inv_acc_timeless hN $$ Hinv with ⟨HP, Hclose⟩
   icases HP with ⟨%h, Hauth, HsepM⟩
   rcases hlk : get? h l with _ | ⟨v', I'⟩
-  · imod iOwn_update (auth_update_alloc (alloc_singleton_local_update
+  · imod iOwn_update (auth_update_alloc_of_localUpdate invHeap_incExtN_of_incN (alloc_singleton_local_update
       (x := ((some (.excl ⟨v⟩), toAgree ⟨I⟩) :
         Option (Excl (DiscreteO V)) × Agree (DiscreteO (V → Prop))))
       (get?_toInvHeap_none hlk) ⟨trivial, toAgree_valid⟩)) $$ Hauth with ⟨Hauth, Hfrag⟩
@@ -256,7 +266,7 @@ theorem invPointsToOwn_acc_strong {E : CoPset} (hN : (↑invHeapN : CoPset) ⊆ 
   iunfold invPointsToOwn at Hl_inv
   icases bigSepM_delete hh $$ HsepM with ⟨⟨$, $⟩, HsepM⟩
   iintro %w %hIw Hl
-  imod iOwn_update_op (auth_update (singleton_local_update
+  imod iOwn_update_op (auth_update_of_localUpdate invHeap_incExtN_of_incN (singleton_local_update
       (get?_heap_some_toInvHeap hh)
       (LocalUpdate.prod_1 _ _ (LocalUpdate.option (LocalUpdate.exclusive (x' := excl ⟨w⟩) trivial)))))
     $$ [$Hauth $Hl_inv] with ⟨Hauth, Hfrag⟩

--- a/Iris/Iris/BI/Lib/MonoList.lean
+++ b/Iris/Iris/BI/Lib/MonoList.lean
@@ -205,7 +205,7 @@ theorem lb_own_get (γ : GName) (dq : DFrac) (l : List α) :
   unfold auth_own lb_own
   iintro H
   iapply iOwn_mono $$ H
-  exact included ..
+  exact CMRA.inc_of_incExt (included ..)
 
 @[rocq_alias mono_list_lb_own_le]
 theorem lb_own_le (γ : GName) {l : List α} (l' : List α) (h : l' <+: l) :
@@ -213,7 +213,7 @@ theorem lb_own_le (γ : GName) {l : List α} (l' : List α) (h : l' <+: l) :
   unfold lb_own
   iintro H
   iapply iOwn_mono $$ H
-  exact lb_mono (h.map _)
+  exact CMRA.inc_of_incExt (lb_mono (h.map _))
 
 @[rocq_alias mono_list_lb_own_nil]
 theorem lb_own_nil (γ : GName) : ⊢@{IProp GF} |==> (γ ↪◯ML ([] : List α)) := by

--- a/Iris/Iris/BI/Lib/MonoNat.lean
+++ b/Iris/Iris/BI/Lib/MonoNat.lean
@@ -124,7 +124,7 @@ theorem lb_own_get (γ : GName) (dq : DFrac) (n : MaxNat) :
   unfold auth_own lb_own
   iintro H
   iapply iOwn_mono $$ H
-  exact included _ _
+  exact CMRA.inc_of_incExt (included _ _)
 
 @[rocq_alias mono_nat_lb_own_le]
 theorem lb_own_le (γ : GName) (n n' : MaxNat) (h : n' ≤ n) :
@@ -132,7 +132,7 @@ theorem lb_own_le (γ : GName) (n n' : MaxNat) (h : n' ≤ n) :
   unfold lb_own
   iintro H
   iapply iOwn_mono $$ H
-  exact lb_mono _ _ h
+  exact CMRA.inc_of_incExt (lb_mono _ _ h)
 
 @[rocq_alias mono_nat_lb_own_0]
 theorem lb_own_0 {GF : BundledGFunctors} [MonoNatG GF] (γ : GName) :

--- a/Iris/Iris/BI/SbiUnfold.lean
+++ b/Iris/Iris/BI/SbiUnfold.lean
@@ -183,10 +183,15 @@ instance sbiUnfold_cmraValid [CMRA A] {a : A} :
   .of_closed (fun h hm => validN_of_le hm h) <|
     siPure_mono_bi <| biEntails_of_iff fun _ => .rfl
 
-@[rocq_alias sbi_unfold_internal_included]
 instance sbiUnfold_included [CMRA A] {a b : A} :
     SbiUnfold clo (iprop(a ≼ b) : PROP) (fun n => a ≼{n} b) :=
   .of_closed (fun h hm => incN_of_incN_le hm h) <|
+    siPure_mono_bi <| biEntails_of_iff fun _ => .rfl
+
+@[rocq_alias sbi_unfold_internal_included]
+instance sbiUnfold_incExt [CMRA A] {a b : A} :
+    SbiUnfold clo (iprop(a ≼ₑ b) : PROP) (fun n => a ≼ₑ{n} b) :=
+  .of_closed (fun h hm => RABase.incExtN_le hm h) <|
     siPure_mono_bi <| biEntails_of_iff fun _ => exists_holds
 
 @[rocq_alias sbi_unfold_si_pure]

--- a/Iris/Iris/Examples/ClosedProofs.lean
+++ b/Iris/Iris/Examples/ClosedProofs.lean
@@ -37,11 +37,11 @@ section proof
 
 noncomputable def GF : BundledGFunctors := fun n =>
   match n with
-  | 0  => ⟨InvMapF, by infer_instance⟩
-  | 1  => ⟨constOF CoPsetDisjL, by infer_instance⟩
-  | 2  => ⟨constOF (DisjointLeibnizSet PosSet), by infer_instance⟩
-  | 3  => ⟨AuthURF (constOF Credit), by infer_instance⟩
-  | _  => ⟨constOF Unit, by infer_instance⟩
+  | 0  => ⟨InvMapF⟩
+  | 1  => ⟨constOF CoPsetDisjL⟩
+  | 2  => ⟨constOF (DisjointLeibnizSet PosSet)⟩
+  | 3  => ⟨AuthURF (constOF Credit)⟩
+  | _  => ⟨constOF Unit⟩
 
 instance : WsatGpreS GF where
   inv := { τ := 0, transp := by unfold GF; rfl }

--- a/Iris/Iris/HeapLang/Lib/Counter.lean
+++ b/Iris/Iris/HeapLang/Lib/Counter.lean
@@ -156,12 +156,13 @@ theorem incr_mono_spec (l : Loc) (n : Nat) :
     imod iOwn_update_op
       (a' := (((● MaxNat.ofNat (c + 1)) • (◯ MaxNat.ofNat (c + 1))) : Auth MaxNat)) $$
       [$Hγ $Hγf] with ⟨Hγ, Hγf⟩
-    · exact auth_update (MaxNat.local_update (by grind))
+    · exact auth_update_of_localUpdate (fun h => h) (MaxNat.local_update (by grind))
     imodintro
     iframe Hγ
     iapply iOwn_mono $$ Hγf
-    refine frag_inc_of_inc (MaxNat.inc_iff.mpr ?_)
-    grind [auth_both_valid_discrete.mp Hv, MaxNat.inc_iff]
+    have hnc := CMRA.inc_of_incExt (auth_both_valid_discrete.mp Hv).1
+    refine CMRA.inc_of_incExt (frag_incExt_of_incExt (MaxNat.inc_iff.mpr ?_))
+    grind [MaxNat.inc_iff]
   iintro !> Hγf
   iapply Hφ
   iexists γ
@@ -178,11 +179,12 @@ theorem read_mono_spec (l : Loc) (j : Nat) :
     icombine Hγ Hγf gives %Hv
     imod iOwn_update_op
       (a' := (((● MaxNat.ofNat c) • (◯ MaxNat.ofNat c)) : Auth MaxNat)) $$ [$Hγ $Hγf] with ⟨Hγ, Hγf⟩
-    · exact auth_update (MaxNat.local_update (by simp))
+    · exact auth_update_of_localUpdate (fun h => h) (MaxNat.local_update (by simp))
     imodintro
     iframe Hγ Hγf
     ipureintro
-    grind [auth_both_valid_discrete.mp Hv, MaxNat.inc_iff]
+    have hjc := CMRA.inc_of_incExt (auth_both_valid_discrete.mp Hv).1
+    grind [MaxNat.inc_iff]
   iintro !> %c ⟨%hle, Hγf⟩
   iapply Hφ
   iframe %hle
@@ -248,7 +250,7 @@ theorem incr_contrib_spec (γ : GName) (l : Loc) (q : Qp) (n : Nat) :
   iapply incr_spec (ccounter γ q n) (ccounter γ q (n+1)) l $$ [$Hctx $Hγf] Hφ
   iintro %c ⟨Hγ, Hγf⟩
   imod iOwn_update_op (a' := CMRA.op (●F (c + 1)) (◯F{q} (n + 1))) $$ [$Hγ $Hγf] with ⟨Hγ, Hγf⟩
-  · exact FracAuth.update (CommMonoidLike.leftCancelAdd_local_update (by grind))
+  · exact FracAuth.update (fun h => h) (CommMonoidLike.leftCancelAdd_local_update (by grind))
   imodintro
   iframe
 

--- a/Iris/Iris/HeapLang/Lib/RwSpinLock.lean
+++ b/Iris/Iris/HeapLang/Lib/RwSpinLock.lean
@@ -252,7 +252,7 @@ theorem tryAcquireReader_spec (γ : GName) (lk : Val) (Φ : Qp → IProp GF) :
       (a' := ((● LeibnizMultiSet.ofSet (g ⊎ {q.half})) •
         ◯ LeibnizMultiSet.ofSet {q.half} : Auth (LeibnizMultiSet ReaderFracs))) $$ Hauth with
       ⟨Hauth, Hview⟩
-    · refine Auth.auth_update_alloc ?_
+    · refine Auth.auth_update_alloc_of_localUpdate (fun h => h) ?_
       have h := localUpdate_alloc (X := g) (Y := (∅ : ReaderFracs)) (X' := {q.half})
       rwa [disjUnion_empty_left] at h
     imod Hclose $$ [Hl Hauth HΦ] with -
@@ -307,7 +307,7 @@ theorem releaseReader_spec (γ : GName) (lk : Val) (Φ : Qp → IProp GF) (q : Q
   ihave %Hmem := own_auth_singleton_2 $$ [$Hauth $Hlocked]
   icombine Hauth Hlocked as Hown
   imod iOwn_update (F := RwSpinLockF) (a' := ● .ofSet (g \ {q})) $$ Hown with Hown
-  · refine Auth.auth_update_dealloc ?_
+  · refine Auth.auth_update_dealloc_of_localUpdate (fun h => h) ?_
     have h := localUpdate_dealloc (X := g) (X' := {q}) subset_refl
     rwa [difference_self] at h
   imod Hclose $$ [-Hφ] with -

--- a/Iris/Iris/HeapLang/Lib/TicketLock.lean
+++ b/Iris/Iris/HeapLang/Lib/TicketLock.lean
@@ -113,6 +113,12 @@ private theorem own_op_valid {γ : GName} {a₁ a₂ : TicketR} :
     own (GF := GF) γ a₁ ∗ own γ a₂ ⊢ ⌜✓ (a₁ • a₂)⌝ :=
   iOwn_cmraValid_op.trans (internalCmraValid_discrete (A := TicketR)).mp
 
+/-- The ticket algebra is classical: its order is its extension inclusion. -/
+private theorem ticket_incExtN_of_incN {n}
+    {x y : Option (Excl (DiscreteO Nat)) × DisjointLeibnizSet Tickets} (h : x ≼{n} y) :
+    x ≼ₑ{n} y :=
+  Prod.incExtN_of_incN (Option.incExtN_of_incN fun h => h) (fun h => h) h
+
 /-- Only one thread at a time holds the right to enter the critical section. -/
 private theorem own_owner_exclusive {γ : GName} {o₁ o₂ : Nat} :
     own (GF := GF) γ (owner o₁) ∗ own γ (owner o₂) ⊢ False :=
@@ -128,7 +134,7 @@ private theorem own_ticket_exclusive {γ : GName} {x : Nat} :
 private theorem own_owner_agree {γ : GName} {o o' n : Nat} :
     own (GF := GF) γ (auth o n) ∗ own γ (owner o') ⊢ ⌜o' = o⌝ :=
   own_op_valid.trans (pure_mono fun h =>
-    DiscreteO.eqv_inj (excl_included.mp (Prod.inc_def.mp (Auth.auth_both_valid_discrete.mp h).1).1))
+    DiscreteO.eqv_inj (excl_included.mp (Auth.auth_both_valid_discrete.mp h).1.1))
 
 @[rocq_alias heap_lang.ticket_lock.locked_exclusive]
 theorem locked_exclusive (γ : GName) : locked γ ∗ locked γ ⊢@{IProp GF} False := by
@@ -169,7 +175,7 @@ theorem newlock_spec :
   wp_alloc lo with Hlo
   imod iOwn_alloc (F := TicketLockF) ((auth 0 0 : TicketR) • owner 0) with
     ⟨%γ, ⟨Hauth, Howner⟩⟩
-  · exact Auth.auth_both_valid_2 ⟨trivial, trivial⟩ (inc_refl _)
+  · exact Auth.auth_both_valid_2 ⟨trivial, trivial⟩ ⟨CMRA.inc_refl _, CMRA.inc_refl _⟩
   wp_pures
   imodintro
   iapply Hcont
@@ -235,7 +241,7 @@ theorem acquire_spec (γ : GName) (lk : Val) (R : IProp GF) :
   · obtain rfl : n' = n := by simp only [Val.lit.injEq, BaseLit.int.injEq] at hsuc; omega
     imod iOwn_update (a' := (auth o' (n' + 1) : TicketR) • ticket n') $$ Hauth
       with ⟨Hauth, Hissued⟩
-    · refine Auth.auth_update_alloc ?_
+    · refine Auth.auth_update_alloc_of_localUpdate ticket_incExtN_of_incN ?_
       rw [setSeq_succ, Nat.zero_add]
       exact LocalUpdate.prod_2 _ _
         (localUpdate_alloc_empty_of_disj _ _ (disjoint_singleton_setSeq (by omega)))
@@ -277,7 +283,7 @@ theorem release_spec (γ : GName) (lk : Val) (R : IProp GF) :
   imod iOwn_update (F := TicketLockF) (a := (auth o n' : TicketR) • owner o)
       (a' := (auth (o + 1) n' : TicketR) • owner (o + 1)) $$ [Hauth Howner]
       with ⟨Hauth, Howner⟩
-  · exact Auth.auth_update
+  · exact Auth.auth_update_of_localUpdate ticket_incExtN_of_incN
       (LocalUpdate.prod_1 _ _ (LocalUpdate.option (LocalUpdate.exclusive trivial)))
   · iapply iOwn_op.mpr; iframe
   imod Hclose $$ [Hlo Hln Hauth Howner HR] with -

--- a/Iris/Iris/HeapLang/PrimitiveLaws.lean
+++ b/Iris/Iris/HeapLang/PrimitiveLaws.lean
@@ -92,16 +92,15 @@ theorem state_interp_step [HeapLangGS hlc GF] (σ : State) (ns : Nat)
     stateInterp (GF := GF) σ ns κs nt ⊢ |==> stateInterp σ (ns + 1) κs nt := bupd_intro
 
 def HeapLangS : BundledGFunctors
-  | 0 => ⟨InvMapF, by infer_instance⟩
-  | 1 => ⟨constOF CoPsetDisjL, by infer_instance⟩
-  | 2 => ⟨constOF (DisjointLeibnizSet PosSet), by infer_instance⟩
-  | 3 => ⟨Auth.AuthURF (constOF Credit), by infer_instance⟩
-  | 4 => ⟨constOF (HeapView Loc (Agree (DiscreteO (Option Val))) HeapF), by infer_instance⟩
-  | 5 => ⟨constOF (HeapView Loc (Agree (DiscreteO GName)) HeapF), by infer_instance⟩
-  | 6 => ⟨constOF MetaUR, by infer_instance⟩
-  | 7 => ⟨constOF (HeapView ProphId (Agree (DiscreteO (List (Val × Val)))) ProphMapF),
-          by infer_instance⟩
-  | _ => ⟨constOF Unit, by infer_instance⟩
+  | 0 => ⟨InvMapF⟩
+  | 1 => ⟨constOF CoPsetDisjL⟩
+  | 2 => ⟨constOF (DisjointLeibnizSet PosSet)⟩
+  | 3 => ⟨Auth.AuthURF (constOF Credit)⟩
+  | 4 => ⟨constOF (HeapView Loc (Agree (DiscreteO (Option Val))) HeapF)⟩
+  | 5 => ⟨constOF (HeapView Loc (Agree (DiscreteO GName)) HeapF)⟩
+  | 6 => ⟨constOF MetaUR⟩
+  | 7 => ⟨constOF (HeapView ProphId (Agree (DiscreteO (List (Val × Val)))) ProphMapF)⟩
+  | _ => ⟨constOF Unit⟩
 
 instance instHeapLangGS_HeapLangS : HeapLangGpreS HasLC.hasLC HeapLangS where
   toWsatGpreS := by

--- a/Iris/Iris/Instances/IProp/Instance.lean
+++ b/Iris/Iris/Instances/IProp/Instance.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 Markus de Medeiros. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Markus de Medeiros, Zongyuan Liu, Remy Seassau
+Authors: Markus de Medeiros, Zongyuan Liu, Remy Seassau, Janine Lohse
 -/
 module
 
@@ -23,7 +23,7 @@ abbrev COFE.OFunctorPre.ap (F : OFunctorPre) (T : Type _) [COFE T] :=
 
 /-- Apply a list of OFunctors at a fixed type and index -/
 abbrev BundledGFunctors.api (FF : BundledGFunctors) (τ : GType) (T : Type _) [COFE T] :=
-  FF τ |>.fst |>.ap T
+  FF τ |>.F |>.ap T
 
 /-- Transport an OFunctorPre application along equality of the OFunctorPre.  -/
 theorem transpAp {F1 F2 : OFunctorPre} (H : F1 = F2) {T} [COFE T] : F1.ap T = F2.ap T :=
@@ -55,6 +55,18 @@ theorem OFE.validN_transpAp_mp (h_fun : F₁ = F₂) (h_inst : HEq RF₁ RF₂) 
     (H : ✓{n} ((transpAp h_fun).mp x)) : ✓{n} x := by
   cases h_fun; cases eq_of_heq h_inst; exact H
 
+theorem OFE.transpAp_incN_mp (h_fun : F₁ = F₂) (h_inst : HEq RF₁ RF₂) {x y : F₁ T T}
+    (H : x ≼{n} y) : (transpAp h_fun).mp x ≼{n} (transpAp h_fun).mp y := by
+  cases h_fun; cases eq_of_heq h_inst; exact H
+
+theorem OFE.transpAp_inc_mp (h_fun : F₁ = F₂) (h_inst : HEq RF₁ RF₂) {x y : F₁ T T}
+    (H : x ≼ y) : (transpAp h_fun).mp x ≼ (transpAp h_fun).mp y := by
+  cases h_fun; cases eq_of_heq h_inst; exact H
+
+theorem OFE.transpAp_increasing_mp (h_fun : F₁ = F₂) (h_inst : HEq RF₁ RF₂) {x : F₁ T T}
+    (H : CMRA.Increasing x) : CMRA.Increasing ((transpAp h_fun).mp x) := by
+  cases h_fun; cases eq_of_heq h_inst; exact H
+
 end TranspAp
 
 section ElemG
@@ -63,7 +75,11 @@ section ElemG
 @[rocq_alias inG]
 class ElemG (FF : BundledGFunctors) (F : OFunctorPre) [RFunctorContractive F] where
   τ : GType
-  transp : FF τ = ⟨F, ‹_›⟩
+  [affine : RFunctorAffine F]
+  transp : FF τ = ⟨F⟩
+
+-- Every functor of the global bundle is affine.
+attribute [instance] ElemG.affine
 
 #rocq_ignore subG_inG "Superseded by Lean's direct `ElemG` typeclass synthesis."
 
@@ -71,11 +87,11 @@ open OFE
 
 variable [I : RFunctorContractive F]
 
-theorem ElemG.transpMap (E : ElemG GF F) T [OFE T] : (GF E.τ).fst = F :=
-  Sigma.mk.inj E.transp |>.1
+theorem ElemG.transpMap (E : ElemG GF F) T [OFE T] : (GF E.τ).F = F :=
+  congrArg GFunctor.F E.transp
 
-theorem ElemG.transpClass (E : ElemG GF F) T [OFE T] : (GF E.τ).snd ≍ I :=
-  Sigma.mk.inj E.transp |>.2
+theorem ElemG.transpClass (E : ElemG GF F) T [OFE T] : (GF E.τ).contractive ≍ I := by
+  rw [E.transp]
 
 def ElemG.bundle (E : ElemG GF F) [COFE T] : F.ap T → GF.api E.τ T :=
   transpAp (E.transpMap T) |>.mpr
@@ -117,8 +133,8 @@ theorem bundle_op {GF : BundledGFunctors} [E : ElemG GF F] (a2 ac : F.ap (IProp 
 
 theorem unbundle_op {GF : BundledGFunctors} [E : ElemG GF F] (a2 ac : GF.api (ElemG.τ GF F) (IProp GF)) :
   E.unbundle (a2 • ac) = E.unbundle a2 • E.unbundle ac :=
-  OFE.transpAp_op_mp (E.transpMap ((GF (ElemG.τ GF F)).fst.ap (IPre GF)))
-    (E.transpClass ((GF (ElemG.τ GF F)).fst.ap (IPre GF)))
+  OFE.transpAp_op_mp (E.transpMap ((GF (ElemG.τ GF F)).F.ap (IPre GF)))
+    (E.transpClass ((GF (ElemG.τ GF F)).F.ap (IPre GF)))
 
 theorem ElemG.bundle_unit {GF F} [RFunctorContractive F] (E : ElemG GF F) {ε : F.ap (IProp GF)} [IsUnit ε] :
     IsUnit (E.bundle ε) := by
@@ -171,15 +187,15 @@ def IProp.foldi : FF.api τ (IPre FF) -n> FF.api τ (IProp FF) :=
 @[rocq_alias inG_unfold_fold]
 theorem IProp.unfoldi_foldi (x : FF.api τ (IPre FF)) : unfoldi (foldi x) = x := by
   refine OFE.eq_dist_2 fun n => ?_
-  refine .trans (OFunctor.map_comp (F := FF τ |>.fst) ..).symm.dist ?_
-  refine .trans ?_ (OFunctor.map_id (F := FF τ |>.fst) x).dist
+  refine .trans (OFunctor.map_comp (F := FF τ |>.F) ..).symm.dist ?_
+  refine .trans ?_ (OFunctor.map_id (F := FF τ |>.F) x).dist
   apply OFunctor.map_ne.ne <;> intro _ <;> simp [IProp.unfold, IProp.fold]
 
 @[rocq_alias inG_fold_unfold]
 theorem IProp.foldi_unfoldi (x : FF.api τ (IProp FF)) : foldi (unfoldi x) = x := by
   refine OFE.eq_dist_2 fun n => ?_
-  refine .trans (OFunctor.map_comp (F := FF τ |>.fst) ..).symm.dist ?_
-  refine .trans ?_ (OFunctor.map_id (F := FF τ |>.fst) x).dist
+  refine .trans (OFunctor.map_comp (F := FF τ |>.F) ..).symm.dist ?_
+  refine .trans ?_ (OFunctor.map_id (F := FF τ |>.F) x).dist
   apply OFunctor.map_ne.ne <;> intro _ <;> simp [IProp.unfold, IProp.fold]
 
 @[rocq_alias iProp_unfold_equivI]
@@ -229,7 +245,7 @@ theorem IProp.unfoldi_unit {τ : GType} {x : FF.api τ (IProp FF)} [IsUnit x] :
       _ = unfoldi (foldi (unfoldi x • y)) := (IProp.unfoldi_foldi _).symm
       _ = unfoldi (foldi y) := congrArg unfoldi.f h
       _ = y := IProp.unfoldi_foldi y
-  · letI : RFunctor (FF τ).fst := (FF τ).snd.toRFunctor
+  · letI : RFunctor (FF τ).F := (FF τ).contractive.toRFunctor
     calc CMRA.pcore (unfoldi.f x)
       _ = (CMRA.pcore x).map unfoldi.f :=
         ((RFunctor.map (IProp.fold FF) (IProp.unfold FF)).pcore x).symm
@@ -313,7 +329,7 @@ theorem unfoldi_bundle_coreId {a : F.ap (IProp GF)} [CMRA.CoreId a] :
     CMRA.CoreId (unfoldi (E.bundle a)) := by
   constructor
   simp only [unfoldi, OFunctor.map]
-  letI : RFunctor (GF E.τ).fst := (GF E.τ).snd.toRFunctor
+  letI : RFunctor (GF E.τ).F := (GF E.τ).contractive.toRFunctor
   have bundle_coreId : CMRA.CoreId (E.bundle a) := by
     constructor
     calc CMRA.pcore (E.bundle a)
@@ -553,10 +569,30 @@ theorem iOwn_op {a1 a2 : F.ap (IProp GF)} : iOwn γ (a1 • a2) ⊣⊢ iOwn γ a
   rw [← iSingleton_op]
   exact UPred.ownM_op _ _
 
+/-- `iSingleton` is monotone for the resource order. -/
+theorem iSingleton_mono {γ : GName} {a1 a2 : F.ap (IProp GF)} (H : a2 ≼ a1) :
+    iSingleton F γ a2 ≼ iSingleton F γ a1 := by
+  have hu : unfoldi (E.bundle a2) ≼ unfoldi (E.bundle a1) :=
+    (RFunctor.map (IProp.fold GF) (IProp.unfold GF)).mono
+      (OFE.transpAp_inc_mp (E.transpMap (F.ap (IProp GF))).symm
+        (E.transpClass (F.ap (IProp GF))).symm H)
+  intro τ'
+  simp only [iSingleton]
+  split
+  · next h =>
+    subst h
+    intro γ'
+    by_cases hγ : γ' = γ
+    · subst hγ
+      rw [GenMap.singleton_map_in, GenMap.singleton_map_in]
+      exact .inr hu
+    · rw [singleton_map_none hγ, singleton_map_none hγ]
+      trivial
+  · exact CMRA.inc_refl _
+
 @[rocq_alias own_mono]
-theorem iOwn_mono {a1 a2 : F.ap (IProp GF)} (H : a2 ≼ a1) : iOwn γ a1 ⊢ iOwn γ a2 := by
-  obtain ⟨c, rfl⟩ := H
-  exact iOwn_op.mp.trans BI.sep_elim_left
+theorem iOwn_mono {a1 a2 : F.ap (IProp GF)} (H : a2 ≼ a1) : iOwn γ a1 ⊢ iOwn γ a2 :=
+  UPred.ownM_mono (iSingleton_mono H)
 
 @[rocq_alias own_valid]
 theorem iOwn_cmraValid {a : F.ap (IProp GF)} : iOwn γ a ⊢ ✓ a :=
@@ -659,7 +695,7 @@ theorem iOwn_alloc_dep (f : GName → F.ap (IProp GF)) (Ha : ∀ γ, ✓ (f γ))
     ⊢ |==> ∃ γ, iOwn γ (f γ) := by
   unfold iOwn
   refine .trans (Q := iprop(|==> ∃ m, ⌜∃ γ, m = iSingleton F γ (f γ)⌝ ∧ UPred.ownM m)) ?_ (BIUpdate.mono ?_)
-  · refine .trans (@UPred.ownM_unit (IResUR GF) _ iprop(emp)) ?_
+  · refine .trans (@UPred.ownM_unit (IResUR GF) _ _ iprop(emp)) ?_
     refine .trans intuitionistically_elim ?_
     apply UPred.bupd_ownM_updateP
     apply alloc_update_unit Ha
@@ -680,7 +716,7 @@ theorem iOwn_alloc_strong_dep (f : GName → F.ap (IProp GF)) (P : GName → Pro
     ⊢ |==> ∃ γ, ⌜P γ⌝ ∗ iOwn γ (f γ) := by
   unfold iOwn
   refine .trans (Q := iprop(|==> ∃ m, ⌜∃ γ, P γ ∧ m = iSingleton F γ (f γ)⌝ ∧ UPred.ownM m)) ?_ (BIUpdate.mono ?_)
-  · refine .trans (@UPred.ownM_unit (IResUR GF) _ iprop(emp)) ?_
+  · refine .trans (@UPred.ownM_unit (IResUR GF) _ _ iprop(emp)) ?_
     refine .trans intuitionistically_elim ?_
     apply UPred.bupd_ownM_updateP
     apply UpdateP.total.mpr
@@ -835,7 +871,8 @@ instance intoAnd_own {γ} {a b1 b2 : F.ap (IProp GF)} [h : IsOp .split a b1 b2] 
     IntoAnd false (iOwn γ a) (iOwn γ b1) (iOwn γ b2) where
   into_and := by
     rw [h.is_op]
-    exact and_intro (iOwn_mono ⟨b2, rfl⟩) (iOwn_mono ⟨b1, CMRA.comm⟩)
+    exact and_intro (iOwn_mono (CMRA.inc_of_incExt ⟨b2, rfl⟩))
+      (iOwn_mono (CMRA.inc_of_incExt ⟨b1, CMRA.comm⟩))
 
 set_option synthInstance.checkSynthOrder false in
 @[rocq_alias from_sep_own]
@@ -984,28 +1021,49 @@ theorem iResProject_below {z : IResUR GF} {c : F.ap (IProp GF)}
     (h : iResProject F γ z = some c) : iSingleton F γ c ≼ z := by
   simp only [iResProject, Option.map_eq_some_iff] at h
   obtain ⟨v, hv, rfl⟩ := h
-  exact ⟨_, (iSingleton_op_alter hv).symm⟩
+  exact inc_of_incExt ⟨_, (iSingleton_op_alter hv).symm⟩
+
+/-- `iResProject` is monotone for the resource order. -/
+theorem iResProject_monoN {n} {x y : IResUR GF} (h : x ≼{n} y) :
+    iResProject F γ x ≼{n} iResProject F γ y := by
+  have hγ : (x E.τ).car γ ≼{n} (y E.τ).car γ := h E.τ γ
+  simp only [iResProject]
+  revert hγ
+  rcases (x E.τ).car γ with _ | u <;> rcases (y E.τ).car γ with _ | v <;> intro hγ
+  · trivial
+  · exact Option.none_incN_some_iff.mpr <|
+      OFE.transpAp_increasing_mp (E.transpMap (F.ap (IProp GF))) (E.transpClass (F.ap (IProp GF))) <|
+        (RFunctor.map (IProp.unfold GF) (IProp.fold GF)).increasing <|
+          Option.none_incN_some_iff.mp hγ
+  · exact absurd hγ Option.not_some_incN_none
+  · refine Option.some_incN_some_iff.mpr (Option.some_incN_some_iff.mp hγ |>.imp ?_ ?_)
+    · exact fun e => ElemG.unbundle.ne.ne (foldi.ne.ne e)
+    · exact fun i =>
+        OFE.transpAp_incN_mp (E.transpMap (F.ap (IProp GF))) (E.transpClass (F.ap (IProp GF))) <|
+          (RFunctor.map (IProp.unfold GF) (IProp.fold GF)).monoN i
 
 @[rocq_alias iRes_project_above]
 theorem iResProject_above {z : IResUR GF} {c : F.ap (IProp GF)} :
     iSingleton F γ c ≼ z ⊢@{IProp GF} some c ≼ iResProject F γ z := by
-  refine (internalCmraIncluded_map (iResProject F γ) iResProject_op).trans ?_
-  rw [iResProject_iSingleton]
+  sbi_unfold
+  intro n h
+  have h2 := iResProject_monoN (F := F) (γ := γ) h
+  rw [iResProject_iSingleton] at h2
+  exact h2
 
 /-- Nothing is owned at `γ` when the projection there is `none`. -/
 theorem iResProject_none_incl_false {z : IResUR GF} (a : F.ap (IProp GF))
     (hz : iResProject F γ z = none) : iSingleton F γ a ≼ z ⊢@{IProp GF} False := by
   refine iResProject_above.trans ?_
   rw [hz]
-  exact option_includedI.mp
+  exact some_includedI_none
 
 @[rocq_alias own_forall]
 theorem iOwn_forall {B : Type _} [Inhabited B] (γ : GName) (f : B → F.ap (IProp GF)) :
     (∀ b, iOwn γ (f b)) ⊢ ∃ c, iOwn γ c ∗ ∀ b, some (f b) ≼ some c := by
   have hforall : (∀ b, UPred.ownM (iSingleton F γ (f b))) ⊢@{IProp GF}
       ∃ z, UPred.ownM z ∧ ∀ b, iSingleton F γ (f b) ≼ z :=
-    (UPred.ownM_forall _).trans <|
-      exists_mono fun _ => and_mono_right (forall_mono fun _ => siPure_exist.mpr)
+    UPred.ownM_forall _
   unfold iOwn
   iintro Hown
   icases hforall $$ Hown with ⟨%z, Hown, #Hincl⟩
@@ -1023,11 +1081,11 @@ theorem iOwn_forall {B : Type _} [Inhabited B] (γ : GName) (f : B → F.ap (IPr
       iexact Hincl
 
 @[rocq_alias own_forall_total]
-theorem iOwn_forall_total [CMRA.IsTotal (F.ap (IProp GF))] {B : Type _} [Inhabited B]
+theorem iOwn_forall_total [IncRefl (F.ap (IProp GF))] {B : Type _} [Inhabited B]
     (γ : GName) (f : B → F.ap (IProp GF)) :
     (∀ b, iOwn γ (f b)) ⊢ ∃ c, iOwn γ c ∗ ∀ b, f b ≼ c :=
   (iOwn_forall γ f).trans <|
-    exists_mono fun _ => sep_mono_right (forall_mono fun _ => Some_included_totalI.mp)
+    exists_mono fun _ => sep_mono_right (forall_mono fun _ => some_includedI.mp)
 
 @[rocq_alias own_and]
 theorem iOwn_and {a1 a2 : F.ap (IProp GF)} :
@@ -1045,10 +1103,10 @@ theorem iOwn_and {a1 a2 : F.ap (IProp GF)} :
     · ihave #H2 := Hincl $$ %false; isimp only [cond_false] at H2; iexact H2
 
 @[rocq_alias own_and_total]
-theorem iOwn_and_total [CMRA.IsTotal (F.ap (IProp GF))] {a1 a2 : F.ap (IProp GF)} :
+theorem iOwn_and_total [IncRefl (F.ap (IProp GF))] {a1 a2 : F.ap (IProp GF)} :
     (iOwn γ a1 ∧ iOwn γ a2) ⊢ ∃ c, iOwn γ c ∗ a1 ≼ c ∗ a2 ≼ c :=
   iOwn_and.trans <| exists_mono fun _ =>
-    sep_mono_right (sep_mono Some_included_totalI.mp Some_included_totalI.mp)
+    sep_mono_right (sep_mono some_includedI.mp some_includedI.mp)
 
 @[rocq_alias own_forall_pred]
 theorem iOwn_forall_pred {B : Type _} (γ : GName) (φ : B → Prop) [Inhabited (Subtype φ)]
@@ -1066,15 +1124,15 @@ theorem iOwn_forall_pred {B : Type _} (γ : GName) (φ : B → Prop) [Inhabited 
       iapply Hincl $$ %(⟨b, hb⟩ : Subtype φ)
 
 @[rocq_alias own_forall_pred_total]
-theorem iOwn_forall_pred_total [CMRA.IsTotal (F.ap (IProp GF))] {B : Type _} (γ : GName)
+theorem iOwn_forall_pred_total [IncRefl (F.ap (IProp GF))] {B : Type _} (γ : GName)
     (φ : B → Prop) [Inhabited (Subtype φ)] (f : B → F.ap (IProp GF)) :
     (∀ b, ⌜φ b⌝ -∗ iOwn γ (f b)) ⊢ ∃ c, iOwn γ c ∗ ∀ b, ⌜φ b⌝ -∗ f b ≼ c :=
   (iOwn_forall_pred γ φ f).trans <| exists_mono fun _ =>
-    sep_mono_right (forall_mono fun _ => wand_mono_right Some_included_totalI.mp)
+    sep_mono_right (forall_mono fun _ => wand_mono_right some_includedI.mp)
 
 @[rocq_alias own_and_discrete_total]
 theorem iOwn_and_discrete_total [CMRA.Discrete (F.ap (IProp GF))]
-    [CMRA.IsTotal (F.ap (IProp GF))] {a1 a2 c : F.ap (IProp GF)}
+    [IncRefl (F.ap (IProp GF))] {a1 a2 c : F.ap (IProp GF)}
     (h : ∀ c', ✓ c' → a1 ≼ c' → a2 ≼ c' → c ≼ c') :
     (iOwn γ a1 ∧ iOwn γ a2) ⊢ iOwn γ c := by
   iintro Hown
@@ -1085,7 +1143,7 @@ theorem iOwn_and_discrete_total [CMRA.Discrete (F.ap (IProp GF))]
 
 @[rocq_alias own_and_discrete_total_False]
 theorem iOwn_and_discrete_total_false [CMRA.Discrete (F.ap (IProp GF))]
-    [CMRA.IsTotal (F.ap (IProp GF))] {a1 a2 : F.ap (IProp GF)}
+    [IncRefl (F.ap (IProp GF))] {a1 a2 : F.ap (IProp GF)}
     (h : ∀ c', ✓ c' → a1 ≼ c' → a2 ≼ c' → False) :
     (iOwn γ a1 ∧ iOwn γ a2) ⊢ False := by
   iintro Hown

--- a/Iris/Iris/Instances/Lib/FUpdFromViewShift.lean
+++ b/Iris/Iris/Instances/Lib/FUpdFromViewShift.lean
@@ -23,7 +23,10 @@ open Iris OFE BI
 
 section fupd
 
-variable {M : Type u} [UCMRA M] (vs : CoPset → CoPset → UPred M → UPred M → UPred M)
+-- Framing spatial hypotheses into `∧`-shaped view-shift premises needs `BIAffine (UPred M)`,
+-- which holds exactly for affine `M`; every classical CMRA qualifies.
+variable {M : Type u} [UCMRA M] [CMRA.Affine M]
+variable (vs : CoPset → CoPset → UPred M → UPred M → UPred M)
 
 @[rocq_alias fupd]
 abbrev fupd_vs (E1 E2 : CoPset) (P : UPred M) : UPred M :=

--- a/Iris/Iris/Instances/Lib/GhostMap.lean
+++ b/Iris/Iris/Instances/Lib/GhostMap.lean
@@ -284,7 +284,7 @@ theorem ghost_map_auth_valid_2 {γ} {dq1 dq2 : DFrac} {m1 m2 : H V} :
   have ⟨h₁, h₂⟩ := auth_op_auth_valid_iff.mp G
   refine ⟨h₁, equiv_iff_eq.mp fun k => ?_⟩
   have h : _ = _ := congrArg (fun m => get? m k) h₂
-  simp only [get?_map, Option.map] at h
+  simp only [LawfulPartialMap.get?_map, Option.map] at h
   cases h₁ : get? m1 k <;> cases h₂ : get? m2 k <;> simp only [h₁, h₂] at h
   · rfl
   · exact (OFE.not_none_eqv_some h).elim
@@ -323,7 +323,8 @@ theorem ghost_map_lookup {γ dq} {m : H V} {k : K} {dq' v} :
   icombine H1 H2 gives %G
   ipureintro
   have ⟨av', _, _, h_av', _, h⟩ := auth_op_frag_valid_total_discrete_iff G
-  cases h₂ : get? m k <;> grind [get?_map,Agree.toAgree_included]
+  replace h := CMRA.inc_of_incExt h
+  cases h₂ : get? m k <;> grind [LawfulPartialMap.get?_map,Agree.toAgree_included]
 
 @[rocq_alias ghost_map_lookup_combine_gives_1]
 instance ghost_map_lookup_combine_gives_1 γ (m : H V) (k : K) (dq1 dq2 : DFrac) (v : V) :
@@ -351,7 +352,7 @@ theorem ghost_map_insert {γ} {m : H V} (k : K) (v : V) (Heq : get? m k = .none)
   unfold ghost_map_auth ghost_map_elem
   iintro H
   imod iOwn_update (update_one_alloc (k := k) (v1 := toAgree ⟨v⟩)
-    (by simp [get?_map, Heq])
+    (by simp [LawfulPartialMap.get?_map, Heq])
     DFrac.valid_own_one
     Agree.toAgree_valid) $$ H with H
   icases H with ⟨H, $⟩
@@ -421,6 +422,7 @@ theorem ghost_map_insert_big [DecidableEq K] {γ m} (m' : H V) (Hdisj : m' ##ₘ
       exact auth_inc_of_map_eq _ map_union
     · iapply iOwn_mono $$ H2
       rw [BigOpM.bigOpM_map_eq]
+      exact CMRA.inc_refl _
 
 @[rocq_alias ghost_map_insert_persist_big]
 theorem ghost_map_insert_persist_big [DecidableEq K] {γ m} (m' : H V) (Hdisj : m' ##ₘ m) :

--- a/Iris/Iris/Instances/Lib/LaterCredits.lean
+++ b/Iris/Iris/Instances/Lib/LaterCredits.lean
@@ -40,6 +40,7 @@ scoped instance : LeftCancelAdd Credit := ⟨Nat.add_left_cancel⟩
 scoped instance : COFE Credit := COFE.ofDiscrete _
 scoped instance : Discrete Credit := ⟨fun h => h⟩
 scoped instance : UCMRA Credit := CommMonoidLike.instUCMRA
+scoped instance : CMRA.Affine Credit := RABase.affine_withExtensionOrder
 scoped instance : CMRA.Discrete Credit := CommMonoidLike.instDiscrete
 scoped instance {a : Credit} : CMRA.Cancelable a := inferInstance
 
@@ -137,7 +138,8 @@ theorem lc_supply_bound {n m} : ⊢@{IProp GF} lc_supply m -∗ £ n -∗ ⌜n �
 theorem lc_decrease_supply {n m} : ⊢@{IProp GF} lc_supply (n + m) -∗ £ n -∗ |==> lc_supply m := by
   iintro H1 H2
   imod iOwn_update_op (E := LC.lc_elem)
-    (auth_update (leftCancelAdd_local_update ((Nat.add_assoc n m 0).trans (Nat.add_comm n m))))
+    (auth_update_of_localUpdate (fun h => h)
+      (leftCancelAdd_local_update ((Nat.add_assoc n m 0).trans (Nat.add_comm n m))))
     $$ [H1 H2] with H
   · unfold lc lc_supply
     isplitl [H1] <;> iassumption
@@ -150,7 +152,8 @@ theorem lc_increase_supply n m : lc_supply m ⊢@{IProp GF} |==> (lc_supply (n +
   unfold lc lc_supply
   iintro H
   imod iOwn_update $$ H with Hown
-  · exact auth_update_alloc (leftCancelAdd_local_update (y := 0) (x' := (n + m)) (y' := n) (by grind))
+  · exact auth_update_alloc_of_localUpdate (fun h => h)
+      (leftCancelAdd_local_update (y := 0) (x' := (n + m)) (y' := n) (by grind))
   icases iOwn_op $$ Hown with ⟨Hm, _⟩
   iframe
 

--- a/Iris/Iris/Instances/Lib/SetBij.lean
+++ b/Iris/Iris/Instances/Lib/SetBij.lean
@@ -117,7 +117,7 @@ theorem set_bij_own_elem_agree {a a' : A} {b b' : B} :
 @[rocq_alias gset_bij_own_elem_get]
 theorem set_bij_own_elem_get (a : A) (b : B) (h : (a, b) ∈ L) :
     (γ ↪●BIJ{dq} L) ⊢@{IProp GF} γ ↪◯BIJ⟨a, b⟩ :=
-  iOwn_mono (elem_inc_auth h)
+  iOwn_mono (CMRA.inc_of_incExt (elem_incExt_auth h))
 
 @[rocq_alias gset_bij_elem_of]
 theorem set_bij_elem_of (a : A) (b : B) :

--- a/Iris/Iris/Instances/Lib/WSat.lean
+++ b/Iris/Iris/Instances/Lib/WSat.lean
@@ -205,7 +205,8 @@ theorem invariant_lookup (I : InvMap (IProp GF)) (i : Pos) (P : IProp GF) :
   ihave ⟨%v', %dp', %Hdp, %Hlookup, H1, H2⟩ :=
     (auth_op_frag_validI_total
       (own 1) (map toAgree (map invariant_unfold I))) $$ H
-  simp only [get?_map, Option.map_map, Option.map_eq_some_iff, Function.comp_apply] at Hlookup
+  simp only [LawfulPartialMap.get?_map, Option.map_map, Option.map_eq_some_iff,
+    Function.comp_apply] at Hlookup
   have ⟨Q', Hget, Hagree⟩ := Hlookup
   iexists Q'
   isplit
@@ -285,7 +286,7 @@ theorem ownI_alloc [W : WsatGS GF] (φ : Pos → Prop) (P : IProp GF)
   -- FIXME: removing E causes a PM error
   imod iOwn_update (E := W.inv) (update_one_alloc (v1 := toAgree (invariant_unfold P)) _
       DFrac.valid_discard (fun _ => ⟨⟩)) $$ Hown with Hown
-  · simpa [get?_map]
+  · simpa [LawfulPartialMap.get?_map]
   icases iOwn_op $$ Hown with ⟨Hown, Hpt⟩
   imodintro
   iexists j
@@ -324,7 +325,7 @@ theorem ownI_alloc_open [W : WsatGS GF] (φ : Pos → Prop) (P : IProp GF)
   obtain ⟨j, HEQ, ⟨Hget, Hφ⟩⟩ := Hpure
   imod iOwn_update (E := W.inv) (update_one_alloc (v1 := toAgree (invariant_unfold P)) _
       DFrac.valid_discard (fun _ => ⟨⟩)) $$ Hown with Hown
-  · simpa [get?_map]
+  · simpa [LawfulPartialMap.get?_map]
   icases iOwn_op $$ Hown with ⟨Hown, Hpt⟩
   imodintro
   iexists j

--- a/Iris/Iris/Instances/UPred/Instance.lean
+++ b/Iris/Iris/Instances/UPred/Instance.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 Markus de Medeiros. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Markus de Medeiros, Mario Carneiro, Viet Anh Nguyen
+Authors: Markus de Medeiros, Mario Carneiro, Viet Anh Nguyen, Janine Lohse
 -/
 module
 
@@ -56,19 +56,13 @@ protected def or (P Q : UPred M) : UPred M where
 #rocq_ignore uPred_or_def "`UPred.or` is defined directly without `seal`/`unseal`."
 #rocq_ignore uPred_or_aux "`UPred.or` is defined directly without `seal`/`unseal`."
 
+/-- Implication quantifies over the resources above `x` in the order
+(Rocq closes under the extension inclusion instead). -/
 @[rocq_alias uPred_impl]
 protected def imp (P Q : UPred M) : UPred M where
-  holds n x := ∀ {n'} (x' : ValidAt M n'), x.val ≼ x'.val → n' ≤ n → P n' x' → Q n' x'
-  mono {_ _ x₁ x₂} H := fun ⟨m₁, Hle⟩ Hn n ⟨x, xP⟩ ⟨m₂, Hxle⟩ Hnle HP => by
-    have Hx :=
-      calc x  ≡{n}≡ x₂ • m₂    := Hxle.dist
-           _  ≡{n}≡ (x₁ • m₁) • m₂ := (Hle.le Hnle).op_l
-    refine (uPred_ne (m₂ := ⟨(x₁.val • m₁) • m₂, Hx.validN.mp xP⟩) Hx).mpr (H _ ?_ ?_ ?_)
-    · calc x₁.val = CMRA.op x₁.val unit               := unit_right_id.symm
-           _      ≼ x₁.val • (m₁ • m₂)                := op_mono_right _ inc_unit
-           _      = CMRA.op (CMRA.op x₁.val m₁) m₂    := assoc'
-    · exact Nat.le_trans Hnle Hn
-    · exact (uPred_ne Hx).mp HP
+  holds n x := ∀ {n'} (x' : ValidAt M n'), x.val ≼{n'} x'.val → n' ≤ n → P n' x' → Q n' x'
+  mono H Hle Hn := fun x' Hxle Hnle HP =>
+    H x' (incN_trans (Hle.le Hnle) Hxle) (Nat.le_trans Hnle Hn) HP
 
 #rocq_ignore uPred_impl_unseal "`UPred.imp` is defined directly without `seal`/`unseal`."
 #rocq_ignore uPred_impl_def "`UPred.imp` is defined directly without `seal`/`unseal`."
@@ -96,18 +90,16 @@ protected def eq [OFE O] (o1 o2 : O) : UPred M where
   holds n _ := o1 ≡{n}≡ o2
   mono H1 _ H2 := H1.le H2
 
+/-- Separation splits a resource *below* `x` (`x1 • x2 ≼{n} x`), not `x` itself as in Rocq
+(`x ≡{n}≡ x1 • x2`); for the extension order the two are equivalent, and this form is
+monotone for any order. -/
 @[rocq_alias uPred_sep]
 protected def sep (P Q : UPred M) : UPred M where
-  holds n x := ∃ x1 x2, ∃ (H : x.val ≡{n}≡ x1 • x2),
-    P n ⟨x1, validN_op_left (validN_ne H x.property)⟩
-    ∧ Q n ⟨x2, validN_op_right (validN_ne H x.property)⟩
-  mono {_ n₂ m₁ m₂} := fun ⟨x₁, x₂, Hx, HP, HQ⟩ ⟨m, Hm⟩ Hn => by
-    refine ⟨x₁, x₂ • m, ?_, ?_, ?_⟩
-    · calc m₂.val ≡{n₂}≡ m₁ • m := Hm
-          _       ≡{n₂}≡ (x₁ • x₂) • m := (Hx.le Hn).op_l
-          _       ≡{n₂}≡ x₁ • (x₂ • m) := assoc.symm.dist
-    · exact P.mono HP (incN_refl x₁) Hn
-    · exact Q.mono HQ (incN_op_left n₂ x₂ m) Hn
+  holds n x := ∃ x1 x2 : M, ∃ (H : x1 • x2 ≼{n} x.val),
+    P n ⟨x1, validN_op_left (validN_of_incN H x.property)⟩
+    ∧ Q n ⟨x2, validN_op_right (validN_of_incN H x.property)⟩
+  mono := fun ⟨x₁, x₂, Hx, HP, HQ⟩ Hm Hn =>
+    ⟨x₁, x₂, (Hx.le Hn).trans Hm, P.mono HP (incN_refl x₁) Hn, Q.mono HQ (incN_refl x₂) Hn⟩
 
 #rocq_ignore uPred_sep_unseal "`UPred.sep` is defined directly without `seal`/`unseal`."
 #rocq_ignore uPred_sep_aux "`UPred.sep` is defined directly without `seal`/`unseal`."
@@ -153,11 +145,7 @@ protected def later (P : UPred M) : UPred M where
 @[rocq_alias uPred_ownM]
 def ownM (m : M) : UPred M where
   holds n x := m ≼{n} x
-  mono {_ n₂ x₁ x₂} := fun ⟨m₁, Hm₁⟩ ⟨m₂, Hm₂⟩ Hn => by
-    exists m₁ • m₂
-    calc x₂.val ≡{n₂}≡ x₁ • m₂ := Hm₂
-         _      ≡{n₂}≡ (m • m₁) • m₂ := (Hm₁.le Hn).op_l
-         _      ≡{n₂}≡ m • (m₁ • m₂) := assoc.symm.dist
+  mono H Hle Hn := (H.le Hn).trans Hle
 
 #rocq_ignore uPred_ownM_unseal "`UPred.ownM` is defined directly without `seal`/`unseal`."
 #rocq_ignore uPred_ownM_def "`UPred.ownM` is defined directly without `seal`/`unseal`."
@@ -171,26 +159,16 @@ def cmraValid {A} [CMRA A] (a : A) : UPred M where
 def bupd (Q : UPred M) : UPred M where
   holds n x := ∀ k yf, k ≤ n → ✓{k} (x.val • yf)
     → ∃ x', ∃ H : ✓{k} (x' • yf), Q k ⟨x', validN_op_left H⟩
-  mono {_ _ x1 _} HQ := by
-    rintro ⟨x3, Hx⟩ Hn k yf Hk Hx0
-    have Hxy' : ✓{k} x1.val • (x3 • yf) := by
-      refine validN_ne ?_ Hx0
-      refine .trans ?_ op_assocN.symm
-      exact op_left_dist _ (OFE.Dist.le Hx Hk)
-    rcases HQ k (x3 • yf) (Nat.le_trans Hk Hn) Hxy' with ⟨x', Hx', HQ'⟩
-    exists (x' • x3)
-    refine ⟨validN_ne op_assocN Hx', ?_⟩
-    refine Q.mono HQ' ?_ k.le_refl
-    exact incN_op_left k x' x3
+  mono HQ Hx Hn k yf Hk Hyf :=
+    HQ k yf (Nat.le_trans Hk Hn) (validN_of_incN (op_monoN_left yf (Hx.le Hk)) Hyf)
 
 #rocq_ignore uPred_bupd_unseal "`UPred.bupd` is defined directly without `seal`/`unseal`."
 #rocq_ignore uPred_bupd_def "`UPred.bupd` is defined directly without `seal`/`unseal`."
 #rocq_ignore uPred_bupd_aux "`UPred.bupd` is defined directly without `seal`/`unseal`."
 
+/-- `emp` holds at exactly the resources above the unit, i.e. `emp = ownM unit`. -/
 @[rocq_alias uPred_emp]
-protected def emp : UPred M where
-  holds _ _ := True
-  mono _ _ _ := trivial
+protected def emp : UPred M := ownM unit
 
 end bidefs
 
@@ -313,11 +291,11 @@ instance : BI (UPred M) where
   sep_ne.ne _ _ _ H _ _ H' _ _ Hn' Hv := by
     constructor <;> intro Hi <;> rcases Hi with ⟨z1, z2, H1, H2, H3⟩
     · refine ⟨z1, z2, H1, (H _ _ Hn' ?_).mp H2, (H' _ _ Hn' ?_).mp H3⟩
-      · exact validN_op_right ((H1.trans op_commN).validN.1 Hv)
-      · exact validN_op_right (H1.validN.1 Hv)
+      · exact validN_op_left (validN_of_incN H1 Hv)
+      · exact validN_op_right (validN_of_incN H1 Hv)
     · refine ⟨z1, z2, H1, (H _ _ Hn' ?_).mpr H2, (H' _ _ Hn' ?_).mpr H3⟩
-      · exact validN_op_right ((H1.trans op_commN).validN.1 Hv)
-      · exact validN_op_right (H1.validN.1 Hv)
+      · exact validN_op_left (validN_of_incN H1 Hv)
+      · exact validN_op_right (validN_of_incN H1 Hv)
   wand_ne.ne _ _ _ H _ _ H' _ _ Hn' Hv := by
     constructor <;> intro HE n x Hn Hv H''
     · refine (H' _ _ (Nat.le_trans Hn Hn') Hv).mp ?_
@@ -353,9 +331,9 @@ instance : BI (UPred M) where
     | .inl H => H1 _ Hv H
     | .inr H => H2 _ Hv H
   imp_intro I _ _ HP _ Hv Hin Hle HQ :=
-    I _ Hv ⟨UPred.mono _ HP Hin.incN Hle, HQ⟩
+    I _ Hv ⟨UPred.mono _ HP Hin Hle, HQ⟩
   imp_elim H' _ Hv := fun ⟨HP, HQ⟩ =>
-    H' _ Hv HP Hv (inc_refl _) .refl HQ
+    H' _ Hv HP Hv (incN_refl _) .refl HQ
   sForall_intro H _ _ Hp _ HΨ := H _ HΨ _ _ Hp
   sForall_elim HΨ _ _ H := H _ HΨ
   sExists_intro H _ _ Hp := ⟨_, H, Hp⟩
@@ -364,37 +342,35 @@ instance : BI (UPred M) where
     fun ⟨x1, x2, HE, Hx1, Hx2⟩ => ⟨x1, x2, HE, H1 _ _ Hx1, H2 _ _ Hx2⟩
   emp_sep {P} := by
     constructor
-    · intro _ _ ⟨x1, x2, HE1, _, HE2⟩
-      exact P.mono HE2 ⟨x1, HE1.trans op_commN⟩ .refl
+    · intro _ _ ⟨x1, x2, HE, Hx1, H⟩
+      exact P.mono H ((incN_op_right_of_unit_incN x2 Hx1).trans HE) .refl
     · intro _ x H
-      exact ⟨_, _, unit_left_id.symm.dist, ⟨⟩, H⟩
-  sep_symm _ _ := fun ⟨x1, x2, HE, HP, HQ⟩ => by
-    refine ⟨x2, x1, ?_, HQ, HP⟩
-    exact HE.trans comm.dist
+      exact ⟨_, _, unit_left_id.dist.to_incN, incN_refl unit, H⟩
+  sep_symm _ _ := fun ⟨x1, x2, HE, HP, HQ⟩ => ⟨x2, x1, incN_of_dist_of_incN op_commN HE, HQ, HP⟩
   sep_assoc_l n x := fun ⟨x1, x2, Hx, ⟨y1, y2, Hy, h1, h2⟩, h3⟩ => by
     refine ⟨y1, y2 • x2, ?_, h1, y2, x2, .rfl, h2, h3⟩
-    calc x.val ≡{n}≡ x1 • x2 := Hx
-         _     ≡{n}≡ (y1 • y2) • x2 := Hy.op_l
-         _     ≡{n}≡ y1 • (y2 • x2) := assoc.symm.dist
+    calc y1 • (y2 • x2) ≡{n}≡ (y1 • y2) • x2 := op_assocN
+         _              ≼{n} x1 • x2 := op_monoN_left x2 Hy
+         _              ≼{n} x.val := Hx
   wand_intro H _ x HP _ x' Hn _ HQ :=
     H _ _ ⟨x, x', .rfl, UPred.mono _ HP .rfl Hn, HQ⟩
   wand_elim H n x := fun ⟨y1, y2, Hy, HP, HQ⟩ => by
-    have Hv := Hy.validN.1 x.property
-    refine UPred.mono (x1 := ⟨y1 • y2, Hv⟩) _ ?_ Hy.symm.to_incN .refl
-    exact H n ⟨y1, (validN_op_left Hv)⟩ HP _ y2 .refl Hv HQ
+    have Hv := validN_of_incN Hy x.property
+    refine UPred.mono (x1 := ⟨y1 • y2, Hv⟩) _ ?_ Hy .refl
+    exact H n ⟨y1, validN_op_left Hv⟩ HP _ y2 .refl Hv HQ
   persistently_mono H _ x H' := H _ ⟨_, validN_core x.property⟩ H'
   persistently_idem_2 {P} _ x H := by
     refine P.mono H ?_ .refl
     refine (incN_iff_right ?_).mpr (incN_refl _)
     exact (core_idem x.val).dist
-  persistently_emp_2 := uPred_entails_preorder.le_refl emp
+  persistently_emp_2 _ _ _ := unit_incN_core _
   persistently_and_2 {P Q} := uPred_entails_preorder.le_refl iprop(<pers> P ∧ <pers> Q)
   persistently_sExists_1 _ _ := fun ⟨p, HΨ, H⟩ => by
     refine ⟨iprop(<pers> p), ⟨p, ?_⟩, H⟩
     ext; exact and_iff_right HΨ
-  persistently_absorb_l {P Q} _ x := fun ⟨x1, x2, H1, H2, H3⟩ =>
-    P.mono H2 (core_incN_core ⟨x2, H1⟩) .refl
-  persistently_and_l _ x H := ⟨core x, x, (core_op _).symm.dist, H⟩
+  persistently_absorb_l {P Q} _ _ := fun ⟨x1, x2, H1, H2, _⟩ =>
+    P.mono H2 ((core_op_mono x1 x2).incN.trans (core_incN_core H1)) .refl
+  persistently_and_l _ x H := ⟨core x, x, (core_op x.val).dist.to_incN, H⟩
   later_mono H := fun
     | 0, _ => id
     | _+1, x => H _ ⟨_, validN_succ x.property⟩
@@ -404,7 +380,7 @@ instance : BI (UPred M) where
   later_sForall_2 {Ψ} := fun
     | 0, _, _ => trivial
     | _+1, _, H => fun _ => by
-      exact H _ ⟨_, rfl⟩ _ (inc_refl _) .refl
+      exact H _ ⟨_, rfl⟩ _ (incN_refl _) .refl
   later_sExists_false := fun
     | 0, _, _ => .inl trivial
     | _+1, x, ⟨p', Hp', H⟩ => by
@@ -412,17 +388,17 @@ instance : BI (UPred M) where
       ext n x; exact and_iff_right Hp'
   later_sep {_ _} := by
     constructor <;> rintro (_ | n) x ⟨x1, x2, H1, H2, H3⟩
-    · exact ⟨unit, x, unit_left_id.dist.symm, trivial, trivial⟩
-    · let ⟨y1, y2, H1', H2', H3'⟩ := extend (validN_succ x.property) H1
-      exact ⟨y1, y2, H1'.dist,
+    · exact ⟨unit, x, unit_left_id.dist.to_incN, trivial, trivial⟩
+    · let ⟨y1, y2, H1', H2', H3'⟩ := op_extend (validN_succ x.property) H1
+      exact ⟨y1, y2, H1',
         (uPred_ne (m₁ := ⟨_, _⟩) (m₂ := ⟨_, _⟩) H2').mpr H2,
         (uPred_ne (m₁ := ⟨_, _⟩) (m₂ := ⟨_, _⟩) H3').mpr H3⟩
     · trivial
-    · exact ⟨x1, x2, H1.lt (Nat.lt_add_one _), H2, H3⟩
+    · exact ⟨x1, x2, H1.succ, H2, H3⟩
   later_persistently := ⟨fun | 0, _ | _+1, _ => id, fun | 0, _ | _+1, _ => id⟩
   later_false_em {P} := fun
     | 0, _, _ => .inl trivial
-    | _+1, _, H => .inr @fun | 0, _, Hx'le, _, _ => P.mono H Hx'le.incN (Nat.zero_le _)
+    | _+1, _, H => .inr @fun | 0, _, Hx'le, _, _ => P.mono H Hx'le (Nat.zero_le _)
 
 #rocq_ignore pure_ne "Direct consequence of propext"
 #rocq_ignore pure_intro "Inlined in `uPredI` construction"
@@ -484,12 +460,12 @@ instance : BI (UPred M) where
 #rocq_ignore uPred_bi_persistently_mixin "Inlined in `uPredI` construction"
 
 @[rocq_alias uPred_primitive.persistently_elim]
-theorem persistently_elim {P : UPred M} : <pers> P ⊢ P :=
+theorem persistently_elim [CMRA.Affine M] {P : UPred M} : <pers> P ⊢ P :=
   fun _ _ H => P.mono H core_inc_self.incN .refl
 
 @[rocq_alias uPred_persistently_forall]
 instance : BIPersistentlyForall (UPred M) where
-  persistently_sForall_2 _ _ x h p hp := h _ ⟨p, rfl⟩ x (inc_refl _) .refl hp
+  persistently_sForall_2 _ _ x h p hp := h _ ⟨p, rfl⟩ x (incN_refl _) .refl hp
 
 #rocq_ignore uPred_primitive.persistently_forall_2 "Inlined in `BIPersistentlyForall` construction"
 
@@ -499,11 +475,11 @@ instance : BIPersistentlyForall (UPred M) where
 instance : BILaterContractive (UPred M) where
   toContractive := later_contractive
 
-instance (P : UPred M) : Affine P where
-  affine _ := by simp [emp, UPred.emp]
+instance [CMRA.Affine M] (P : UPred M) : Affine P where
+  affine _ _ _ := incN_unit
 
 @[rocq_alias uPred_affine]
-instance : BIAffine (UPred M) := ⟨by infer_instance⟩
+instance [CMRA.Affine M] : BIAffine (UPred M) := ⟨by infer_instance⟩
 
 @[rocq_alias uPred_si_pure]
 protected def uPredSiPure (Pi : SiProp) : UPred M where
@@ -568,14 +544,13 @@ theorem uPredSiEmpValid_uPredSiPure {Pi : SiProp} : <si_emp_valid> (<si_pure> Pi
 
 @[rocq_alias si_pure_si_emp_valid, rocq_alias uPred_primitive.si_pure_si_emp_valid]
 theorem uPredSiPure_uPredSiEmpValid {P : UPred M} : <si_pure> <si_emp_valid> P ⊢ <pers> P :=
-  fun n _ hp => P.mono hp incN_unit n.le_refl
+  fun n x hp => P.mono hp (unit_incN_core x.val) n.le_refl
 
 @[rocq_alias persistently_impl_si_pure, rocq_alias uPred_primitive.persistently_impl_si_pure]
 theorem persistently_imp_uPredSiPure {Pi : SiProp} {Q : UPred M} :
     (<si_pure> Pi → <pers> Q) ⊢ <pers> (<si_pure> Pi → Q) := by
   intro n x hpq m y hinc hle hp
-  have hq := hpq (x.le hle) (inc_refl x.val) hle hp
-  exact Q.mono hq hinc.incN m.le_refl
+  exact Q.mono (hpq (x.le hle) (incN_refl x.val) hle hp) hinc m.le_refl
 
 @[rocq_alias uPred_primitive.prop_ext_2]
 theorem prop_ext_uPredSiEmpValid {P Q : UPred M} : <si_emp_valid> (P ∗-∗ Q) ⊢ SiProp.internalEq P Q := by
@@ -602,7 +577,7 @@ instance : Sbi (UPred M) where
   siPure_later := uPredSiPure_later
   siPure_absorbing _ := ⟨fun _ _ ⟨_, _, _, _, h⟩ => h⟩
   siEmpValid_later_mp := uPredSiEmpValid_later_mp
-  siEmpValid_affinely_mpr _ h := ⟨trivial, h⟩
+  siEmpValid_affinely_mpr _ h := ⟨incN_refl unit, h⟩
   prop_ext_siEmpValid := prop_ext_uPredSiEmpValid
 
 #rocq_ignore uPred_sbi_mixin "Inlined in uPred_sbi construction"
@@ -643,7 +618,8 @@ instance : BIUpdate (UPred M) where
     let ⟨x', Hx', Hx''⟩ := H k yf Hx Hyf
     Hx'' k yf k.le_refl Hx'
   frame_right {_ R} _ _ := fun ⟨x1, x2, Hx, HP, HR⟩ k yf Hk Hyf => by
-    have L : ✓{k} x1 • (x2 • yf) := (op_assocN.trans (Hx.le Hk).op_l.symm).validN.2 Hyf
+    have L : ✓{k} x1 • (x2 • yf) :=
+      validN_of_incN (incN_of_dist_of_incN op_assocN (op_monoN_left yf (Hx.le Hk))) Hyf
     let ⟨x', Hx'1, Hx'2⟩ := HP k (x2 • yf) Hk L
     refine ⟨x' • x2, op_assocN.validN.1 Hx'1, x', x2, .rfl, Hx'2, ?_⟩
     exact R.mono HR (incN_refl x2) Hk
@@ -669,35 +645,23 @@ instance : BIBUpdateSbi (UPred M) where
 theorem ownM_valid (m : M) : ownM m ⊢ internalCmraValid m := fun _ h hp => hp.validN h.property
 
 @[rocq_alias uPred_primitive.ownM_op, rocq_alias uPred.ownM_op]
-theorem ownM_op (m1 m2 : M) : ownM (m1 • m2) ⊣⊢ ownM m1 ∗ ownM m2 := by
-  constructor
-  · intro n _ ⟨z, Hz⟩
-    refine ⟨m1, m2 • z, ?_, .rfl, incN_op_left n m2 z⟩
-    exact Hz.trans assoc.symm.dist
-  · intro n x ⟨y1, y2, H, ⟨w1, Hw1⟩, ⟨w2, Hw2⟩⟩
-    exists w1 • w2
-    calc
-      x.val ≡{n}≡ y1 • y2 := H
-      _     ≡{n}≡ (m1 • w1) • (m2 • w2) := Hw1.op Hw2
-      _     ≡{n}≡ m1 • (w1 • (m2 • w2)) := assoc.symm.dist
-      _     ≡{n}≡ m1 • ((m2 • w2) • w1) := comm'.dist.op_r
-      _     ≡{n}≡ m1 • (m2 • (w2 • w1)) := assoc'.symm.dist.op_r
-      _     ≡{n}≡ (m1 • m2) • (w2 • w1) := assoc.dist
-      _     ≡{n}≡ (m1 • m2) • (w1 • w2) := comm'.dist.op_r
+theorem ownM_op (m1 m2 : M) : ownM (m1 • m2) ⊣⊢ ownM m1 ∗ ownM m2 :=
+  ⟨fun _ _ H => ⟨m1, m2, H, incN_refl m1, incN_refl m2⟩,
+   fun _ _ ⟨_, _, H, H1, H2⟩ => (op_monoN H1 H2).trans H⟩
 
 theorem ownM_always_invalid_elim (m : M) (H : ∀ n, ¬✓{n} m) : internalCmraValid m ⊢@{UPred M} False :=
   fun n _ => H n
 
 @[rocq_alias uPred.ownM_unit, rocq_alias uPred_primitive.ownM_unit]
-theorem ownM_unit P : P ⊢ □ ownM (unit : M) :=
-  fun _ _ _ => ⟨trivial, incN_unit⟩
+theorem ownM_unit [CMRA.Affine M] P : P ⊢ □ ownM (unit : M) :=
+  fun _ x _ => ⟨incN_unit, unit_incN_core x.val⟩
 
 @[rocq_alias uPred.persistently_ownM_core, rocq_alias uPred_primitive.persistently_ownM_core]
 theorem persistently_ownM_core (a : M) : ownM a ⊢ <pers> ownM (core a) :=
   fun _ _ => core_incN_core
 
-theorem intuitionistically_ownM_core (m : M) : ownM m ⊢ □ ownM (core m) :=
-  fun _ _ h => ⟨trivial, core_incN_core h⟩
+theorem intuitionistically_ownM_core [CMRA.Affine M] (m : M) : ownM m ⊢ □ ownM (core m) :=
+  fun _ _ h => ⟨incN_unit, core_incN_core h⟩
 
 instance {a : M} : Persistent (ownM (core a)) where
   persistent := by
@@ -708,41 +672,31 @@ instance {a : M} : Persistent (ownM (core a)) where
 @[rocq_alias uPred.bupd_ownM_updateP, rocq_alias uPred_primitive.bupd_ownM_updateP]
 theorem bupd_ownM_updateP (x : M) (Φ : M → Prop) :
   (x ~~>: Φ) → ownM x ⊢ |==> ∃ y, ⌜Φ y⌝ ∧ ownM y := by
-  intro Hup _ _ ⟨x3, Hx⟩ k yf Hk Hyf
-  have Hxv : ✓{k} x • (x3 • yf) := by
-    refine validN_ne ?_ Hyf
-    exact (Hx.le Hk).op_l.trans assoc.symm.dist
-  rcases Hup k (some (x3 • yf)) Hxv with ⟨y, HΦy, Hyv⟩
-  refine ⟨y • x3, validN_ne op_assocN Hyv, ?_⟩
-  refine ⟨iprop(⌜Φ y⌝ ∧ ownM y), ?_, ?_⟩
-  · exists y
-  · exact ⟨HΦy, incN_op_left k y x3⟩
+  intro Hup _ _ Hx k yf Hk Hyf
+  let ⟨y, HΦy, Hyv⟩ := Hup k (some yf) (validN_of_incN (op_monoN_left yf (Hx.le Hk)) Hyf)
+  exact ⟨y, Hyv, iprop(⌜Φ y⌝ ∧ ownM y), ⟨y, rfl⟩, HΦy, incN_refl y⟩
 
+/-- The inclusion in the conclusion is the internal order; on classical CMRAs it coincides
+with Rocq's extension inclusion. -/
 @[rocq_alias uPred.ownM_forall, rocq_alias uPred_primitive.ownM_forall]
-theorem ownM_forall (f : A → M) :
-  (∀ a, ownM (f a)) ⊢ ∃ z, ownM z ∧ (∀ a, ∃ xf, z ≡ f a • xf) := by
+theorem ownM_forall (f : A → M) : (∀ a, ownM (f a)) ⊢ ∃ z, ownM z ∧ (∀ a, f a ≼ z) := by
   intro _ x Hf
-  refine ⟨iprop(ownM x ∧ ∀ a, ∃ xf, x.val ≡ f a • xf), ⟨x, rfl⟩, ?_⟩
-  refine ⟨incN_refl x.val, ?_⟩
+  refine ⟨iprop(ownM x ∧ ∀ a, f a ≼ x.val), ⟨x, rfl⟩, incN_refl x.val, ?_⟩
   rintro p ⟨a, rfl⟩
-  rcases Hf (ownM (f a)) ⟨a, rfl⟩ with ⟨xf, Hxf⟩
-  exact ⟨iprop(x.val ≡ f a • xf), ⟨xf, rfl⟩, Hxf⟩
+  exact Hf (ownM (f a)) ⟨a, rfl⟩
 
 @[rocq_alias uPred.later_ownM, rocq_alias uPred_primitive.later_ownM]
 theorem later_ownM (a : M) : ▷ ownM a ⊢ ∃ b, ownM b ∧ ▷ (a ≡ b)
-  | 0, _, _ => ⟨iprop(ownM unit ∧ ▷ (a ≡ unit)), ⟨unit, rfl⟩, incN_unit, trivial⟩
-  | n+1, x, ⟨y, hx⟩ => by
-    let ⟨a', y', hx', ha', hy'⟩ := extend (validN_succ x.property) hx
-    refine ⟨iprop(ownM a' ∧ ▷ (a ≡ a')), ⟨a', rfl⟩, ?_, ?_⟩
-    · exact (incN_iff_right hx'.dist).mpr (incN_op_left (n + 1) a' y')
-    · exact OFE.Dist.symm ha'
+  | 0, x, _ => ⟨iprop(ownM x.val ∧ ▷ (a ≡ x.val)), ⟨x.val, rfl⟩, incN_refl x.val, trivial⟩
+  | _+1, x, hx =>
+    let ⟨b, hb, hab⟩ := incN_extend (validN_succ x.property) hx
+    ⟨iprop(ownM b ∧ ▷ (a ≡ b)), ⟨b, rfl⟩, hb, hab.symm⟩
 
-theorem pure_soundness : iprop(True ⊢ (⌜P⌝ : UPred M)) → P :=
-  (· 0 ⟨unit, unit_validN⟩ ⟨⟩)
+theorem pure_soundness : (⊢ (⌜P⌝ : UPred M)) → P :=
+  (· 0 ⟨unit, unit_validN⟩ (incN_refl unit))
 
-theorem later_soundness : iprop(True ⊢ ▷ P) → iprop((True : UPred M) ⊢ P) := by
-  intro HP n x H
-  exact UPred.mono _ (HP n.succ ⟨unit, unit_validN⟩ H) incN_unit .refl
+theorem later_soundness : (⊢ ▷ P) → ⊢@{UPred M} P :=
+  fun HP n _ H => P.mono (HP n.succ ⟨unit, unit_validN⟩ (incN_refl unit)) H .refl
 
 section derived
 
@@ -753,7 +707,7 @@ section derived
 #rocq_ignore uPred.ownM_proper "OFE is Leibniz; use equality"
 
 @[rocq_alias uPred.intuitionistically_ownM]
-theorem intuitionistically_ownM (a : M) [CoreId a] : □ ownM a ⊣⊢ ownM a := by
+theorem intuitionistically_ownM [CMRA.Affine M] (a : M) [CoreId a] : □ ownM a ⊣⊢ ownM a := by
   refine ⟨intuitionistically_elim, ?_⟩
   refine (intuitionistically_ownM_core a).trans ?_
   refine intuitionistically_mono ?_
@@ -768,8 +722,7 @@ theorem ownM_mono {a b : M} (hinc : b ≼ a) : ownM a ⊢ ownM b :=
   fun n _ ha => incN_trans (incN_of_inc n hinc) ha
 
 @[rocq_alias uPred.ownM_unit']
-theorem ownM_unit' : ownM unit ⊣⊢@{UPred M} True :=
-  ⟨fun _ _ _ => trivial, fun _ _ _ => incN_unit⟩
+theorem ownM_unit' : ownM unit ⊣⊢@{UPred M} emp := .rfl
 
 @[rocq_alias uPred.bupd_ownM_update]
 theorem bupd_ownM_update {x y : M} (hupd : x ~~> y) : ownM x ⊢ |==> ownM y := by
@@ -780,10 +733,9 @@ theorem bupd_ownM_update {x y : M} (hupd : x ~~> y) : ownM x ⊢ |==> ownM y := 
 instance ownM_timeless (a : M) [OFE.DiscreteE a] : BI.Timeless (ownM a) where
   timeless
     | 0, _, _ => .inl trivial
-    | n+1, x, ⟨_, Hxy⟩ =>
-      let ⟨_a', y', Hx, Ha', _⟩ := extend (validN_succ x.property) Hxy
-      .inr ⟨y', OFE.Dist.of_eq (Hx.trans
-        (congrArg (CMRA.op · _) (OFE.DiscreteE.discrete (Ha'.symm.le n.zero_le)).symm))⟩
+    | n+1, x, hx =>
+      let ⟨_, hb, hab⟩ := incN_extend (validN_succ x.property) hx
+      .inr (OFE.DiscreteE.discrete (hab.symm.le n.zero_le) ▸ hb)
 
 @[rocq_alias uPred.ownM_persistent]
 instance ownM_persistent (a : M) [CoreId a] : Persistent (ownM a) where
@@ -800,10 +752,10 @@ instance ownM_sep_homomorphism :
   op_proper ha hb := ha ▸ hb ▸ rfl
   map_ne := ownM_ne
   map_op := (ownM_op ..).to_eq
-  map_unit := ownM_unit'.to_eq.trans true_emp.to_eq
+  map_unit := ownM_unit'.to_eq
 
 @[rocq_alias uPred.bupd_soundness]
-theorem bupd_soundness {P : UPred M} [Plain P] : (⊢ |==> P) → ⊢ P :=
+theorem bupd_soundness [CMRA.Affine M] {P : UPred M} [Plain P] : (⊢ |==> P) → ⊢ P :=
   fun h => h.trans bupd_elim
 
 @[rocq_alias uPred.modality]
@@ -823,7 +775,7 @@ def Modality.denote : Modality → UPred M → UPred M
 @[rocq_alias uPred.denote_modalities]
 def Modality.denoteAll (ms : List Modality) (P : UPred M) : UPred M := ms.foldr denote P
 
-theorem Modality.denoteAll_laterN {P : UPred M} [Plain P] :
+theorem Modality.denoteAll_laterN [CMRA.Affine M] {P : UPred M} [Plain P] :
     ∀ ms : List Modality, denoteAll ms P ⊢ ▷^[ms.length] P
   | [] => .rfl
   | .bupd :: ms => (bupd_mono (denoteAll_laterN ms)).trans (bupd_elim.trans later_intro)
@@ -834,7 +786,7 @@ theorem Modality.denoteAll_laterN {P : UPred M} [Plain P] :
 
 /-- Soundness under an arbitrary nesting of modalities, for plain propositions. -/
 @[rocq_alias uPred.modal_soundness]
-theorem modal_soundness {P : UPred M} [Plain P] (ms : List Modality)
+theorem modal_soundness [CMRA.Affine M] {P : UPred M} [Plain P] (ms : List Modality)
     (h : ⊢ Modality.denoteAll ms P) : ⊢ P :=
   laterN_soundness (h.trans (Modality.denoteAll_laterN ms))
 
@@ -855,7 +807,7 @@ theorem plainly_valid [CMRA A] (a : A) :
     ■ internalCmraValid a ⊣⊢@{UPred M} internalCmraValid a :=
   ⟨plainly_elim, plainly_valid_mpr a⟩
 
-theorem intuitionistically_valid {A} [CMRA A] (a : A) :
+theorem intuitionistically_valid [CMRA.Affine M] {A} [CMRA A] (a : A) :
     □ internalCmraValid a ⊣⊢@{UPred M} internalCmraValid a := by
   constructor
   · exact intuitionistically_elim
@@ -904,28 +856,20 @@ theorem BUpdPlain_bupd [UCMRA M] (P : UPred M) : BUpdPlain P ⊢ |==> P := by
     refine ⟨z, validN_ne op_commN Hvyz, HP⟩
 
 @[rocq_alias bupd_alt_bupd_iff]
-theorem BUpdPlain_bupd_iff [UCMRA M] (P : UPred M) : BUpdPlain P ⊣⊢ |==> P :=
+theorem BUpdPlain_bupd_iff [UCMRA M] [CMRA.Affine M] (P : UPred M) : BUpdPlain P ⊣⊢ |==> P :=
   ⟨BUpdPlain_bupd P, BUpd_BUpdPlain (PROP := UPred M)⟩
 
 @[rocq_alias ownM_updateP]
 theorem ownM_updateP [UCMRA M] {x : M} {R : UPred M} (Φ : M → Prop) (Hup : x ~~>: Φ) :
     iprop(ownM x ∗ ∀ y, ⌜Φ y⌝ -∗ ownM y -∗ ■ R) ⊢ ■ R := by
   rw [plainly_eq_uPred_plainly]
-  intro n z ⟨x1, z2, Hx, ⟨z1, Hz1⟩, HR⟩
-  have Hvalid : ✓{n} (x •? some (z1 • z2)) := by
-    show ✓{n} (x • (z1 • z2))
-    refine validN_ne ?_ z.property
-    calc z.val ≡{n}≡ x1 • z2 := Hx
-         _     ≡{n}≡ (x • z1) • z2 := Hz1.op_l
-         _     ≡{n}≡ x • (z1 • z2) := assoc.symm.dist
-  have ⟨y, HΦy, Hvalid_y⟩ := Hup n (some (z1 • z2)) Hvalid
+  intro n z ⟨x1, z2, Hx, Hx1, HR⟩
+  have Hvalid : ✓{n} (x •? some z2) :=
+    validN_of_incN ((op_monoN_left z2 Hx1).trans Hx) z.property
+  have ⟨y, HΦy, Hvalid_y⟩ := Hup n (some z2) Hvalid
   have Hp := HR (iprop(⌜Φ y⌝ -∗ (UPred.ownM y -∗ UPred.plainly R))) ⟨y, rfl⟩
-  have Hcomm : y •? some (z1 • z2) ≡{n}≡ (z2 • z1) • y :=
-    calc y • (z1 • z2) ≡{n}≡ y • (z2 • z1) := comm.dist.op_r
-         _             ≡{n}≡ (z2 • z1) • y := comm.symm.dist
-  exact Hp n z1 .refl
-    (validN_ne comm.dist (validN_op_right Hvalid)) HΦy n y .refl
-    (validN_ne Hcomm Hvalid_y) (incN_refl y)
+  exact Hp n unit .refl (validN_ne (unit_right_id_dist z2).symm (validN_op_right Hvalid)) HΦy n y
+    .refl (validN_ne (comm.dist.trans (unit_right_id_dist z2).symm.op_l) Hvalid_y) (incN_refl y)
 
 end UPredAlt
 

--- a/Iris/Iris/Instances/UPred/ProofMode.lean
+++ b/Iris/Iris/Instances/UPred/ProofMode.lean
@@ -38,10 +38,10 @@ instance fromAnd_ownM_coreId {a b1 b2 : M} [h : IsOp .split a b1 b2]
   from_and := by
     rw [h.is_op]
     refine .trans ?_ (ownM_op ..).mpr
-    cases (inferInstance : TCOr (CoreId b1) (CoreId b2)) <;> exact persistent_and_sep.mp
+    cases (inferInstance : TCOr (CoreId b1) (CoreId b2)) <;> exact persistent_and_sep_mp
 
 @[rocq_alias into_and_ownM]
-instance intoAnd_ownM (p : Bool) {a b1 b2 : M} [h : IsOp .split a b1 b2] :
+instance intoAnd_ownM [CMRA.Affine M] (p : Bool) {a b1 b2 : M} [h : IsOp .split a b1 b2] :
     IntoAnd p (ownM a) (ownM b1) (ownM b2) where
   into_and := intuitionisticallyIf_mono <| by rw [h.is_op]; exact (ownM_op ..).mp.trans sep_and
 

--- a/Iris/Iris/ProofMode/InstancesCmra.lean
+++ b/Iris/Iris/ProofMode/InstancesCmra.lean
@@ -27,24 +27,32 @@ instance fromPure_internalCmraValid io α [CMRA α] (a : α) :
   FromPure (PROP := PROP) false iprop(✓ a) io (✓ a) where
   from_pure := BI.pure_elim' internalCmraValid_intro
 
-@[rocq_alias into_pure_internal_included]
 instance intoPure_internalCmraIncluded α [CMRA α] [CMRA.Discrete α] (a b : α) :
   IntoPure (PROP := PROP) iprop(a ≼ b) (a ≼ b) where
   into_pure := internalCmraIncluded_discrete.1
 
-@[rocq_alias from_pure_internal_included]
 instance fromPure_internalCmraIncluded io α [CMRA α] (a b : α) :
   FromPure (PROP := PROP) false iprop(a ≼ b) io (a ≼ b) where
   from_pure := BI.pure_elim' internalCmraIncluded_intro
 
+@[rocq_alias into_pure_internal_included]
+instance intoPure_internalCmraIncExt α [CMRA α] [CMRA.Discrete α] (a b : α) :
+  IntoPure (PROP := PROP) iprop(a ≼ₑ b) (a ≼ₑ b) where
+  into_pure := internalCmraIncExt_discrete.1
+
+@[rocq_alias from_pure_internal_included]
+instance fromPure_internalCmraIncExt io α [CMRA α] (a b : α) :
+  FromPure (PROP := PROP) false iprop(a ≼ₑ b) io (a ≼ₑ b) where
+  from_pure := BI.pure_elim' internalCmraIncExt_intro
+
 @[rocq_alias into_exist_internal_included]
-instance intoExists_internalCmraIncluded α [CMRA α] (a b : α) :
-  IntoExists (PROP := PROP) iprop(a ≼ b) (λ c => iprop(b ≡ (a • c))) where
-  into_exists := siPure_exist.1
+instance intoExists_internalCmraIncExt α [CMRA α] (a b : α) :
+  IntoExists (PROP := PROP) iprop(a ≼ₑ b) (λ c => iprop(b ≡ (a • c))) where
+  into_exists := siPure_exist.mp
 
 @[rocq_alias from_exist_internal_included]
-instance fromExists_internalCmraIncluded α [CMRA α] (a b : α) :
-  FromExists (PROP := PROP) iprop(a ≼ b) (λ c => iprop(b ≡ (a • c))) where
-  from_exists := siPure_exist.2
+instance fromExists_internalCmraIncExt α [CMRA α] (a b : α) :
+  FromExists (PROP := PROP) iprop(a ≼ₑ b) (λ c => iprop(b ≡ (a • c))) where
+  from_exists := siPure_exist.mpr
 
 end cmra

--- a/Iris/IrisTest/Tactics.lean
+++ b/Iris/IrisTest/Tactics.lean
@@ -2336,7 +2336,7 @@ example [BI PROP] (P : PROP) : □ P ∗ <affine> P ⊢ <affine> P := by
   iexact HP2
 
 /- Tests `imodintro` for affinely (intuitionistic: id, spatial: forall Affine) failing. -/
-/-- error: imodintro: hypothesis HP2: P does not satisfy Affine -/
+/-- error: imodintro: hypothesis HP2: P does not satisfy BI.Affine -/
 #guard_msgs in
 example [BI PROP] (P : PROP) : □ P ∗ P ⊢ <affine> P := by
   iintro ⟨#HP1, HP2⟩
@@ -3460,7 +3460,7 @@ example {GF} [ElemG GF (constOF DFrac)]
 
 /-- Tests `icombine` for combining propositions involving `iOwn` and `IsOp`
     instances for the authoritative CMRA. -/
-example {GF A} [UCMRA A] [ElemG GF (constOF (Auth A))] {γ}
+example {GF A} [UCMRA A] [CMRA.Affine A] [ElemG GF (constOF (Auth A))] {γ}
     {a1 a2 a3 b c : A} {q1 q2 : Qp} {dq'' dq3 dq4 : DFrac}
     [IsOp .merge b a2 a3] [IsOp .merge c a1 b]
     [IsOp .merge dq'' dq3 dq4] :

--- a/Iris/IrisTest/UPred.lean
+++ b/Iris/IrisTest/UPred.lean
@@ -34,13 +34,13 @@ variable [UCMRA M] (a b : M) (c : M) [CoreId c]
 #guard_msgs (whitespace := lax) in
 #ipm_synth IntoSep (ownM (a • b)) _ _
 
-/- Tests `intoAnd_ownM`. -/
+/- Tests `intoAnd_ownM` (which requires an affine algebra). -/
 /-- info:
   solution: IntoAnd p (ownM (a • b)) (ownM a) (ownM b),
   new goals: []
 -/
 #guard_msgs (whitespace := lax) in
-variable (p : Bool) in
+variable (p : Bool) [CMRA.Affine M] in
 #ipm_synth IntoAnd p (ownM (a • b)) _ _
 
 /-


### PR DESCRIPTION
This PR rebases iris-lean on *ordered resource algebras* (MoSeL) following [this Zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/490604-iris-lean/topic/Ordered.20Resource.20Algebras/with/619796293) 

The main goal is being able to support distributional probabilistic logics, which all need a custom order (PSL, Lilac, Bluebell, pcOL, Amaryllis, opOL). To my understanding, the lack of ORAs is the only reason why the iris-lean implementations of Lilac and Bluebell are currently not uPred instances. The Lilac paper even explicitly mentions the lack of support for a custom order as a main obstruction for mechanizing Lilac in Iris. Another use case of ORAs are linear (non-affine) logics.

I'm putting up the draft implementation for discussion. Doing such a change would mean deviating from Iris-Rocq, since this is not yet implemented there.

All CMRA constructions generalize naturally to a custom order, Auth is affine-only.

Updates and all the uPred laws that involve weakening are affine-only: it is a known limitation that this doesn't work for linear logics. 

iProp is also affine-only right now: all infrastructure for higher-order ghost state relies on updates, so I don't see a use-case for non-affine iProp right now, and making it affine-only omits a lot of side conditions.

While the original MoSeL ORA definition only allows reflexive orders, I changed this for compatibility: CMRA does not need a reflexive order, only UCMRA does.

Change List:
- the name "CMRA" now refers to ORAs, following Markus' Proposal 
- The CMRA definition is no longer monolithic, but the laws are split Mathlib-style across Typeclasses that bundle the operation together with their laws (ie Op includes the CMRA laws that are only about Op). This avoids duplicating axioms for cmras with and without extension order, and is in general more modular.
- Homomorphisms now need to respect the order and preserve affiness.
- (u)ORAs with the extension order are built using (u)CMRA.withExtensionOrder. For those CMRAs, the order computationally reduces to the extension order.
- discrete CMRAs must ignore the step index for the order
- The generic ViewRel needs new monotonicity axioms and corresponding infrastructure

Currently a draft because I haven't reviewed every line of AI-generated code. I carefully checked that the code implements what it should. In case the iris-lean community agrees that ORAs should end up upstream, I'm happy to invest the additional time to review the code line-by-line before handing it over.
